### PR TITLE
feat: motivation layer — Utility-Value + Growth-Mindset + OLM narrative + LLM-authored webhook nudges

### DIFF
--- a/db/implementation_intentions.go
+++ b/db/implementation_intentions.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"learning-runtime/models"
+)
+
+// InsertImplementationIntention persists a Gollwitzer-style if-then commitment
+// captured at session close. scheduledFor is optional (use the zero time to skip).
+func (s *Store) InsertImplementationIntention(learnerID, domainID, trigger, action string, scheduledFor time.Time) (int64, error) {
+	var scheduled any
+	if !scheduledFor.IsZero() {
+		scheduled = scheduledFor.UTC()
+	}
+	result, err := s.db.Exec(
+		`INSERT INTO implementation_intentions (learner_id, domain_id, trigger_text, action_text, scheduled_for, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		learnerID, domainID, trigger, action, scheduled, time.Now().UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert implementation intention: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("get impl intention id: %w", err)
+	}
+	return id, nil
+}
+
+// HasRecentImplementationIntention returns true if the learner (and optionally the
+// specific domain) recorded any implementation intention since `since`.
+// Pass an empty domainID to check across all domains.
+func (s *Store) HasRecentImplementationIntention(learnerID, domainID string, since time.Time) (bool, error) {
+	var query string
+	var args []any
+	if domainID == "" {
+		query = `SELECT COUNT(*) FROM implementation_intentions WHERE learner_id = ? AND created_at >= ?`
+		args = []any{learnerID, since.UTC()}
+	} else {
+		query = `SELECT COUNT(*) FROM implementation_intentions WHERE learner_id = ? AND domain_id = ? AND created_at >= ?`
+		args = []any{learnerID, domainID, since.UTC()}
+	}
+	var count int
+	if err := s.db.QueryRow(query, args...).Scan(&count); err != nil {
+		return false, fmt.Errorf("check recent implementation intention: %w", err)
+	}
+	return count > 0, nil
+}
+
+// GetRecentImplementationIntentions returns intentions for a learner recorded on or after `since`,
+// most recent first.
+func (s *Store) GetRecentImplementationIntentions(learnerID string, since time.Time, limit int) ([]*models.ImplementationIntention, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(
+		`SELECT id, learner_id, domain_id, trigger_text, action_text, honored, created_at, scheduled_for
+		 FROM implementation_intentions
+		 WHERE learner_id = ? AND created_at >= ?
+		 ORDER BY created_at DESC LIMIT ?`,
+		learnerID, since.UTC(), limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get implementation intentions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.ImplementationIntention
+	for rows.Next() {
+		ii := &models.ImplementationIntention{}
+		var honored sql.NullInt64
+		var scheduled sql.NullTime
+		if err := rows.Scan(&ii.ID, &ii.LearnerID, &ii.DomainID, &ii.Trigger, &ii.Action, &honored, &ii.CreatedAt, &scheduled); err != nil {
+			return nil, fmt.Errorf("scan implementation intention: %w", err)
+		}
+		if honored.Valid {
+			b := honored.Int64 != 0
+			ii.Honored = &b
+		}
+		if scheduled.Valid {
+			t := scheduled.Time
+			ii.ScheduledFor = &t
+		}
+		out = append(out, ii)
+	}
+	return out, rows.Err()
+}
+
+// MarkIntentionHonored transitions the honored flag to 1 (honored) or 0 (missed).
+func (s *Store) MarkIntentionHonored(id int64, honored bool) error {
+	val := 0
+	if honored {
+		val = 1
+	}
+	_, err := s.db.Exec(
+		`UPDATE implementation_intentions SET honored = ? WHERE id = ?`,
+		val, id,
+	)
+	if err != nil {
+		return fmt.Errorf("mark intention honored: %w", err)
+	}
+	return nil
+}

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -39,6 +39,8 @@ func Migrate(db *sql.DB) error {
 		`ALTER TABLE domains ADD COLUMN archived INTEGER DEFAULT 0`,
 		`ALTER TABLE interactions ADD COLUMN misconception_type TEXT`,
 		`ALTER TABLE interactions ADD COLUMN misconception_detail TEXT`,
+		`ALTER TABLE domains ADD COLUMN value_framings_json TEXT DEFAULT ''`,
+		`ALTER TABLE domains ADD COLUMN last_value_axis TEXT DEFAULT ''`,
 	}
 	for _, m := range alterMigrations {
 		_, _ = db.Exec(m) // ignore "duplicate column" errors
@@ -101,6 +103,30 @@ func Migrate(db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_transfer_records_learner_concept ON transfer_records(learner_id, concept_id, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_interactions_self_initiated ON interactions(learner_id, self_initiated, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_interactions_misconception ON interactions(learner_id, concept, misconception_type)`,
+		`CREATE TABLE IF NOT EXISTS implementation_intentions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    learner_id     TEXT    NOT NULL REFERENCES learners(id),
+    domain_id      TEXT    NOT NULL,
+    trigger_text   TEXT    NOT NULL,
+    action_text    TEXT    NOT NULL,
+    honored        INTEGER,
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    scheduled_for  DATETIME
+)`,
+		`CREATE TABLE IF NOT EXISTS webhook_message_queue (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    learner_id     TEXT    NOT NULL REFERENCES learners(id),
+    kind           TEXT    NOT NULL,
+    scheduled_for  DATETIME NOT NULL,
+    expires_at     DATETIME,
+    content        TEXT    NOT NULL,
+    priority       INTEGER DEFAULT 0,
+    status         TEXT    DEFAULT 'pending',
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at        DATETIME
+)`,
+		`CREATE INDEX IF NOT EXISTS idx_impl_intent_learner ON implementation_intentions(learner_id, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_wmq_dispatch ON webhook_message_queue(learner_id, kind, status, scheduled_for)`,
 	}
 	for _, m := range idempotentMigrations {
 		if _, err := db.Exec(m); err != nil {

--- a/db/motivation_queries.go
+++ b/db/motivation_queries.go
@@ -1,0 +1,232 @@
+package db
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"learning-runtime/algorithms"
+	"learning-runtime/models"
+)
+
+// ConceptMasteryDelta estimates per-concept mastery trajectory over a window.
+// For each domain concept with interactions, returns (now, approximate past, delta),
+// sorted by descending delta. Only concepts with positive delta are returned.
+//
+// Note: past mastery is approximated from success ratio on interactions before `since`.
+// Exact historical BKT snapshots are not persisted — this is good enough for a
+// learner-facing trajectory narrative.
+func (s *Store) ConceptMasteryDelta(learnerID string, domainConcepts []string, since time.Time, limit int) ([]models.ConceptDelta, error) {
+	if limit <= 0 {
+		limit = 3
+	}
+
+	// Current mastery per concept (BKT p_mastery).
+	states, err := s.GetConceptStatesByLearner(learnerID)
+	if err != nil {
+		return nil, fmt.Errorf("mastery delta: get states: %w", err)
+	}
+	stateByConcept := make(map[string]*models.ConceptState)
+	for _, cs := range states {
+		stateByConcept[cs.Concept] = cs
+	}
+
+	var deltas []models.ConceptDelta
+	for _, concept := range domainConcepts {
+		cs := stateByConcept[concept]
+		if cs == nil {
+			continue
+		}
+
+		// Count successes/failures before `since` — approximates past mastery.
+		var totalBefore, successBefore int
+		err := s.db.QueryRow(
+			`SELECT COUNT(*), COALESCE(SUM(success), 0)
+			 FROM interactions WHERE learner_id = ? AND concept = ? AND created_at < ?`,
+			learnerID, concept, since.UTC(),
+		).Scan(&totalBefore, &successBefore)
+		if err != nil {
+			continue
+		}
+
+		var masteryWas float64
+		if totalBefore == 0 {
+			masteryWas = 0.1 // initial BKT prior
+		} else {
+			masteryWas = float64(successBefore) / float64(totalBefore)
+		}
+
+		delta := cs.PMastery - masteryWas
+		if delta <= 0.05 {
+			continue // not enough movement to narrate
+		}
+
+		deltas = append(deltas, models.ConceptDelta{
+			Concept:    concept,
+			MasteryNow: cs.PMastery,
+			MasteryWas: masteryWas,
+			Delta:      delta,
+		})
+	}
+
+	sort.Slice(deltas, func(i, j int) bool { return deltas[i].Delta > deltas[j].Delta })
+	if len(deltas) > limit {
+		deltas = deltas[:limit]
+	}
+	return deltas, nil
+}
+
+// MilestonesInWindow returns concepts newly mastered in the window [since, now].
+// "Newly mastered" = current PMastery >= BKTMasteryThreshold AND the most recent
+// interaction on that concept is after `since` (approximation).
+func (s *Store) MilestonesInWindow(learnerID string, domainConcepts []string, since time.Time) ([]string, error) {
+	states, err := s.GetConceptStatesByLearner(learnerID)
+	if err != nil {
+		return nil, fmt.Errorf("milestones: get states: %w", err)
+	}
+	domainSet := make(map[string]bool, len(domainConcepts))
+	for _, c := range domainConcepts {
+		domainSet[c] = true
+	}
+
+	var milestones []string
+	for _, cs := range states {
+		if !domainSet[cs.Concept] {
+			continue
+		}
+		if cs.PMastery < algorithms.BKTMasteryThreshold {
+			continue
+		}
+		// Check there's at least one interaction since `since`.
+		var count int
+		err := s.db.QueryRow(
+			`SELECT COUNT(*) FROM interactions
+			 WHERE learner_id = ? AND concept = ? AND success = 1 AND created_at >= ?`,
+			learnerID, cs.Concept, since.UTC(),
+		).Scan(&count)
+		if err != nil {
+			continue
+		}
+		if count > 0 {
+			milestones = append(milestones, cs.Concept)
+		}
+	}
+	sort.Strings(milestones)
+	return milestones, nil
+}
+
+// CountInteractionsByConcept returns the total number of interactions on a given concept.
+func (s *Store) CountInteractionsByConcept(learnerID, concept string) (int, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM interactions WHERE learner_id = ? AND concept = ?`,
+		learnerID, concept,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count interactions by concept: %w", err)
+	}
+	return count, nil
+}
+
+// CountSessionsOnConcept approximates the number of distinct study sessions the
+// learner has had on a concept. Uses distinct calendar dates with at least one
+// interaction on that concept (rough proxy — good enough for Hidi-Renninger phase
+// inference). The substr(created_at, 1, 10) works around modernc-sqlite's ISO 8601
+// serialization (the built-in DATE() doesn't parse the 'T' separator).
+func (s *Store) CountSessionsOnConcept(learnerID, concept string) (int, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(DISTINCT substr(created_at, 1, 10)) FROM interactions
+		 WHERE learner_id = ? AND concept = ?`,
+		learnerID, concept,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count sessions on concept: %w", err)
+	}
+	return count, nil
+}
+
+// CountLearnerSessionStreak returns the consecutive-day streak for a learner,
+// computed via substr-based date extraction (works with modernc's ISO serialization).
+func (s *Store) CountLearnerSessionStreak(learnerID string) (int, error) {
+	rows, err := s.db.Query(
+		`SELECT DISTINCT substr(created_at, 1, 10) AS d FROM interactions
+		 WHERE learner_id = ? ORDER BY d DESC`,
+		learnerID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("count session streak: %w", err)
+	}
+	defer rows.Close()
+
+	streak := 0
+	expected := time.Now().UTC().Truncate(24 * time.Hour)
+	for rows.Next() {
+		var dateStr string
+		if err := rows.Scan(&dateStr); err != nil {
+			return streak, nil
+		}
+		d, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return streak, nil
+		}
+		if streak == 0 {
+			diff := expected.Sub(d).Hours() / 24
+			if diff > 1 {
+				return 0, nil
+			}
+			streak = 1
+			expected = d.AddDate(0, 0, -1)
+			continue
+		}
+		if d.Equal(expected) {
+			streak++
+			expected = d.AddDate(0, 0, -1)
+		} else {
+			break
+		}
+	}
+	return streak, nil
+}
+
+// SelfInitiatedRatio returns the ratio of self_initiated interactions on a concept
+// (0 if no interactions).
+func (s *Store) SelfInitiatedRatio(learnerID, concept string) (float64, error) {
+	var total, selfInit int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(self_initiated), 0)
+		 FROM interactions WHERE learner_id = ? AND concept = ?`,
+		learnerID, concept,
+	).Scan(&total, &selfInit)
+	if err != nil {
+		return 0, fmt.Errorf("self-initiated ratio: %w", err)
+	}
+	if total == 0 {
+		return 0, nil
+	}
+	return float64(selfInit) / float64(total), nil
+}
+
+// LastFailureOnConcept returns the most recent failed interaction on a concept,
+// or nil if none exists within `window`.
+func (s *Store) LastFailureOnConcept(learnerID, concept string, window time.Duration) (*models.Interaction, error) {
+	cutoff := time.Now().UTC().Add(-window)
+	rows, err := s.db.Query(
+		`SELECT `+interactionCols+` FROM interactions
+		 WHERE learner_id = ? AND concept = ? AND success = 0 AND created_at >= ?
+		 ORDER BY created_at DESC LIMIT 1`,
+		learnerID, concept, cutoff,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("last failure on concept: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanInteractions(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}

--- a/db/motivation_queries_test.go
+++ b/db/motivation_queries_test.go
@@ -1,0 +1,262 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// Seed a concept_state with a given PMastery.
+func seedConceptState(t *testing.T, store *Store, concept string, pMastery float64) {
+	t.Helper()
+	_, err := store.db.Exec(
+		`INSERT INTO concept_states (learner_id, concept, p_mastery, card_state, updated_at)
+		 VALUES ('L1', ?, ?, 'learning', ?)`,
+		concept, pMastery, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertSimpleInteraction(t *testing.T, store *Store, concept string, success bool, createdAt time.Time) {
+	t.Helper()
+	succInt := 0
+	if success {
+		succInt = 1
+	}
+	_, err := store.db.Exec(
+		`INSERT INTO interactions (learner_id, concept, activity_type, success, response_time, confidence, notes, created_at)
+		 VALUES ('L1', ?, 'RECALL_EXERCISE', ?, 60, 0.5, '', ?)`,
+		concept, succInt, createdAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestImplementationIntentionsInsertAndRecent verifies that an insert is persisted
+// and HasRecentImplementationIntention correctly respects the `since` cutoff.
+func TestImplementationIntentionsInsertAndRecent(t *testing.T) {
+	store := setupTestDB(t)
+
+	_, err := store.InsertImplementationIntention("L1", "D1", "demain matin", "ferai 1 exercice", time.Time{})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Should find it within the last hour.
+	has, err := store.HasRecentImplementationIntention("L1", "D1", time.Now().UTC().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("has recent: %v", err)
+	}
+	if !has {
+		t.Errorf("expected has=true within 1h")
+	}
+
+	// Should NOT find it when looking in the future.
+	has, _ = store.HasRecentImplementationIntention("L1", "D1", time.Now().UTC().Add(1*time.Hour))
+	if has {
+		t.Errorf("expected has=false for future cutoff")
+	}
+
+	// Any-domain check works too.
+	hasAny, _ := store.HasRecentImplementationIntention("L1", "", time.Now().UTC().Add(-1*time.Hour))
+	if !hasAny {
+		t.Errorf("expected any-domain has=true")
+	}
+}
+
+// TestImplementationIntentionsDomainScope ensures that the domain filter in
+// HasRecentImplementationIntention is strict.
+func TestImplementationIntentionsDomainScope(t *testing.T) {
+	store := setupTestDB(t)
+
+	_, err := store.InsertImplementationIntention("L1", "D1", "t", "a", time.Time{})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// D2 must not see D1's intention.
+	has, _ := store.HasRecentImplementationIntention("L1", "D2", time.Now().UTC().Add(-1*time.Hour))
+	if has {
+		t.Errorf("expected D2 has=false, intention belongs to D1")
+	}
+}
+
+// TestWebhookQueueEnqueueDequeueLifecycle covers enqueue, dequeue within the
+// scheduling window, and the mark-sent transition (which should prevent redelivery).
+func TestWebhookQueueEnqueueDequeueLifecycle(t *testing.T) {
+	store := setupTestDB(t)
+
+	now := time.Now().UTC()
+	scheduled := now.Add(5 * time.Minute) // within a 30min dispatch window
+	id, err := store.EnqueueWebhookMessage("L1", "daily_motivation", "hello", scheduled, time.Time{}, 0)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero id")
+	}
+
+	// Dequeue with 30min window.
+	item, err := store.DequeueNextPending("L1", "daily_motivation", now, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if item == nil {
+		t.Fatal("expected a queued item, got nil")
+	}
+	if item.Content != "hello" {
+		t.Errorf("expected content 'hello', got %q", item.Content)
+	}
+
+	// Mark sent.
+	if err := store.MarkWebhookSent(item.ID, now); err != nil {
+		t.Fatalf("mark sent: %v", err)
+	}
+
+	// Next dequeue should find nothing.
+	item2, _ := store.DequeueNextPending("L1", "daily_motivation", now, 30*time.Minute)
+	if item2 != nil {
+		t.Errorf("expected nil after mark sent, got id=%d", item2.ID)
+	}
+}
+
+// TestWebhookQueuePriorityOrdering verifies the highest-priority pending message
+// is returned first when multiple messages match the window.
+func TestWebhookQueuePriorityOrdering(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+
+	// Lower priority
+	_, _ = store.EnqueueWebhookMessage("L1", "daily_motivation", "low", now, time.Time{}, 0)
+	// Higher priority
+	_, _ = store.EnqueueWebhookMessage("L1", "daily_motivation", "high", now, time.Time{}, 5)
+
+	item, _ := store.DequeueNextPending("L1", "daily_motivation", now, 30*time.Minute)
+	if item == nil || item.Content != "high" {
+		t.Errorf("expected 'high', got %+v", item)
+	}
+}
+
+// TestWebhookQueueExpiry checks that a message whose expires_at is in the past
+// is filtered out by dequeue, and ExpirePastWebhookMessages transitions it.
+func TestWebhookQueueExpiry(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+
+	scheduled := now.Add(-10 * time.Minute)
+	expired := now.Add(-1 * time.Minute) // already expired
+	_, err := store.EnqueueWebhookMessage("L1", "daily_recap", "stale", scheduled, expired, 0)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	item, _ := store.DequeueNextPending("L1", "daily_recap", now, 30*time.Minute)
+	if item != nil {
+		t.Errorf("expected nil for expired item, got id=%d", item.ID)
+	}
+
+	n, err := store.ExpirePastWebhookMessages(now)
+	if err != nil {
+		t.Fatalf("expire: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 expired row, got %d", n)
+	}
+}
+
+// TestConceptMasteryDelta — seed a high current mastery + all-failure history
+// → delta is positive and concept appears.
+func TestConceptMasteryDelta(t *testing.T) {
+	store := setupTestDB(t)
+	since := time.Now().UTC().Add(-30 * 24 * time.Hour)
+
+	seedConceptState(t, store, "Goroutines", 0.85)
+	// 2 old failures before `since` → past mastery estimate ≈ 0
+	insertSimpleInteraction(t, store, "Goroutines", false, since.Add(-5*24*time.Hour))
+	insertSimpleInteraction(t, store, "Goroutines", false, since.Add(-10*24*time.Hour))
+
+	deltas, err := store.ConceptMasteryDelta("L1", []string{"Goroutines"}, since, 3)
+	if err != nil {
+		t.Fatalf("mastery delta: %v", err)
+	}
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Delta < 0.5 {
+		t.Errorf("expected significant delta, got %.2f", deltas[0].Delta)
+	}
+}
+
+// TestMilestonesInWindow — concept crossed mastery threshold AND has recent
+// successful interactions → appears; concept that's mastered but inactive → skipped.
+func TestMilestonesInWindow(t *testing.T) {
+	store := setupTestDB(t)
+	since := time.Now().UTC().Add(-7 * 24 * time.Hour)
+
+	// Active concept — mastered, has recent success
+	seedConceptState(t, store, "Goroutines", 0.9)
+	insertSimpleInteraction(t, store, "Goroutines", true, time.Now().UTC().Add(-1*time.Hour))
+
+	// Inactive concept — mastered but last interaction was before window
+	seedConceptState(t, store, "Interfaces", 0.9)
+	insertSimpleInteraction(t, store, "Interfaces", true, since.Add(-5*24*time.Hour))
+
+	// Unmastered concept — should not appear
+	seedConceptState(t, store, "Channels", 0.3)
+	insertSimpleInteraction(t, store, "Channels", true, time.Now().UTC().Add(-1*time.Hour))
+
+	milestones, err := store.MilestonesInWindow("L1", []string{"Goroutines", "Interfaces", "Channels"}, since)
+	if err != nil {
+		t.Fatalf("milestones: %v", err)
+	}
+	if len(milestones) != 1 {
+		t.Fatalf("expected 1 milestone, got %d: %v", len(milestones), milestones)
+	}
+	if milestones[0] != "Goroutines" {
+		t.Errorf("expected 'Goroutines', got %q", milestones[0])
+	}
+}
+
+// TestCountSessionsOnConcept uses distinct-date heuristic.
+func TestCountSessionsOnConcept(t *testing.T) {
+	store := setupTestDB(t)
+
+	// 3 interactions, 2 distinct dates
+	insertSimpleInteraction(t, store, "Goroutines", true, time.Now().UTC().Add(-48*time.Hour))
+	insertSimpleInteraction(t, store, "Goroutines", false, time.Now().UTC().Add(-45*time.Hour)) // same day as above
+	insertSimpleInteraction(t, store, "Goroutines", true, time.Now().UTC().Add(-1*time.Hour))
+
+	count, err := store.CountSessionsOnConcept("L1", "Goroutines")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 distinct sessions, got %d", count)
+	}
+}
+
+// TestLastFailureOnConcept_WithinWindow — a fresh failure should be returned;
+// an old one (outside window) should not.
+func TestLastFailureOnConcept_WithinWindow(t *testing.T) {
+	store := setupTestDB(t)
+
+	insertSimpleInteraction(t, store, "Goroutines", false, time.Now().UTC().Add(-2*time.Hour))
+	failure, err := store.LastFailureOnConcept("L1", "Goroutines", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("last failure: %v", err)
+	}
+	if failure == nil {
+		t.Fatal("expected a failure within 24h")
+	}
+	if failure.Success {
+		t.Errorf("expected success=false, got true")
+	}
+
+	// Outside window
+	none, _ := store.LastFailureOnConcept("L1", "Goroutines", 30*time.Minute)
+	if none != nil {
+		t.Errorf("expected nil outside window, got id=%d", none.ID)
+	}
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -17,12 +17,15 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 );
 
 CREATE TABLE IF NOT EXISTS domains (
-    id            TEXT PRIMARY KEY,
-    learner_id    TEXT NOT NULL REFERENCES learners(id),
-    name          TEXT NOT NULL,
-    personal_goal TEXT DEFAULT '',
-    graph_json    TEXT NOT NULL,
-    created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+    id                   TEXT PRIMARY KEY,
+    learner_id           TEXT NOT NULL REFERENCES learners(id),
+    name                 TEXT NOT NULL,
+    personal_goal        TEXT DEFAULT '',
+    graph_json           TEXT NOT NULL,
+    value_framings_json  TEXT DEFAULT '',
+    last_value_axis      TEXT DEFAULT '',
+    archived             INTEGER DEFAULT 0,
+    created_at           DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS concept_states (
@@ -138,6 +141,32 @@ CREATE TABLE IF NOT EXISTS transfer_records (
     created_at   DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Motivation layer (v0.10)
+
+CREATE TABLE IF NOT EXISTS implementation_intentions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    learner_id     TEXT    NOT NULL REFERENCES learners(id),
+    domain_id      TEXT    NOT NULL,
+    trigger_text   TEXT    NOT NULL,
+    action_text    TEXT    NOT NULL,
+    honored        INTEGER,
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    scheduled_for  DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS webhook_message_queue (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    learner_id     TEXT    NOT NULL REFERENCES learners(id),
+    kind           TEXT    NOT NULL,
+    scheduled_for  DATETIME NOT NULL,
+    expires_at     DATETIME,
+    content        TEXT    NOT NULL,
+    priority       INTEGER DEFAULT 0,
+    status         TEXT    DEFAULT 'pending',
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at        DATETIME
+);
+
 CREATE INDEX IF NOT EXISTS idx_concept_states_learner
     ON concept_states(learner_id);
 
@@ -164,6 +193,12 @@ CREATE INDEX IF NOT EXISTS idx_calibration_records_learner
 
 CREATE INDEX IF NOT EXISTS idx_transfer_records_learner_concept
     ON transfer_records(learner_id, concept_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_impl_intent_learner
+    ON implementation_intentions(learner_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_wmq_dispatch
+    ON webhook_message_queue(learner_id, kind, status, scheduled_for);
 
 -- idx_interactions_self_initiated is created in idempotent migrations
 -- (must run after ALTER TABLE adds the self_initiated column)

--- a/db/store.go
+++ b/db/store.go
@@ -204,6 +204,12 @@ func (s *Store) DeleteRefreshToken(token string) error {
 // ─── Domains ──────────────────────────────────────────────────────────────────
 
 func (s *Store) CreateDomain(learnerID, name, personalGoal string, graph models.KnowledgeSpace) (*models.Domain, error) {
+	return s.CreateDomainWithValueFramings(learnerID, name, personalGoal, graph, "")
+}
+
+// CreateDomainWithValueFramings creates a domain and optionally persists a JSON-encoded
+// set of value framings (4 axes: financial, employment, intellectual, innovation).
+func (s *Store) CreateDomainWithValueFramings(learnerID, name, personalGoal string, graph models.KnowledgeSpace, valueFramingsJSON string) (*models.Domain, error) {
 	id := generateID()
 	now := time.Now().UTC()
 
@@ -213,62 +219,93 @@ func (s *Store) CreateDomain(learnerID, name, personalGoal string, graph models.
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO domains (id, learner_id, name, personal_goal, graph_json, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-		id, learnerID, name, personalGoal, string(graphJSON), now,
+		`INSERT INTO domains (id, learner_id, name, personal_goal, graph_json, value_framings_json, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, learnerID, name, personalGoal, string(graphJSON), valueFramingsJSON, now,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create domain: %w", err)
 	}
 	return &models.Domain{
-		ID:           id,
-		LearnerID:    learnerID,
-		Name:         name,
-		PersonalGoal: personalGoal,
-		Graph:        graph,
-		CreatedAt:    now,
+		ID:                id,
+		LearnerID:         learnerID,
+		Name:              name,
+		PersonalGoal:      personalGoal,
+		Graph:             graph,
+		ValueFramingsJSON: valueFramingsJSON,
+		CreatedAt:         now,
 	}, nil
 }
 
-func (s *Store) GetDomainByLearner(learnerID string) (*models.Domain, error) {
+const domainCols = `id, learner_id, name, personal_goal, graph_json, value_framings_json, last_value_axis, archived, created_at`
+
+func scanDomainRow(row *sql.Row) (*models.Domain, error) {
 	d := &models.Domain{}
 	var graphJSON string
+	var valueFramings, lastAxis sql.NullString
 	var archived int
-	err := s.db.QueryRow(
-		`SELECT id, learner_id, name, personal_goal, graph_json, archived, created_at
-		 FROM domains WHERE learner_id = ? AND archived = 0 ORDER BY created_at DESC LIMIT 1`,
-		learnerID,
-	).Scan(&d.ID, &d.LearnerID, &d.Name, &d.PersonalGoal, &graphJSON, &archived, &d.CreatedAt)
+	err := row.Scan(&d.ID, &d.LearnerID, &d.Name, &d.PersonalGoal, &graphJSON, &valueFramings, &lastAxis, &archived, &d.CreatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("get domain by learner: %w", err)
+		return nil, err
 	}
 	d.Archived = archived != 0
+	if valueFramings.Valid {
+		d.ValueFramingsJSON = valueFramings.String
+	}
+	if lastAxis.Valid {
+		d.LastValueAxis = lastAxis.String
+	}
 	if err := json.Unmarshal([]byte(graphJSON), &d.Graph); err != nil {
 		return nil, fmt.Errorf("unmarshal graph: %w", err)
+	}
+	return d, nil
+}
+
+func scanDomainRows(rows *sql.Rows) (*models.Domain, error) {
+	d := &models.Domain{}
+	var graphJSON string
+	var valueFramings, lastAxis sql.NullString
+	var archived int
+	err := rows.Scan(&d.ID, &d.LearnerID, &d.Name, &d.PersonalGoal, &graphJSON, &valueFramings, &lastAxis, &archived, &d.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	d.Archived = archived != 0
+	if valueFramings.Valid {
+		d.ValueFramingsJSON = valueFramings.String
+	}
+	if lastAxis.Valid {
+		d.LastValueAxis = lastAxis.String
+	}
+	if err := json.Unmarshal([]byte(graphJSON), &d.Graph); err != nil {
+		return nil, fmt.Errorf("unmarshal graph: %w", err)
+	}
+	return d, nil
+}
+
+func (s *Store) GetDomainByLearner(learnerID string) (*models.Domain, error) {
+	row := s.db.QueryRow(
+		`SELECT `+domainCols+` FROM domains WHERE learner_id = ? AND archived = 0 ORDER BY created_at DESC LIMIT 1`,
+		learnerID,
+	)
+	d, err := scanDomainRow(row)
+	if err != nil {
+		return nil, fmt.Errorf("get domain by learner: %w", err)
 	}
 	return d, nil
 }
 
 func (s *Store) GetDomainByID(id string) (*models.Domain, error) {
-	d := &models.Domain{}
-	var graphJSON string
-	var archived int
-	err := s.db.QueryRow(
-		`SELECT id, learner_id, name, personal_goal, graph_json, archived, created_at
-		 FROM domains WHERE id = ?`, id,
-	).Scan(&d.ID, &d.LearnerID, &d.Name, &d.PersonalGoal, &graphJSON, &archived, &d.CreatedAt)
+	row := s.db.QueryRow(`SELECT `+domainCols+` FROM domains WHERE id = ?`, id)
+	d, err := scanDomainRow(row)
 	if err != nil {
 		return nil, fmt.Errorf("get domain by id: %w", err)
-	}
-	d.Archived = archived != 0
-	if err := json.Unmarshal([]byte(graphJSON), &d.Graph); err != nil {
-		return nil, fmt.Errorf("unmarshal graph: %w", err)
 	}
 	return d, nil
 }
 
 func (s *Store) GetDomainsByLearner(learnerID string, includeArchived bool) ([]*models.Domain, error) {
-	query := `SELECT id, learner_id, name, personal_goal, graph_json, archived, created_at
-		 FROM domains WHERE learner_id = ?`
+	query := `SELECT ` + domainCols + ` FROM domains WHERE learner_id = ?`
 	if !includeArchived {
 		query += ` AND archived = 0`
 	}
@@ -281,19 +318,37 @@ func (s *Store) GetDomainsByLearner(learnerID string, includeArchived bool) ([]*
 
 	var domains []*models.Domain
 	for rows.Next() {
-		d := &models.Domain{}
-		var graphJSON string
-		var archived int
-		if err := rows.Scan(&d.ID, &d.LearnerID, &d.Name, &d.PersonalGoal, &graphJSON, &archived, &d.CreatedAt); err != nil {
+		d, err := scanDomainRows(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan domain row: %w", err)
-		}
-		d.Archived = archived != 0
-		if err := json.Unmarshal([]byte(graphJSON), &d.Graph); err != nil {
-			return nil, fmt.Errorf("unmarshal graph: %w", err)
 		}
 		domains = append(domains, d)
 	}
 	return domains, rows.Err()
+}
+
+// UpdateDomainValueFramings stores the JSON-encoded value framings for a domain.
+func (s *Store) UpdateDomainValueFramings(domainID, valueFramingsJSON string) error {
+	_, err := s.db.Exec(
+		`UPDATE domains SET value_framings_json = ? WHERE id = ?`,
+		valueFramingsJSON, domainID,
+	)
+	if err != nil {
+		return fmt.Errorf("update domain value framings: %w", err)
+	}
+	return nil
+}
+
+// UpdateDomainLastValueAxis records which axis was surfaced most recently (used for rotation).
+func (s *Store) UpdateDomainLastValueAxis(domainID, axis string) error {
+	_, err := s.db.Exec(
+		`UPDATE domains SET last_value_axis = ? WHERE id = ?`,
+		axis, domainID,
+	)
+	if err != nil {
+		return fmt.Errorf("update domain last value axis: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) UpdateDomainGraph(domainID string, graph models.KnowledgeSpace) error {

--- a/db/webhook_queue.go
+++ b/db/webhook_queue.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"learning-runtime/models"
+)
+
+// EnqueueWebhookMessage persists a scheduled, LLM-authored webhook nudge.
+// Returns the inserted row ID.
+func (s *Store) EnqueueWebhookMessage(learnerID, kind, content string, scheduledFor, expiresAt time.Time, priority int) (int64, error) {
+	if kind == "" {
+		return 0, fmt.Errorf("kind is required")
+	}
+	if content == "" {
+		return 0, fmt.Errorf("content is required")
+	}
+	if scheduledFor.IsZero() {
+		return 0, fmt.Errorf("scheduled_for is required")
+	}
+	var expires any
+	if !expiresAt.IsZero() {
+		expires = expiresAt.UTC()
+	}
+	result, err := s.db.Exec(
+		`INSERT INTO webhook_message_queue (learner_id, kind, scheduled_for, expires_at, content, priority, status, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)`,
+		learnerID, kind, scheduledFor.UTC(), expires, content, priority, time.Now().UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("enqueue webhook message: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("get webhook queue id: %w", err)
+	}
+	return id, nil
+}
+
+// DequeueNextPending returns the highest-priority pending message for a learner/kind
+// whose scheduled_for is within [now-window, now+window] and not expired.
+// Returns (nil, nil) if nothing is pending.
+func (s *Store) DequeueNextPending(learnerID, kind string, now time.Time, window time.Duration) (*models.WebhookQueueItem, error) {
+	lower := now.Add(-window).UTC()
+	upper := now.Add(window).UTC()
+	row := s.db.QueryRow(
+		`SELECT id, learner_id, kind, scheduled_for, expires_at, content, priority, status, created_at, sent_at
+		 FROM webhook_message_queue
+		 WHERE learner_id = ? AND kind = ? AND status = 'pending'
+		   AND scheduled_for BETWEEN ? AND ?
+		   AND (expires_at IS NULL OR expires_at > ?)
+		 ORDER BY priority DESC, scheduled_for ASC
+		 LIMIT 1`,
+		learnerID, kind, lower, upper, now.UTC(),
+	)
+	item, err := scanWebhookQueueItem(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("dequeue webhook message: %w", err)
+	}
+	return item, nil
+}
+
+// MarkWebhookSent marks the given queue item as sent at `now`.
+func (s *Store) MarkWebhookSent(id int64, now time.Time) error {
+	_, err := s.db.Exec(
+		`UPDATE webhook_message_queue SET status = 'sent', sent_at = ? WHERE id = ?`,
+		now.UTC(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("mark webhook sent: %w", err)
+	}
+	return nil
+}
+
+// MarkWebhookFailed marks the given queue item as failed (will not be retried).
+func (s *Store) MarkWebhookFailed(id int64) error {
+	_, err := s.db.Exec(
+		`UPDATE webhook_message_queue SET status = 'failed' WHERE id = ?`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("mark webhook failed: %w", err)
+	}
+	return nil
+}
+
+// ExpirePastWebhookMessages marks any pending message whose expires_at is in the past as 'expired'.
+// Returns the number of rows updated.
+func (s *Store) ExpirePastWebhookMessages(now time.Time) (int64, error) {
+	result, err := s.db.Exec(
+		`UPDATE webhook_message_queue SET status = 'expired'
+		 WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?`,
+		now.UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("expire past webhook messages: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// GetPendingWebhookMessages returns all pending messages (for monitoring / debugging).
+func (s *Store) GetPendingWebhookMessages(learnerID string) ([]*models.WebhookQueueItem, error) {
+	rows, err := s.db.Query(
+		`SELECT id, learner_id, kind, scheduled_for, expires_at, content, priority, status, created_at, sent_at
+		 FROM webhook_message_queue
+		 WHERE learner_id = ? AND status = 'pending'
+		 ORDER BY scheduled_for ASC`,
+		learnerID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get pending webhook messages: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.WebhookQueueItem
+	for rows.Next() {
+		item, err := scanWebhookQueueItemRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+// scanWebhookQueueItem is used for QueryRow results.
+func scanWebhookQueueItem(row *sql.Row) (*models.WebhookQueueItem, error) {
+	item := &models.WebhookQueueItem{}
+	var expiresAt, sentAt sql.NullTime
+	err := row.Scan(
+		&item.ID, &item.LearnerID, &item.Kind, &item.ScheduledFor,
+		&expiresAt, &item.Content, &item.Priority, &item.Status,
+		&item.CreatedAt, &sentAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if expiresAt.Valid {
+		t := expiresAt.Time
+		item.ExpiresAt = &t
+	}
+	if sentAt.Valid {
+		t := sentAt.Time
+		item.SentAt = &t
+	}
+	return item, nil
+}
+
+// scanWebhookQueueItemRows is used for Query results (iteration).
+func scanWebhookQueueItemRows(rows *sql.Rows) (*models.WebhookQueueItem, error) {
+	item := &models.WebhookQueueItem{}
+	var expiresAt, sentAt sql.NullTime
+	err := rows.Scan(
+		&item.ID, &item.LearnerID, &item.Kind, &item.ScheduledFor,
+		&expiresAt, &item.Content, &item.Priority, &item.Status,
+		&item.CreatedAt, &sentAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if expiresAt.Valid {
+		t := expiresAt.Time
+		item.ExpiresAt = &t
+	}
+	if sentAt.Valid {
+		t := sentAt.Time
+		item.SentAt = &t
+	}
+	return item, nil
+}

--- a/engine/motivation.go
+++ b/engine/motivation.go
@@ -1,0 +1,325 @@
+package engine
+
+import (
+	"encoding/json"
+	"time"
+
+	"learning-runtime/algorithms"
+	"learning-runtime/db"
+	"learning-runtime/models"
+)
+
+// BriefInput gathers the signals the motivation engine needs to decide which brief (if any) to fire.
+// Keep this purely data — no store access — so the selection logic can be unit-tested in isolation.
+type BriefInput struct {
+	Domain               *models.Domain
+	Concept              string
+	ActivityType         models.ActivityType
+	ConceptState         *models.ConceptState
+	LastFailure          *models.Interaction // within 24h, same concept
+	LatestAffect         *models.AffectState
+	SessionsOnConcept    int
+	SelfInitiatedRatio   float64
+	SessionExerciseCount int  // number of concepts already practiced in current session
+	PlateauActive        bool // any PLATEAU alert active on this concept
+	Now                  time.Time
+}
+
+// InferInterestPhase maps session count / mastery / self-initiated ratio to a
+// Hidi-Renninger phase label.
+func InferInterestPhase(sessions int, mastery, selfInitRatio float64) string {
+	if mastery > 0.85 || (selfInitRatio > 0.6 && sessions >= 3) {
+		return models.InterestPhaseIndividual
+	}
+	if mastery >= 0.5 {
+		return models.InterestPhaseEmerging
+	}
+	if sessions >= 3 {
+		return models.InterestPhaseSustained
+	}
+	return models.InterestPhaseTriggered
+}
+
+// crossedMilestone returns the nearest threshold (0.5, 0.7, 0.85) the current
+// mastery sits within ±0.02 of, or 0 if none.
+func crossedMilestone(p float64) float64 {
+	thresholds := []float64{algorithms.BKTMasteryThreshold, 0.7, 0.5}
+	for _, t := range thresholds {
+		if p >= t-0.02 && p <= t+0.02 {
+			return t
+		}
+	}
+	return 0
+}
+
+// shouldFireCompetenceValue fires:
+//   - on the first exercise of a session when the chosen concept is new (sessions <= 1)
+//   - every 5 sessions on a concept (sustained reminder of stakes)
+//   - when a milestone was also just crossed (combined emphasis)
+func shouldFireCompetenceValue(in BriefInput, milestone float64) bool {
+	if in.Domain == nil {
+		return false
+	}
+	if milestone > 0 {
+		return true
+	}
+	if in.SessionsOnConcept <= 1 && in.SessionExerciseCount <= 1 {
+		return true
+	}
+	if in.SessionsOnConcept > 0 && in.SessionsOnConcept%5 == 0 && in.SessionExerciseCount <= 1 {
+		return true
+	}
+	return false
+}
+
+// nextValueAxis picks the next axis in round-robin order, skipping axes whose
+// authored statement is empty if at least one is populated (prefer authored content).
+func nextValueAxis(lastAxis string, framings *models.DomainValueFramings) string {
+	axes := models.ValueAxes
+	// Determine starting index (one past lastAxis)
+	start := 0
+	for i, a := range axes {
+		if a == lastAxis {
+			start = (i + 1) % len(axes)
+			break
+		}
+	}
+
+	// If any authored statement exists, prefer the next authored axis.
+	hasAuthored := framings != nil && (framings.Financial != "" || framings.Employment != "" || framings.Intellectual != "" || framings.Innovation != "")
+	if hasAuthored {
+		for i := 0; i < len(axes); i++ {
+			a := axes[(start+i)%len(axes)]
+			if framings.StatementFor(a) != "" {
+				return a
+			}
+		}
+	}
+	return axes[start]
+}
+
+// SelectBrief chooses which motivation brief kind to fire (or "" for silence).
+// Priority order (first match wins):
+//  1. milestone         — just crossed a mastery threshold
+//  2. competence_value  — reminder of the concrete gain this skill unlocks
+//  3. growth_mindset    — a failure occurred on this concept within 24h
+//  4. affect_reframe    — the latest end-of-session affect was negative
+//  5. plateau_recontext — plateau detected on this concept
+//  6. why_this_exercise — utility-value fallback, linked to personal_goal
+func SelectBrief(in BriefInput) string {
+	milestone := 0.0
+	if in.ConceptState != nil {
+		milestone = crossedMilestone(in.ConceptState.PMastery)
+	}
+	if milestone > 0 {
+		return models.MotivationKindMilestone
+	}
+	if shouldFireCompetenceValue(in, milestone) {
+		return models.MotivationKindCompetenceValue
+	}
+	if in.LastFailure != nil && !in.LastFailure.Success {
+		return models.MotivationKindGrowthMindset
+	}
+	if affectIsNegative(in.LatestAffect, in.Now) {
+		return models.MotivationKindAffectReframe
+	}
+	if in.PlateauActive {
+		return models.MotivationKindPlateauRecontext
+	}
+	if in.Domain != nil && in.Domain.PersonalGoal != "" &&
+		(in.ActivityType == models.ActivityNewConcept || in.SessionExerciseCount <= 1) {
+		return models.MotivationKindWhyThisExercise
+	}
+	return ""
+}
+
+// affectIsNegative checks whether the most recent affect (within the last ~24h)
+// carries a clear negative signal. Returns false if there is no affect state or
+// if it is older than 24h.
+func affectIsNegative(a *models.AffectState, now time.Time) bool {
+	if a == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if now.Sub(a.CreatedAt) > 24*time.Hour {
+		return false
+	}
+	if a.Satisfaction > 0 && a.Satisfaction <= 2 {
+		return true
+	}
+	if a.PerceivedDifficulty == 4 {
+		return true
+	}
+	if a.Energy > 0 && a.Energy <= 1 {
+		return true
+	}
+	return false
+}
+
+// ComposeBrief builds a MotivationBrief from the given signals and the chosen kind.
+// The caller is responsible for persisting Domain.LastValueAxis when kind == competence_value.
+func ComposeBrief(in BriefInput, kind, pickedAxis string) *models.MotivationBrief {
+	if kind == "" {
+		return &models.MotivationBrief{Kind: ""}
+	}
+
+	brief := &models.MotivationBrief{Kind: kind}
+	if in.ConceptState != nil {
+		brief.InterestPhase = InferInterestPhase(in.SessionsOnConcept, in.ConceptState.PMastery, in.SelfInitiatedRatio)
+	}
+
+	switch kind {
+	case models.MotivationKindMilestone:
+		threshold := 0.0
+		if in.ConceptState != nil {
+			threshold = crossedMilestone(in.ConceptState.PMastery)
+			brief.ProgressDelta = &models.ProgressDelta{
+				Concept:    in.Concept,
+				MasteryNow: in.ConceptState.PMastery,
+				Threshold:  threshold,
+			}
+		}
+		brief.Instruction = "Celebre brievement le franchissement du seuil, sans emphase excessive. Relie a la progression globale en une phrase."
+
+	case models.MotivationKindCompetenceValue:
+		var framings *models.DomainValueFramings
+		if in.Domain != nil && in.Domain.ValueFramingsJSON != "" {
+			var parsed models.DomainValueFramings
+			if err := json.Unmarshal([]byte(in.Domain.ValueFramingsJSON), &parsed); err == nil {
+				framings = &parsed
+			}
+		}
+		statement := ""
+		if framings != nil {
+			statement = framings.StatementFor(pickedAxis)
+		}
+		brief.ValueFraming = &models.ValueFraming{
+			Axis:      pickedAxis,
+			Statement: statement,
+		}
+		if statement == "" {
+			brief.Instruction = "Compose une phrase soulignant le gain concret sur l'axe " + pickedAxis + " de la maitrise de ce concept. Puis persiste-la en rappelant a l'utilisateur que c'est une vue parmi d'autres."
+		} else {
+			brief.Instruction = "Integre le gain sur l'axe " + pickedAxis + " en une phrase, relie au concept de l'exercice. Pas de chiffres invente, pas de copie verbatim du statement."
+		}
+		if in.Domain != nil {
+			brief.GoalLink = in.Domain.PersonalGoal
+		}
+
+	case models.MotivationKindGrowthMindset:
+		if in.LastFailure != nil {
+			fm := &models.FailureMeta{
+				Concept:             in.LastFailure.Concept,
+				HintsRequested:      in.LastFailure.HintsRequested,
+				ErrorType:           in.LastFailure.ErrorType,
+				MisconceptionType:   in.LastFailure.MisconceptionType,
+				HoursAgo:            int(in.Now.Sub(in.LastFailure.CreatedAt).Hours()),
+			}
+			if in.Now.IsZero() {
+				fm.HoursAgo = int(time.Since(in.LastFailure.CreatedAt).Hours())
+			}
+			brief.FailureContext = fm
+		}
+		brief.Instruction = "Reframe l'echec precedent en termes d'effort/strategie, jamais d'aptitude personnelle. Une phrase courte qui valide et relance."
+
+	case models.MotivationKindAffectReframe:
+		if in.LatestAffect != nil {
+			am := &models.AffectMeta{SessionID: in.LatestAffect.SessionID}
+			switch {
+			case in.LatestAffect.Satisfaction > 0 && in.LatestAffect.Satisfaction <= 2:
+				am.Dimension = "satisfaction"
+				am.Value = in.LatestAffect.Satisfaction
+			case in.LatestAffect.PerceivedDifficulty == 4:
+				am.Dimension = "difficulty"
+				am.Value = in.LatestAffect.PerceivedDifficulty
+			case in.LatestAffect.Energy > 0 && in.LatestAffect.Energy <= 1:
+				am.Dimension = "energy"
+				am.Value = in.LatestAffect.Energy
+			}
+			am.HoursAgo = int(in.Now.Sub(in.LatestAffect.CreatedAt).Hours())
+			if in.Now.IsZero() {
+				am.HoursAgo = int(time.Since(in.LatestAffect.CreatedAt).Hours())
+			}
+			brief.AffectContext = am
+		}
+		brief.Instruction = "Valide d'abord l'emotion detectee, puis reframe brievement (frustration = bord du ZPD ; fatigue = sois plus leger). Une phrase."
+
+	case models.MotivationKindPlateauRecontext:
+		brief.Instruction = "Propose un angle d'attaque different pour sortir du plateau. Pas de discours general, un hook concret sur ce concept precis."
+
+	case models.MotivationKindWhyThisExercise:
+		if in.Domain != nil {
+			brief.GoalLink = in.Domain.PersonalGoal
+		}
+		brief.Instruction = "Relie exercice -> concept -> goal_link en UNE phrase. Ni plus ni moins."
+	}
+
+	return brief
+}
+
+// MotivationEngine wires SelectBrief / ComposeBrief to the persistence layer and
+// handles side effects (e.g., rotating the domain's last_value_axis).
+type MotivationEngine struct {
+	store *db.Store
+}
+
+func NewMotivationEngine(store *db.Store) *MotivationEngine {
+	return &MotivationEngine{store: store}
+}
+
+// Build gathers signals from the store, selects a brief kind, composes the brief,
+// and persists side effects (rotates Domain.LastValueAxis when a competence_value
+// brief fires). Returns a brief with Kind == "" when no trigger matches.
+func (m *MotivationEngine) Build(learnerID string, domain *models.Domain, concept string, activityType models.ActivityType, plateauActive bool, sessionExerciseCount int) (*models.MotivationBrief, error) {
+	now := time.Now().UTC()
+
+	in := BriefInput{
+		Domain:               domain,
+		Concept:              concept,
+		ActivityType:         activityType,
+		SessionExerciseCount: sessionExerciseCount,
+		PlateauActive:        plateauActive,
+		Now:                  now,
+	}
+
+	// Concept-scoped signals (only if we have a concept target)
+	if concept != "" {
+		cs, _ := m.store.GetConceptState(learnerID, concept)
+		in.ConceptState = cs
+
+		if fail, _ := m.store.LastFailureOnConcept(learnerID, concept, 24*time.Hour); fail != nil {
+			in.LastFailure = fail
+		}
+		if sessions, err := m.store.CountSessionsOnConcept(learnerID, concept); err == nil {
+			in.SessionsOnConcept = sessions
+		}
+		if ratio, err := m.store.SelfInitiatedRatio(learnerID, concept); err == nil {
+			in.SelfInitiatedRatio = ratio
+		}
+	}
+
+	// Latest affect (global, not concept-scoped)
+	if affects, _ := m.store.GetRecentAffectStates(learnerID, 1); len(affects) > 0 {
+		in.LatestAffect = affects[0]
+	}
+
+	kind := SelectBrief(in)
+
+	// Rotate axis if kind is competence_value
+	pickedAxis := ""
+	if kind == models.MotivationKindCompetenceValue && domain != nil {
+		var framings *models.DomainValueFramings
+		if domain.ValueFramingsJSON != "" {
+			var parsed models.DomainValueFramings
+			if err := json.Unmarshal([]byte(domain.ValueFramingsJSON), &parsed); err == nil {
+				framings = &parsed
+			}
+		}
+		pickedAxis = nextValueAxis(domain.LastValueAxis, framings)
+		_ = m.store.UpdateDomainLastValueAxis(domain.ID, pickedAxis)
+	}
+
+	return ComposeBrief(in, kind, pickedAxis), nil
+}

--- a/engine/motivation_test.go
+++ b/engine/motivation_test.go
@@ -1,0 +1,231 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"learning-runtime/models"
+)
+
+func newDomainWithGoal(goal string) *models.Domain {
+	return &models.Domain{ID: "D1", Name: "Go", PersonalGoal: goal}
+}
+
+// TestInferInterestPhase covers all four phases.
+func TestInferInterestPhase(t *testing.T) {
+	cases := []struct {
+		name          string
+		sessions      int
+		mastery       float64
+		selfInitRatio float64
+		want          string
+	}{
+		{"beginner", 1, 0.1, 0.0, models.InterestPhaseTriggered},
+		{"a few sessions, low mastery", 4, 0.3, 0.0, models.InterestPhaseSustained},
+		{"emerging mastery", 5, 0.6, 0.2, models.InterestPhaseEmerging},
+		{"individual via mastery", 10, 0.9, 0.1, models.InterestPhaseIndividual},
+		{"individual via self-initiation", 5, 0.4, 0.7, models.InterestPhaseIndividual},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := InferInterestPhase(tc.sessions, tc.mastery, tc.selfInitRatio)
+			if got != tc.want {
+				t.Errorf("phase for sessions=%d mastery=%.2f selfInit=%.2f = %q, want %q",
+					tc.sessions, tc.mastery, tc.selfInitRatio, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSelectBrief_WhyThisExercise — new concept in a domain with personal_goal fires utility-value.
+func TestSelectBrief_WhyThisExercise(t *testing.T) {
+	in := BriefInput{
+		Domain:               newDomainWithGoal("devenir SRE"),
+		Concept:              "Goroutines",
+		ActivityType:         models.ActivityNewConcept,
+		ConceptState:         &models.ConceptState{PMastery: 0.1},
+		SessionExerciseCount: 1,
+		SessionsOnConcept:    1,
+		Now:                  time.Now().UTC(),
+	}
+	got := SelectBrief(in)
+	// SessionsOnConcept == 1 means competence_value fires first (1st session rule)
+	if got != models.MotivationKindCompetenceValue {
+		t.Errorf("expected competence_value (1st session on concept), got %q", got)
+	}
+}
+
+// TestSelectBrief_GrowthMindsetOnFailure — a fresh failure takes precedence over fallback.
+func TestSelectBrief_GrowthMindsetOnFailure(t *testing.T) {
+	now := time.Now().UTC()
+	in := BriefInput{
+		Domain:       newDomainWithGoal("objectif"),
+		Concept:      "Goroutines",
+		ActivityType: models.ActivityRecall,
+		ConceptState: &models.ConceptState{PMastery: 0.35},
+		LastFailure: &models.Interaction{
+			Concept: "Goroutines", Success: false,
+			HintsRequested: 2, ErrorType: "LOGIC_ERROR",
+			CreatedAt: now.Add(-2 * time.Hour),
+		},
+		SessionExerciseCount: 3, // not 1st exercise, so why_this_exercise would not fire
+		SessionsOnConcept:    4,
+		Now:                  now,
+	}
+	got := SelectBrief(in)
+	if got != models.MotivationKindGrowthMindset {
+		t.Errorf("expected growth_mindset, got %q", got)
+	}
+}
+
+// TestSelectBrief_AffectReframe — negative satisfaction triggers affect_reframe.
+func TestSelectBrief_AffectReframe(t *testing.T) {
+	now := time.Now().UTC()
+	in := BriefInput{
+		Domain:       newDomainWithGoal("goal"),
+		Concept:      "Goroutines",
+		ActivityType: models.ActivityRecall,
+		ConceptState: &models.ConceptState{PMastery: 0.35},
+		LatestAffect: &models.AffectState{
+			SessionID: "s1", Satisfaction: 1, CreatedAt: now.Add(-3 * time.Hour),
+		},
+		SessionExerciseCount: 3,
+		SessionsOnConcept:    4,
+		Now:                  now,
+	}
+	got := SelectBrief(in)
+	if got != models.MotivationKindAffectReframe {
+		t.Errorf("expected affect_reframe, got %q", got)
+	}
+}
+
+// TestSelectBrief_Milestone — mastery in the 0.85 band fires milestone, beating others.
+func TestSelectBrief_Milestone(t *testing.T) {
+	now := time.Now().UTC()
+	in := BriefInput{
+		Domain:       newDomainWithGoal("goal"),
+		Concept:      "Goroutines",
+		ActivityType: models.ActivityRecall,
+		ConceptState: &models.ConceptState{PMastery: 0.86},
+		LastFailure: &models.Interaction{
+			Concept: "Goroutines", Success: false, CreatedAt: now.Add(-1 * time.Hour),
+		},
+		SessionExerciseCount: 3,
+		SessionsOnConcept:    7,
+		Now:                  now,
+	}
+	got := SelectBrief(in)
+	if got != models.MotivationKindMilestone {
+		t.Errorf("expected milestone (priority 1), got %q", got)
+	}
+}
+
+// TestSelectBrief_Silent — no triggers match → empty kind.
+func TestSelectBrief_Silent(t *testing.T) {
+	in := BriefInput{
+		Domain:               &models.Domain{ID: "D1", Name: "Go", PersonalGoal: ""}, // no goal
+		Concept:              "Goroutines",
+		ActivityType:         models.ActivityRecall,
+		ConceptState:         &models.ConceptState{PMastery: 0.35},
+		SessionExerciseCount: 5,
+		SessionsOnConcept:    4, // not new, not a 5th-session trigger
+		Now:                  time.Now().UTC(),
+	}
+	got := SelectBrief(in)
+	if got != "" {
+		t.Errorf("expected silent (empty), got %q", got)
+	}
+}
+
+// TestSelectBrief_CompetenceValueEveryFifthSession — at session 5 with a fresh
+// session_exercise_count of 1, competence_value should fire even without other triggers.
+func TestSelectBrief_CompetenceValueEveryFifthSession(t *testing.T) {
+	in := BriefInput{
+		Domain:               newDomainWithGoal("goal"),
+		Concept:              "Goroutines",
+		ActivityType:         models.ActivityRecall,
+		ConceptState:         &models.ConceptState{PMastery: 0.45},
+		SessionExerciseCount: 1,
+		SessionsOnConcept:    5,
+		Now:                  time.Now().UTC(),
+	}
+	got := SelectBrief(in)
+	if got != models.MotivationKindCompetenceValue {
+		t.Errorf("expected competence_value at 5th session, got %q", got)
+	}
+}
+
+// TestNextValueAxis_RoundRobin confirms the rotation is deterministic and wraps.
+func TestNextValueAxis_RoundRobin(t *testing.T) {
+	// No framings authored: pure rotation starting from after lastAxis.
+	if got := nextValueAxis("", nil); got != "financial" {
+		t.Errorf("expected first axis 'financial', got %q", got)
+	}
+	if got := nextValueAxis("financial", nil); got != "employment" {
+		t.Errorf("expected 'employment', got %q", got)
+	}
+	if got := nextValueAxis("innovation", nil); got != "financial" {
+		t.Errorf("expected wrap to 'financial', got %q", got)
+	}
+}
+
+// TestNextValueAxis_PrefersAuthored — when some axes have authored statements,
+// the rotation skips unauthored axes.
+func TestNextValueAxis_PrefersAuthored(t *testing.T) {
+	framings := &models.DomainValueFramings{
+		Financial:    "", // unauthored
+		Employment:   "good employment statement",
+		Intellectual: "", // unauthored
+		Innovation:   "good innovation statement",
+	}
+	// Starting from nothing, we should hit employment first (the first authored axis in order).
+	if got := nextValueAxis("", framings); got != "employment" {
+		t.Errorf("expected 'employment' (first authored), got %q", got)
+	}
+	// After employment, the next authored axis is innovation.
+	if got := nextValueAxis("employment", framings); got != "innovation" {
+		t.Errorf("expected 'innovation' (next authored), got %q", got)
+	}
+	// After innovation, wrap back to employment (financial and intellectual are empty).
+	if got := nextValueAxis("innovation", framings); got != "employment" {
+		t.Errorf("expected wrap to 'employment', got %q", got)
+	}
+}
+
+// TestComposeBrief_CompetenceValue — the composed brief carries axis + statement.
+func TestComposeBrief_CompetenceValue(t *testing.T) {
+	domain := newDomainWithGoal("goal")
+	domain.ValueFramingsJSON = `{"financial":"salaires quant 80k+"}`
+	in := BriefInput{
+		Domain:       domain,
+		Concept:      "Goroutines",
+		ConceptState: &models.ConceptState{PMastery: 0.1},
+	}
+	brief := ComposeBrief(in, models.MotivationKindCompetenceValue, "financial")
+	if brief.ValueFraming == nil {
+		t.Fatal("expected ValueFraming populated")
+	}
+	if brief.ValueFraming.Axis != "financial" {
+		t.Errorf("expected axis 'financial', got %q", brief.ValueFraming.Axis)
+	}
+	if brief.ValueFraming.Statement != "salaires quant 80k+" {
+		t.Errorf("expected statement copied from JSON, got %q", brief.ValueFraming.Statement)
+	}
+}
+
+// TestComposeBrief_Silent — empty kind yields empty brief.
+func TestComposeBrief_Silent(t *testing.T) {
+	brief := ComposeBrief(BriefInput{}, "", "")
+	if brief.Kind != "" {
+		t.Errorf("expected empty kind, got %q", brief.Kind)
+	}
+}
+
+// TestAffectNegative_StaleIgnored — an affect older than 24h should not trigger.
+func TestAffectNegative_StaleIgnored(t *testing.T) {
+	now := time.Now().UTC()
+	old := &models.AffectState{Satisfaction: 1, CreatedAt: now.Add(-48 * time.Hour)}
+	if affectIsNegative(old, now) {
+		t.Errorf("expected stale affect to be ignored")
+	}
+}

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"learning-runtime/algorithms"
 	"learning-runtime/db"
 	"learning-runtime/models"
 
@@ -183,12 +181,32 @@ func (s *Scheduler) sendReviewReminders() {
 }
 
 // ─── Daily Motivation (8h) ──────────────────────────────────────────────────
+//
+// The scheduler no longer composes motivational text. Claude authors messages
+// during sessions via queue_webhook_message, the scheduler dispatches from the
+// queue. If the queue is empty for a learner, we fall back to a sober one-liner
+// (no KPIs, no analytics bulletin tone).
 
 func (s *Scheduler) sendDailyMotivation() {
+	s.dispatchQueued("daily_motivation", "DAILY_MOTIVATION", fallbackDailyMotivation)
+}
+
+// ─── Daily Recap (21h) ─────────────────────────────────────────────────────
+
+func (s *Scheduler) sendDailyRecap() {
+	s.dispatchQueued("daily_recap", "DAILY_RECAP", fallbackDailyRecap)
+}
+
+// dispatchQueued pulls the best pending webhook message for each active learner
+// (kind + ±30min scheduling window) and posts it. Falls back to a sober template
+// when the queue is empty.
+func (s *Scheduler) dispatchQueued(kind, alertTag string, fallback func(*models.Learner) discordPayload) {
 	learners, err := s.store.GetActiveLearners()
 	if err != nil {
+		s.logger.Error("scheduler: dispatch get learners", "err", err, "kind", kind)
 		return
 	}
+	now := time.Now().UTC()
 
 	for _, learner := range learners {
 		if learner.WebhookURL == "" {
@@ -199,77 +217,92 @@ func (s *Scheduler) sendDailyMotivation() {
 			continue
 		}
 
-		streak, _ := s.store.GetDailyStreak(learner.ID)
-		states, _ := s.store.GetConceptStatesByLearner(learner.ID)
-		due, _ := s.store.GetConceptsDueForReview(learner.ID)
-
-		// Count mastered concepts
-		mastered := 0
-		total := len(states)
-		for _, cs := range states {
-			if cs.PMastery >= algorithms.BKTMasteryThreshold {
-				mastered++
-			}
-		}
-
-		// Compute day number
-		dayNumber := int(math.Floor(time.Since(learner.CreatedAt).Hours()/24)) + 1
-
-		msg := formatDailyMotivation(dayNumber, streak, mastered, total, len(due), learner.Objective)
-		if err := s.sendDiscordEmbed(learner.WebhookURL, msg); err != nil {
-			s.logger.Error("scheduler: motivation webhook", "err", err)
+		// Dedup at the alert layer — don't fire twice in one day.
+		sent, _ := s.store.WasAlertSentToday(learner.ID, alertTag)
+		if sent {
 			continue
 		}
-		s.store.CreateScheduledAlert(learner.ID, "DAILY_MOTIVATION", "", time.Now())
-		s.logger.Info("scheduler: motivation sent", "learner", learner.ID, "streak", streak)
+
+		item, err := s.store.DequeueNextPending(learner.ID, kind, now, 30*time.Minute)
+		if err != nil {
+			s.logger.Error("scheduler: dequeue", "err", err, "learner", learner.ID, "kind", kind)
+			continue
+		}
+
+		var payload discordPayload
+		var source string
+		if item != nil && item.Content != "" {
+			payload = discordPayload{Embeds: []discordEmbed{{
+				Title:       queueKindTitle(kind),
+				Description: item.Content,
+				Color:       queueKindColor(kind),
+			}}}
+			source = "queue"
+		} else if fallback != nil {
+			payload = fallback(learner)
+			source = "fallback"
+		} else {
+			continue
+		}
+
+		if err := s.sendDiscordEmbed(learner.WebhookURL, payload); err != nil {
+			s.logger.Error("scheduler: dispatch webhook", "err", err, "learner", learner.ID, "kind", kind)
+			if item != nil {
+				_ = s.store.MarkWebhookFailed(item.ID)
+			}
+			continue
+		}
+		if item != nil {
+			_ = s.store.MarkWebhookSent(item.ID, now)
+		}
+		s.store.CreateScheduledAlert(learner.ID, alertTag, "", time.Now())
+		s.logger.Info("scheduler: dispatched", "learner", learner.ID, "kind", kind, "source", source)
 	}
 }
 
-// ─── Daily Recap (21h) ─────────────────────────────────────────────────────
-
-func (s *Scheduler) sendDailyRecap() {
-	learners, err := s.store.GetActiveLearners()
-	if err != nil {
-		return
+// queueKindTitle returns the embed title for a given webhook kind.
+func queueKindTitle(kind string) string {
+	switch kind {
+	case "daily_motivation":
+		return "☀️ Bonjour"
+	case "daily_recap":
+		return "🌙 Ce soir"
+	case "reactivation":
+		return "👋 Reprends quand tu veux"
+	case "reminder":
+		return "📚 Note"
 	}
+	return "✉️ Message"
+}
 
-	for _, learner := range learners {
-		if learner.WebhookURL == "" {
-			continue
-		}
-
-		todayCount, _ := s.store.GetTodayInteractionCount(learner.ID)
-		if todayCount == 0 {
-			// No activity today — send a gentle nudge instead of recap
-			hoursSinceActive := time.Since(learner.LastActive).Hours()
-			if hoursSinceActive > 24 {
-				msg := formatInactivityNudge(hoursSinceActive)
-				s.sendDiscordEmbed(learner.WebhookURL, msg)
-				s.store.CreateScheduledAlert(learner.ID, "INACTIVITY_NUDGE", "", time.Now())
-			}
-			continue
-		}
-
-		successRate, total, _ := s.store.GetTodaySuccessRate(learner.ID)
-		streak, _ := s.store.GetDailyStreak(learner.ID)
-
-		// Find concepts worked on today
-		states, _ := s.store.GetConceptStatesByLearner(learner.ID)
-		mastered := 0
-		for _, cs := range states {
-			if cs.PMastery >= algorithms.BKTMasteryThreshold {
-				mastered++
-			}
-		}
-
-		msg := formatDailyRecap(total, successRate, streak, mastered, len(states))
-		if err := s.sendDiscordEmbed(learner.WebhookURL, msg); err != nil {
-			s.logger.Error("scheduler: recap webhook", "err", err)
-			continue
-		}
-		s.store.CreateScheduledAlert(learner.ID, "DAILY_RECAP", "", time.Now())
-		s.logger.Info("scheduler: recap sent", "learner", learner.ID, "exercises", total)
+func queueKindColor(kind string) int {
+	switch kind {
+	case "daily_motivation":
+		return 0x5865F2
+	case "daily_recap":
+		return 0x57F287
+	case "reactivation":
+		return 0xFEE75C
 	}
+	return 0x99AAB5
+}
+
+// ─── Sober fallback templates (no KPI, no analytics) ─────────────────────────
+
+func fallbackDailyMotivation(_ *models.Learner) discordPayload {
+	return discordPayload{Embeds: []discordEmbed{{
+		Title:       "☀️ Bonjour",
+		Description: "Meme 5 minutes aujourd'hui, ca tient la trajectoire. Reviens quand tu veux.",
+		Color:       0x5865F2,
+	}}}
+}
+
+func fallbackDailyRecap(_ *models.Learner) discordPayload {
+	return discordPayload{Embeds: []discordEmbed{{
+		Title:       "🌙 Ce soir",
+		Description: "Si tu passes, on continue. Sinon, a demain.",
+		Color:       0x57F287,
+	}}}
 }
 
 // ─── Cleanup (hourly) ─────────────────────────────────────────────────────
@@ -287,6 +320,13 @@ func (s *Scheduler) cleanupExpiredData() {
 		s.logger.Error("scheduler: cleanup tokens", "err", err)
 	} else if tokens > 0 {
 		s.logger.Info("scheduler: cleaned expired refresh tokens", "count", tokens)
+	}
+
+	expired, err := s.store.ExpirePastWebhookMessages(time.Now().UTC())
+	if err != nil {
+		s.logger.Error("scheduler: expire webhook queue", "err", err)
+	} else if expired > 0 {
+		s.logger.Info("scheduler: expired webhook messages", "count", expired)
 	}
 }
 
@@ -361,104 +401,9 @@ func formatReviewReminder(due []string, hoursSinceActive float64) discordPayload
 	}
 }
 
-func formatDailyMotivation(dayNumber, streak, mastered, total, dueCount int, objective string) discordPayload {
-	var lines []string
-
-	lines = append(lines, fmt.Sprintf("**Jour %d** de ton apprentissage", dayNumber))
-
-	if streak > 1 {
-		lines = append(lines, fmt.Sprintf("🔥 **%d jours consecutifs** — continue !", streak))
-	} else if streak == 1 {
-		lines = append(lines, "Hier c'etait bien. Enchaine aujourd'hui.")
-	} else {
-		lines = append(lines, "Nouvelle journee, nouveau depart. Une seule session suffit.")
-	}
-
-	if total > 0 {
-		pct := float64(mastered) / float64(total) * 100
-		lines = append(lines, fmt.Sprintf("📊 Progression : **%d/%d** concepts maitrises (%.0f%%)", mastered, total, pct))
-	}
-
-	if dueCount > 0 {
-		lines = append(lines, fmt.Sprintf("📋 %d concept(s) a reviser aujourd'hui", dueCount))
-	} else {
-		lines = append(lines, "✅ Rien a reviser — explore un nouveau concept")
-	}
-
-	if objective != "" {
-		lines = append(lines, fmt.Sprintf("\n🎯 *%s*", objective))
-	}
-
-	return discordPayload{
-		Embeds: []discordEmbed{{
-			Title:       "☀️ Bonne session",
-			Description: strings.Join(lines, "\n"),
-			Color:       0x5865F2, // discord blurple
-		}},
-	}
-}
-
-func formatDailyRecap(exerciseCount int, successRate float64, streak, mastered, total int) discordPayload {
-	var lines []string
-
-	lines = append(lines, fmt.Sprintf("**%d exercices** aujourd'hui", exerciseCount))
-
-	// Success rate with emoji
-	rateEmoji := "🟡"
-	if successRate >= 0.8 {
-		rateEmoji = "🟢"
-	} else if successRate < 0.5 {
-		rateEmoji = "🔴"
-	}
-	lines = append(lines, fmt.Sprintf("%s Taux de reussite : **%.0f%%**", rateEmoji, successRate*100))
-
-	if streak > 1 {
-		lines = append(lines, fmt.Sprintf("🔥 Streak : **%d jours**", streak))
-	}
-
-	if total > 0 {
-		pct := float64(mastered) / float64(total) * 100
-		lines = append(lines, fmt.Sprintf("📊 **%d/%d** concepts maitrises (%.0f%%)", mastered, total, pct))
-	}
-
-	// Encouragement based on performance
-	if successRate >= 0.8 && exerciseCount >= 5 {
-		lines = append(lines, "\n💪 Excellente session. Demain on pousse plus loin.")
-	} else if successRate >= 0.6 {
-		lines = append(lines, "\n👍 Bonne session. La regularite fait la difference.")
-	} else {
-		lines = append(lines, "\n🧠 Session difficile — c'est normal. Reviens demain, le cerveau consolide pendant la nuit.")
-	}
-
-	return discordPayload{
-		Embeds: []discordEmbed{{
-			Title:       "📊 Recap du jour",
-			Description: strings.Join(lines, "\n"),
-			Color:       0x57F287, // green
-		}},
-	}
-}
-
-func formatInactivityNudge(hoursSinceActive float64) discordPayload {
-	days := int(hoursSinceActive / 24)
-	var desc string
-	switch {
-	case days <= 1:
-		desc = "Tu n'as pas pratique aujourd'hui. Meme 5 minutes comptent."
-	case days <= 3:
-		desc = fmt.Sprintf("Ca fait **%d jours** sans session. Ta retention baisse — une revision rapide suffit pour inverser la courbe.", days)
-	default:
-		desc = fmt.Sprintf("**%d jours** d'absence. Pas de jugement — reviens quand tu veux. Une seule session relance tout.", days)
-	}
-
-	return discordPayload{
-		Embeds: []discordEmbed{{
-			Title:       "👋 On ne t'oublie pas",
-			Description: desc,
-			Color:       0xFEE75C, // yellow
-		}},
-	}
-}
+// Note: formatDailyMotivation / formatDailyRecap / formatInactivityNudge have been
+// removed. Daily motivation and recap are now authored by Claude via queue_webhook_message
+// and dispatched by dispatchQueued (with sober Go fallbacks when the queue is empty).
 
 // ─── Discord Webhook ─────────────────────────────────────────────────────────
 

--- a/models/domain.go
+++ b/models/domain.go
@@ -63,13 +63,15 @@ type KnowledgeSpace struct {
 }
 
 type Domain struct {
-	ID           string
-	LearnerID    string
-	Name         string
-	PersonalGoal string
-	Graph        KnowledgeSpace
-	Archived     bool
-	CreatedAt    time.Time
+	ID                 string
+	LearnerID          string
+	Name               string
+	PersonalGoal       string
+	Graph              KnowledgeSpace
+	ValueFramingsJSON  string
+	LastValueAxis      string
+	Archived           bool
+	CreatedAt          time.Time
 }
 
 type TimeWindow struct {

--- a/models/motivation.go
+++ b/models/motivation.go
@@ -1,0 +1,171 @@
+package models
+
+import "time"
+
+// MotivationBrief is attached to get_next_activity responses. When Kind == ""
+// no trigger fired — Claude should compose the exercise without motivational
+// preamble. When populated, Claude weaves the signals into its message per
+// the Motivation doctrine in the system prompt.
+type MotivationBrief struct {
+	Kind           string         `json:"kind"`
+	GoalLink       string         `json:"goal_link,omitempty"`
+	ValueFraming   *ValueFraming  `json:"value_framing,omitempty"`
+	ProgressDelta  *ProgressDelta `json:"progress_delta,omitempty"`
+	FailureContext *FailureMeta   `json:"failure_context,omitempty"`
+	AffectContext  *AffectMeta    `json:"affect_context,omitempty"`
+	InterestPhase  string         `json:"interest_phase,omitempty"`
+	Instruction    string         `json:"instruction"`
+}
+
+// Motivation brief kinds, in priority order (earlier kinds win when multiple triggers fire).
+const (
+	MotivationKindMilestone        = "milestone"
+	MotivationKindPhaseTransition  = "phase_transition"
+	MotivationKindCompetenceValue  = "competence_value"
+	MotivationKindGrowthMindset    = "growth_mindset"
+	MotivationKindAffectReframe    = "affect_reframe"
+	MotivationKindPlateauRecontext = "plateau_recontext"
+	MotivationKindWhyThisExercise  = "why_this_exercise"
+)
+
+// Hidi-Renninger 4-phase interest development.
+const (
+	InterestPhaseTriggered  = "triggered"
+	InterestPhaseSustained  = "sustained"
+	InterestPhaseEmerging   = "emerging"
+	InterestPhaseIndividual = "individual"
+)
+
+// ValueFraming — Eccles-Wigfield utility/attainment value axes.
+// One axis is surfaced per brief (round-robin rotation via Domain.LastValueAxis).
+type ValueFraming struct {
+	Axis             string `json:"axis"` // financial | employment | intellectual | innovation
+	Statement        string `json:"statement,omitempty"`
+	ConceptRelevance string `json:"concept_relevance,omitempty"`
+}
+
+// Canonical value axes (and their rotation order).
+var ValueAxes = []string{"financial", "employment", "intellectual", "innovation"}
+
+// DomainValueFramings is the JSON shape persisted in domains.value_framings_json.
+// Each axis maps to a short (1-2 sentence) authored statement.
+type DomainValueFramings struct {
+	Financial    string `json:"financial,omitempty"`
+	Employment   string `json:"employment,omitempty"`
+	Intellectual string `json:"intellectual,omitempty"`
+	Innovation   string `json:"innovation,omitempty"`
+}
+
+// StatementFor returns the authored statement for a given axis, or "" if none.
+func (v *DomainValueFramings) StatementFor(axis string) string {
+	switch axis {
+	case "financial":
+		return v.Financial
+	case "employment":
+		return v.Employment
+	case "intellectual":
+		return v.Intellectual
+	case "innovation":
+		return v.Innovation
+	}
+	return ""
+}
+
+// ConceptDelta captures the change in mastery on a concept over a window.
+type ConceptDelta struct {
+	Concept    string  `json:"concept"`
+	MasteryNow float64 `json:"mastery_now"`
+	MasteryWas float64 `json:"mastery_was"`
+	Delta      float64 `json:"delta"`
+}
+
+// ProgressDelta shows forward motion on the current concept (used for milestone / narrative).
+type ProgressDelta struct {
+	Concept    string  `json:"concept"`
+	MasteryNow float64 `json:"mastery_now"`
+	MasteryWas float64 `json:"mastery_was"`
+	Threshold  float64 `json:"threshold,omitempty"` // the milestone just crossed, if any
+}
+
+// FailureMeta summarises the most recent failure on a concept (for growth_mindset reframing).
+type FailureMeta struct {
+	Concept           string `json:"concept"`
+	HintsRequested    int    `json:"hints_requested"`
+	ErrorType         string `json:"error_type,omitempty"`
+	MisconceptionType string `json:"misconception_type,omitempty"`
+	HoursAgo          int    `json:"hours_ago"`
+}
+
+// AffectMeta surfaces the dominant negative signal from the most recent record_affect
+// call (for affect_reframe).
+type AffectMeta struct {
+	SessionID           string `json:"session_id"`
+	Dimension           string `json:"dimension"` // satisfaction | difficulty | energy
+	Value               int    `json:"value"`
+	HoursAgo            int    `json:"hours_ago"`
+}
+
+// ProgressNarrative is attached to get_learner_context responses. Claude uses it
+// to open the session with a short (1-2 sentence) trajectory story.
+type ProgressNarrative struct {
+	MasteryTrajectory  []ConceptDelta `json:"mastery_trajectory"`
+	SessionStreak      int            `json:"session_streak"`
+	AutonomyTrend      string         `json:"autonomy_trend"` // rising | stable | declining
+	MilestonesThisWeek []string       `json:"milestones_this_week"`
+	DormancyImminent   bool           `json:"dormancy_imminent"` // true if last_session > 24h ago
+	Instruction        string         `json:"instruction"`
+}
+
+// ImplementationIntention is a Gollwitzer-style if-then commitment captured at
+// session close ("when X happens, I will Y").
+type ImplementationIntention struct {
+	ID           int64      `json:"id"`
+	LearnerID    string     `json:"learner_id"`
+	DomainID     string     `json:"domain_id"`
+	Trigger      string     `json:"trigger"`
+	Action       string     `json:"action"`
+	Honored      *bool      `json:"honored,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ScheduledFor *time.Time `json:"scheduled_for,omitempty"`
+}
+
+// RecapBrief is returned by record_session_close — signals for Claude to compose
+// the closing message.
+type RecapBrief struct {
+	ConceptsPracticed             []string `json:"concepts_practiced"`
+	Wins                          []string `json:"wins"`
+	InterestingStruggles          []string `json:"interesting_struggles"`
+	NextScheduledReview           string   `json:"next_scheduled_review,omitempty"`
+	PromptForImplementationIntent bool     `json:"prompt_for_implementation_intent"`
+	Instruction                   string   `json:"instruction"`
+}
+
+// Webhook queue kinds.
+const (
+	WebhookKindDailyMotivation = "daily_motivation"
+	WebhookKindDailyRecap      = "daily_recap"
+	WebhookKindReactivation    = "reactivation"
+	WebhookKindReminder        = "reminder"
+)
+
+// Webhook queue statuses.
+const (
+	WebhookStatusPending = "pending"
+	WebhookStatusSent    = "sent"
+	WebhookStatusExpired = "expired"
+	WebhookStatusFailed  = "failed"
+)
+
+// WebhookQueueItem represents a scheduled, LLM-authored webhook nudge.
+type WebhookQueueItem struct {
+	ID           int64      `json:"id"`
+	LearnerID    string     `json:"learner_id"`
+	Kind         string     `json:"kind"`
+	ScheduledFor time.Time  `json:"scheduled_for"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	Content      string     `json:"content"`
+	Priority     int        `json:"priority"`
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	SentAt       *time.Time `json:"sent_at,omitempty"`
+}

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -178,6 +178,21 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			}
 		}
 
+		// Motivation layer — compose a context-adaptive brief for this activity.
+		// Detect plateau active on the chosen concept from the alerts list.
+		plateauActive := false
+		for _, a := range alerts {
+			if a.Type == models.AlertPlateau && a.Concept == activity.Concept {
+				plateauActive = true
+				break
+			}
+		}
+		motivationEngine := engine.NewMotivationEngine(deps.Store)
+		motivationBrief, _ := motivationEngine.Build(
+			learnerID, domain, activity.Concept, activity.Type,
+			plateauActive, len(sessionConcepts),
+		)
+
 		r, _ := jsonResult(map[string]any{
 			"needs_domain_setup":        false,
 			"domain_id":                 domain.ID,
@@ -187,6 +202,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			"tutor_mode":               tutorMode,
 			"active_misconceptions":     activeMisconceptions,
 			"known_misconception_types": knownMisconceptionTypes,
+			"motivation_brief":          motivationBrief,
 		})
 		return r, nil, nil
 	})

--- a/tools/context.go
+++ b/tools/context.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"learning-runtime/algorithms"
+	"learning-runtime/engine"
+	"learning-runtime/models"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -112,6 +114,12 @@ func registerGetLearnerContext(server *mcp.Server, deps *Deps) {
 			archivedList = []map[string]interface{}{}
 		}
 
+		// Progress narrative — open learner model surfaced at session start.
+		var narrative *models.ProgressNarrative
+		if !needsDomainSetup && domain != nil {
+			narrative = buildProgressNarrative(deps, learnerID, learner, domain)
+		}
+
 		r, _ := jsonResult(map[string]interface{}{
 			"learner_id":         learnerID,
 			"objective":          learner.Objective,
@@ -125,7 +133,48 @@ func registerGetLearnerContext(server *mcp.Server, deps *Deps) {
 			"priority_retention": priorityRetention,
 			"domains":            domainList,
 			"archived_domains":   archivedList,
+			"progress_narrative": narrative,
 		})
 		return r, nil, nil
 	})
+}
+
+// buildProgressNarrative composes the session-opening OLM narrative signals. Returns
+// nil if there's nothing meaningful to narrate (e.g., zero interactions so far).
+func buildProgressNarrative(deps *Deps, learnerID string, learner *models.Learner, domain *models.Domain) *models.ProgressNarrative {
+	window := 30 * 24 * time.Hour
+	since := time.Now().UTC().Add(-window)
+
+	deltas, _ := deps.Store.ConceptMasteryDelta(learnerID, domain.Graph.Concepts, since, 3)
+	streak, _ := deps.Store.CountLearnerSessionStreak(learnerID)
+	milestones, _ := deps.Store.MilestonesInWindow(learnerID, domain.Graph.Concepts, time.Now().UTC().Add(-7*24*time.Hour))
+
+	trend := "stable"
+	affects, _ := deps.Store.GetRecentAffectStates(learnerID, 5)
+	if len(affects) >= 3 {
+		var scores []float64
+		for _, a := range affects {
+			scores = append(scores, a.AutonomyScore)
+		}
+		trend = engine.ComputeAutonomyTrendExported(scores)
+	}
+
+	dormancy := false
+	if !learner.LastActive.IsZero() && time.Since(learner.LastActive) > 24*time.Hour {
+		dormancy = true
+	}
+
+	// Only return a narrative if there's something to say.
+	if len(deltas) == 0 && streak == 0 && len(milestones) == 0 && !dormancy {
+		return nil
+	}
+
+	return &models.ProgressNarrative{
+		MasteryTrajectory:  deltas,
+		SessionStreak:      streak,
+		AutonomyTrend:      trend,
+		MilestonesThisWeek: milestones,
+		DormancyImminent:   dormancy,
+		Instruction:        "Raconte la trajectoire en 1-2 phrases, pas une liste. Si dormancy_imminent est vrai, formule une reprise accueillante sans reproche.",
+	}
 }

--- a/tools/domain.go
+++ b/tools/domain.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"learning-runtime/models"
@@ -9,11 +10,19 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+type ValueFramingsInput struct {
+	Financial    string `json:"financial,omitempty" jsonschema:"Gain financier (1-2 phrases)"`
+	Employment   string `json:"employment,omitempty" jsonschema:"Gain employabilite / carriere (1-2 phrases)"`
+	Intellectual string `json:"intellectual,omitempty" jsonschema:"Gain intellectuel / beau raisonnement (1-2 phrases)"`
+	Innovation   string `json:"innovation,omitempty" jsonschema:"Gain creation / innovation (1-2 phrases)"`
+}
+
 type InitDomainParams struct {
 	Name          string              `json:"name" jsonschema:"Nom du domaine d'apprentissage"`
 	Concepts      []string            `json:"concepts" jsonschema:"Liste des concepts du domaine"`
 	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Graphe de prerequis (concept -> liste de prerequis)"`
 	PersonalGoal  string              `json:"personal_goal,omitempty" jsonschema:"Objectif personnel de l'apprenant dans ce domaine (optionnel)"`
+	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 axes de valeur (financier/emploi/intellectuel/innovation). 1-2 phrases authored par axe. Optionnel — peut etre rempli a la volee par la suite."`
 }
 
 func registerInitDomain(server *mcp.Server, deps *Deps) {
@@ -45,7 +54,20 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 			graph.Prerequisites = make(map[string][]string)
 		}
 
-		domain, err := deps.Store.CreateDomain(learnerID, params.Name, params.PersonalGoal, graph)
+		valueFramingsJSON := ""
+		if params.ValueFramings != nil {
+			vf := models.DomainValueFramings{
+				Financial:    params.ValueFramings.Financial,
+				Employment:   params.ValueFramings.Employment,
+				Intellectual: params.ValueFramings.Intellectual,
+				Innovation:   params.ValueFramings.Innovation,
+			}
+			if buf, merr := json.Marshal(vf); merr == nil {
+				valueFramingsJSON = string(buf)
+			}
+		}
+
+		domain, err := deps.Store.CreateDomainWithValueFramings(learnerID, params.Name, params.PersonalGoal, graph, valueFramingsJSON)
 		if err != nil {
 			deps.Logger.Error("init_domain: failed to create domain", "err", err, "learner", learnerID)
 			r, _ := errorResult(fmt.Sprintf("failed to create domain: %v", err))

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -9,11 +9,13 @@ import (
 const systemPrompt = `Tu es un learning runtime — pas un assistant. Tu as un role precis.
 
 OUTILS DISPONIBLES :
-- get_learner_context(domain_id?) : contexte de session, liste des domaines
+- get_learner_context(domain_id?) : contexte de session, liste des domaines, progress_narrative
 - get_pending_alerts(domain_id?) : alertes critiques
-- get_next_activity(domain_id?) : prochaine activite optimale + miroir metacognitif + tutor_mode
+- get_next_activity(domain_id?) : prochaine activite optimale + miroir metacognitif + tutor_mode + motivation_brief
 - record_interaction(concept, success, confidence, error_type?, hints_requested?, self_initiated?, calibration_id?, domain_id?) : enregistre + met a jour BKT/FSRS/IRT/PFA
 - record_affect(session_id, energy?, confidence?, satisfaction?, perceived_difficulty?, next_session_intent?) : check-in emotionnel debut/fin de session
+- record_session_close(domain_id?, implementation_intention?) : cloture la session, retourne recap_brief (wins, struggles, prompt_for_implementation_intent)
+- queue_webhook_message(kind, scheduled_for, content, expires_at?, priority?) : mettre en queue un nudge que le scheduler postera sur le webhook Discord (daily_motivation | daily_recap | reactivation | reminder)
 - calibration_check(concept_id, predicted_mastery, domain_id?) : auto-evaluation avant exercice
 - record_calibration_result(prediction_id, actual_score) : compare prediction vs resultat
 - get_autonomy_metrics(domain_id?) : score d'autonomie et ses 4 composantes
@@ -25,9 +27,10 @@ OUTILS DISPONIBLES :
 - learning_negotiation(session_id, learner_concept?, learner_rationale?, domain_id?) : negocier le plan de session
 - get_cockpit_state(domain_id?) : dashboard complet + autonomie + calibration + affect
 - get_availability_model() : creneaux et frequence
-- init_domain(name, concepts, prerequisites, personal_goal?) : cree un domaine
+- init_domain(name, concepts, prerequisites, personal_goal?, value_framings?) : cree un domaine (value_framings = 4 axes de gain: financial/employment/intellectual/innovation)
 - add_concepts(domain_id?, concepts, prerequisites) : ajoute des concepts
 - update_learner_profile(device?, background?, learning_style?, objective?, language?, level?, calibration_bias?, affect_baseline?, autonomy_score?) : metadonnees persistantes
+- get_misconceptions(domain_id?, concept?) : liste les misconceptions detectees par concept
 
 REGLES ABSOLUES — a chaque reponse, dans cet ordre :
 
@@ -56,6 +59,12 @@ REGLES ABSOLUES — a chaque reponse, dans cet ordre :
 4. FIN DE SESSION
    → Appelle record_affect(session_id, satisfaction, perceived_difficulty, next_session_intent)
    → Reagis au calibration_bias_delta retourne
+   → Appelle record_session_close(domain_id) — lit les signaux pour le mot de fin
+   → Si recap_brief.prompt_for_implementation_intent : pose UNE question concrete
+     ("Quand et ou tu pratiques ensuite ?") et rappelle record_session_close avec implementation_intention
+   → Puis appelle queue_webhook_message 2x : (a) daily_motivation pour demain 8h UTC,
+     (b) daily_recap pour demain 21h UTC. Textes chaleureux, relies au personal_goal,
+     max ~300 caracteres chacun. JAMAIS de %reussite brut ni de KPI sec — ton de mentor, pas d'analytics.
 
 5. ENRICHISSEMENT DU DOMAINE
    → Si l'apprenant decouvre un concept non prevu, utilise add_concepts()
@@ -81,7 +90,22 @@ REGLES ABSOLUES — a chaque reponse, dans cet ordre :
    → Toujours termine par la question ouverte — ne la remplace pas
    → Ne s'active que sur patterns consolides (3+ sessions)
 
-10. COMPORTEMENT
+10. COUCHE MOTIVATION (motivation_brief + progress_narrative)
+    → Si motivation_brief.kind != "" : integre le signal dans ton message, jamais en paragraphe separe.
+      Ne recite jamais les champs verbatim, traduis en langage naturel.
+      - why_this_exercise : relie exercice → concept → goal_link en UNE phrase
+      - competence_value : rappelle le gain sur value_framing.axis (financial/employment/intellectual/innovation)
+        en UNE phrase reliee au concept. Pas de chiffres invente. Si statement est fourni, inspire-t'en sans copier
+      - growth_mindset : reframe l'echec en effort/strategie (hints utilises, auto-correction), jamais en aptitude
+      - affect_reframe : valide l'emotion (frustration/fatigue) PUIS reframe court
+      - milestone : celebre brievement, sans emphase
+      - plateau_recontext : propose un angle d'attaque different
+    → Si motivation_brief.kind == "" : fais l'exercice sans preambule motivationnel — le silence est un choix
+    → Si progress_narrative present : ouvre la session par 1-2 phrases racontant la trajectoire.
+      Si dormancy_imminent : ton accueillant, aucun reproche
+    → Ne surcharge pas : un seul angle motivationnel par message
+
+11. COMPORTEMENT
     → Tu ne laisses pas l'apprenant deriver de sa trajectoire
     → Tu confirmes explicitement quand la trajectoire est bonne
     → Tu n'expliques jamais tes raisonnements algorithmiques

--- a/tools/queue_webhook.go
+++ b/tools/queue_webhook.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"learning-runtime/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type QueueWebhookMessageParams struct {
+	Kind         string `json:"kind" jsonschema:"Type de nudge : daily_motivation | daily_recap | reactivation | reminder"`
+	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 timestamp UTC de la fenetre de tir (ex: 2026-04-13T08:00:00Z)"`
+	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 timestamp UTC apres lequel le message ne doit plus etre envoye"`
+	Content      string `json:"content" jsonschema:"Contenu Markdown pret a poster sur le webhook Discord (max ~300 caracteres recommande)"`
+	Priority     int    `json:"priority,omitempty" jsonschema:"Priorite (plus grand = plus prioritaire, defaut 0)"`
+}
+
+const maxWebhookContentLen = 1500
+
+func registerQueueWebhookMessage(server *mcp.Server, deps *Deps) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "queue_webhook_message",
+		Description: "Met en queue un message de nudge que le scheduler postera sur le webhook Discord de l'apprenant a la fenetre voulue. Le LLM compose le texte (chaleureux, sans KPI brut) ; le scheduler dispatche.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params QueueWebhookMessageParams) (*mcp.CallToolResult, any, error) {
+		learnerID, err := getLearnerID(ctx)
+		if err != nil {
+			deps.Logger.Error("queue_webhook_message: auth failed", "err", err)
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
+		if !validWebhookKind(params.Kind) {
+			r, _ := errorResult(fmt.Sprintf("invalid kind %q (expected daily_motivation | daily_recap | reactivation | reminder)", params.Kind))
+			return r, nil, nil
+		}
+		if params.ScheduledFor == "" {
+			r, _ := errorResult("scheduled_for is required")
+			return r, nil, nil
+		}
+		if params.Content == "" {
+			r, _ := errorResult("content is required")
+			return r, nil, nil
+		}
+		if len(params.Content) > maxWebhookContentLen {
+			r, _ := errorResult(fmt.Sprintf("content too long (%d chars, max %d)", len(params.Content), maxWebhookContentLen))
+			return r, nil, nil
+		}
+
+		scheduledFor, err := time.Parse(time.RFC3339, params.ScheduledFor)
+		if err != nil {
+			r, _ := errorResult(fmt.Sprintf("scheduled_for must be RFC3339 (got %q)", params.ScheduledFor))
+			return r, nil, nil
+		}
+
+		var expiresAt time.Time
+		if params.ExpiresAt != "" {
+			parsed, perr := time.Parse(time.RFC3339, params.ExpiresAt)
+			if perr != nil {
+				r, _ := errorResult(fmt.Sprintf("expires_at must be RFC3339 (got %q)", params.ExpiresAt))
+				return r, nil, nil
+			}
+			expiresAt = parsed
+		}
+
+		id, err := deps.Store.EnqueueWebhookMessage(learnerID, params.Kind, params.Content, scheduledFor, expiresAt, params.Priority)
+		if err != nil {
+			deps.Logger.Error("queue_webhook_message: enqueue failed", "err", err, "learner", learnerID)
+			r, _ := errorResult(fmt.Sprintf("failed to enqueue: %v", err))
+			return r, nil, nil
+		}
+
+		r, _ := jsonResult(map[string]any{
+			"queue_id":      id,
+			"kind":          params.Kind,
+			"scheduled_for": scheduledFor.UTC().Format(time.RFC3339),
+		})
+		return r, nil, nil
+	})
+}
+
+func validWebhookKind(k string) bool {
+	switch k {
+	case models.WebhookKindDailyMotivation,
+		models.WebhookKindDailyRecap,
+		models.WebhookKindReactivation,
+		models.WebhookKindReminder:
+		return true
+	}
+	return false
+}

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -1,0 +1,147 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"learning-runtime/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ImplementationIntentionInput struct {
+	Trigger      string `json:"trigger" jsonschema:"Clause 'quand' (ex: 'demain matin au cafe')"`
+	Action       string `json:"action" jsonschema:"Clause 'alors je' (ex: 'ferai 1 exercice de derivees')"`
+	ScheduledFor string `json:"scheduled_for,omitempty" jsonschema:"ISO 8601 timestamp optionnel (UTC)"`
+}
+
+type RecordSessionCloseParams struct {
+	DomainID                 string                        `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	ImplementationIntention  *ImplementationIntentionInput `json:"implementation_intention,omitempty" jsonschema:"Engagement if-then optionnel (Gollwitzer)"`
+}
+
+func registerRecordSessionClose(server *mcp.Server, deps *Deps) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "record_session_close",
+		Description: "Cloture la session : enregistre optionnellement une implementation intention (if-then) et retourne des signaux structures pour composer le message de fin (concepts pratiques, wins, intent prompt, message queue filler).",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordSessionCloseParams) (*mcp.CallToolResult, any, error) {
+		learnerID, err := getLearnerID(ctx)
+		if err != nil {
+			deps.Logger.Error("record_session_close: auth failed", "err", err)
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
+		domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
+		if err != nil || domain == nil {
+			deps.Logger.Error("record_session_close: domain resolution failed", "err", err, "learner", learnerID)
+			r, _ := errorResult("domain not found")
+			return r, nil, nil
+		}
+
+		// Persist the implementation intention if provided.
+		if params.ImplementationIntention != nil &&
+			params.ImplementationIntention.Trigger != "" &&
+			params.ImplementationIntention.Action != "" {
+			var scheduled time.Time
+			if params.ImplementationIntention.ScheduledFor != "" {
+				if parsed, perr := time.Parse(time.RFC3339, params.ImplementationIntention.ScheduledFor); perr == nil {
+					scheduled = parsed
+				}
+			}
+			if _, err := deps.Store.InsertImplementationIntention(
+				learnerID, domain.ID,
+				params.ImplementationIntention.Trigger,
+				params.ImplementationIntention.Action,
+				scheduled,
+			); err != nil {
+				deps.Logger.Error("record_session_close: insert intention failed", "err", err, "learner", learnerID)
+			}
+		}
+
+		recap := buildRecapBrief(deps, learnerID, domain)
+		r, _ := jsonResult(map[string]any{"recap_brief": recap})
+		return r, nil, nil
+	})
+}
+
+// buildRecapBrief produces session-close signals for Claude.
+func buildRecapBrief(deps *Deps, learnerID string, domain *models.Domain) *models.RecapBrief {
+	domainSet := make(map[string]bool, len(domain.Graph.Concepts))
+	for _, c := range domain.Graph.Concepts {
+		domainSet[c] = true
+	}
+
+	sessionInteractions, _ := deps.Store.GetSessionInteractions(learnerID)
+
+	practicedSet := map[string]bool{}
+	winsSet := map[string]bool{}
+	strugglesSet := map[string]bool{}
+	for _, i := range sessionInteractions {
+		if !domainSet[i.Concept] {
+			continue
+		}
+		practicedSet[i.Concept] = true
+		if i.Success {
+			winsSet[i.Concept] = true
+		} else {
+			strugglesSet[i.Concept] = true
+		}
+	}
+
+	practiced := mapKeys(practicedSet)
+	wins := mapKeys(winsSet)
+	// "Interesting" struggles = failed but not completely blocked (partial progress signal heuristic:
+	// the learner also had a success on the same concept during the session).
+	var interesting []string
+	for c := range strugglesSet {
+		if winsSet[c] {
+			interesting = append(interesting, c)
+		}
+	}
+
+	// Next scheduled review — earliest next_review across domain states.
+	states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
+	var next string
+	var earliest time.Time
+	for _, cs := range states {
+		if !domainSet[cs.Concept] || cs.NextReview == nil {
+			continue
+		}
+		if earliest.IsZero() || cs.NextReview.Before(earliest) {
+			earliest = *cs.NextReview
+			next = fmt.Sprintf("%s (%s)", cs.Concept, cs.NextReview.Format("02/01 15:04 UTC"))
+		}
+	}
+
+	// Prompt for implementation intention if none recorded in last 7 days for any domain.
+	has, _ := deps.Store.HasRecentImplementationIntention(learnerID, "", time.Now().UTC().Add(-7*24*time.Hour))
+	promptIntent := !has
+
+	instruction := "Clos la session en 2-3 phrases. Mentionne un win tangible ou une belle tentative. " +
+		"Si prompt_for_implementation_intention est vrai, pose une question concrete du type 'Quand et ou tu pratiques ensuite ?' " +
+		"et attends la reponse pour rappeler record_session_close avec implementation_intention. " +
+		"Puis appelle queue_webhook_message 2 fois (daily_motivation pour demain 8h UTC, daily_recap pour demain 21h UTC) " +
+		"avec un contenu chaleureux lie au personal_goal - sans KPI brut."
+
+	return &models.RecapBrief{
+		ConceptsPracticed:             practiced,
+		Wins:                          wins,
+		InterestingStruggles:          interesting,
+		NextScheduledReview:           next,
+		PromptForImplementationIntent: promptIntent,
+		Instruction:                   instruction,
+	}
+}
+
+func mapKeys(m map[string]bool) []string {
+	if len(m) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -81,5 +81,7 @@ func RegisterTools(server *mcp.Server, deps *Deps) {
 	registerUnarchiveDomain(server, deps)
 	registerDeleteDomain(server, deps)
 	registerGetMisconceptions(server, deps)
+	registerRecordSessionClose(server, deps)
+	registerQueueWebhookMessage(server, deps)
 	RegisterPrompt(server)
 }


### PR DESCRIPTION
## Context
The learning runtime had solid motivational *detection* (affect, autonomy, metacognitive mirror, Discord scheduler) but **no narrative layer at the exercise level**: `Activity.PromptForLLM` was purely pedagogical, `domains.personal_goal` was stored but never surfaced, failures were never reframed, and the Discord webhooks pushed cold KPIs (% success, streak, mastery count).

This PR adds a full-stack motivation layer grounded in empirically-supported frameworks:

| Framework | Feature |
|---|---|
| Hulleman & Harackiewicz — Utility-Value Intervention | `why_this_exercise` kind |
| Eccles-Wigfield — Expectancy-Value typology | `competence_value` kind (4 axes: financial / employment / intellectual / innovation) |
| Dweck — Growth Mindset / process praise | `growth_mindset` kind (reframes failures) |
| Pekrun — Control-Value Theory | `affect_reframe` kind |
| Bull & Kay — Open Learner Model narratives | `progress_narrative` on `get_learner_context` |
| Gollwitzer — Implementation Intentions | `record_session_close` captures if-then commitments |
| N/A — product decision | `queue_webhook_message` — Claude now authors Discord nudges, scheduler dispatches |

**Design principle preserved:** Go provides structured signals; Claude composes the text. No static text bank.

## Scope
- **New tables**: `implementation_intentions`, `webhook_message_queue` (idempotent migrations).
- **New columns**: `domains.value_framings_json`, `domains.last_value_axis` (round-robin axis rotation).
- **New MCP tools**: `record_session_close`, `queue_webhook_message`.
- **Extended tools**: `get_next_activity` emits `motivation_brief`; `get_learner_context` emits `progress_narrative`; `init_domain` accepts optional `value_framings`.
- **Scheduler refactor**: `sendDailyMotivation` / `sendDailyRecap` become `dispatchQueued(kind)`, pulling from the queue with a sober Go fallback when empty. Dead KPI-heavy templates removed.
- **System prompt**: Motivation doctrine section (#10), updated tool list, end-of-session flow requires `record_session_close` + 2× `queue_webhook_message`.

## Notable design choices
- Briefs are **context-adaptive**: `motivation_brief.kind == \"\"` is a valid state — no trigger, no preamble. Avoids the robotic effect of always-on nudges.
- Priority order: milestone > competence_value > growth_mindset > affect_reframe > plateau_recontext > why_this_exercise. First match wins.
- Value axes rotate round-robin, preferring authored statements in `domains.value_framings_json`.
- Date queries use `substr(created_at, 1, 10)` — modernc-sqlite's ISO 8601 output breaks SQLite's built-in `DATE()`.
- **No gamification, no streak punishment** — CET predicts these undermine intrinsic motivation.
- **No server-side LLM API calls** — if a learner is dormant and the queue is empty, fallback is a one-line sober message, not a KPI dump.

## Tests
- `go test ./db/...` — new tests for implementation intentions (insert, scope, recency), webhook queue (enqueue/dequeue/priority/expiry), mastery delta, milestones, sessions count, last failure.
- `go test ./engine/...` — phase inference, each brief kind's trigger, priority ordering, silence fallback, axis rotation (incl. authored-preference).

## Deployment
Deployed to prod on the same host:
- `go build -o learning-runtime .`
- `systemctl --user restart learning-runtime`
- Health: HTTP 200 ✓
- Migrations applied (domains, implementation_intentions, webhook_message_queue verified) ✓
- No errors in logs ✓

## Test plan
- [x] `go test ./...` all pass
- [x] Fresh build deployed to prod, service active, /health 200
- [x] Prod DB migrations applied idempotently
- [ ] Live session end-to-end: a learner exercise flow should show `motivation_brief` varying (sometimes empty), progress narrative on open, webhook messages crafted by Claude for next day