### PR TITLE
test(regulation): cover phase persistence, goal-relevance helpers, orchestrator escape

### DIFF
--- a/db/phase_test.go
+++ b/db/phase_test.go
@@ -1,0 +1,427 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"tutor-mcp/models"
+)
+
+// ─── UpdateDomainPhase ─────────────────────────────────────────────────────
+
+func TestUpdateDomainPhase_DiagnosticPersistsEntropy(t *testing.T) {
+	store := setupTestDB(t)
+	d := mkDomain(t, store, []string{"A", "B"})
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseDiagnostic, 0.42, now); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, err := store.GetDomainByID(d.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Phase != models.PhaseDiagnostic {
+		t.Errorf("phase: want DIAGNOSTIC, got %q", got.Phase)
+	}
+	if got.PhaseEntryEntropy != 0.42 {
+		t.Errorf("entropy: want 0.42, got %v", got.PhaseEntryEntropy)
+	}
+	if !got.PhaseChangedAt.Equal(now) {
+		t.Errorf("phase_changed_at: want %v, got %v", now, got.PhaseChangedAt)
+	}
+}
+
+func TestUpdateDomainPhase_NonDiagnosticNullifiesEntropy(t *testing.T) {
+	store := setupTestDB(t)
+	d := mkDomain(t, store, []string{"A"})
+
+	// First write DIAGNOSTIC with entropy populated.
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseDiagnostic, 0.55, time.Now().UTC()); err != nil {
+		t.Fatalf("set diag: %v", err)
+	}
+	// Then transition to INSTRUCTION — entropy column must reset to NULL.
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseInstruction, 999, time.Now().UTC()); err != nil {
+		t.Fatalf("set instruction: %v", err)
+	}
+
+	got, err := store.GetDomainByID(d.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Phase != models.PhaseInstruction {
+		t.Errorf("phase: want INSTRUCTION, got %q", got.Phase)
+	}
+	// Defensive: PhaseEntryEntropy should be 0 (the sql.NullFloat64 default
+	// when the column is NULL — we ignore the entropyArg in that branch).
+	if got.PhaseEntryEntropy != 0 {
+		t.Errorf("entropy: want 0 (NULL), got %v", got.PhaseEntryEntropy)
+	}
+}
+
+func TestUpdateDomainPhase_MaintenanceAlsoNullifiesEntropy(t *testing.T) {
+	store := setupTestDB(t)
+	d := mkDomain(t, store, []string{"A"})
+
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseDiagnostic, 0.7, time.Now().UTC()); err != nil {
+		t.Fatalf("set diag: %v", err)
+	}
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseMaintenance, 999, time.Now().UTC()); err != nil {
+		t.Fatalf("set maint: %v", err)
+	}
+	got, _ := store.GetDomainByID(d.ID)
+	if got.Phase != models.PhaseMaintenance {
+		t.Errorf("phase: want MAINTENANCE, got %q", got.Phase)
+	}
+	if got.PhaseEntryEntropy != 0 {
+		t.Errorf("entropy on MAINTENANCE: want 0 (NULL), got %v", got.PhaseEntryEntropy)
+	}
+}
+
+func TestUpdateDomainPhase_NonexistentDomainNoError(t *testing.T) {
+	// SQL UPDATE on a missing PK is a no-op, not an error. Pin the
+	// behaviour: callers don't need to pre-check existence.
+	store := setupTestDB(t)
+	err := store.UpdateDomainPhase("nonexistent", models.PhaseInstruction, 0, time.Now().UTC())
+	if err != nil {
+		t.Errorf("nonexistent domain: want no error, got %v", err)
+	}
+}
+
+func TestUpdateDomainPhase_Idempotent(t *testing.T) {
+	store := setupTestDB(t)
+	d := mkDomain(t, store, []string{"A"})
+
+	t1 := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseInstruction, 0, t1); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	t2 := t1.Add(1 * time.Hour)
+	if err := store.UpdateDomainPhase(d.ID, models.PhaseInstruction, 0, t2); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	got, _ := store.GetDomainByID(d.ID)
+	if !got.PhaseChangedAt.Equal(t2) {
+		t.Errorf("phase_changed_at: want updated to %v, got %v", t2, got.PhaseChangedAt)
+	}
+}
+
+// ─── GetActiveMisconceptionsBatch ──────────────────────────────────────────
+
+func TestGetActiveMisconceptionsBatch_EmptyConceptsReturnsEmptyMap(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetActiveMisconceptionsBatch("L1", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected empty (non-nil) map, got nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected size 0, got %d", len(got))
+	}
+}
+
+func TestGetActiveMisconceptionsBatch_OnlyActiveReported(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+
+	// Active misconception on Goroutines (recent fail).
+	insertInteraction(t, store, "Goroutines", false, "confusion", "x", now.Add(-1*time.Hour))
+
+	// Resolved misconception on Interfaces (old fail + 3 successes).
+	insertInteraction(t, store, "Interfaces", false, "type assertion", "old", now.Add(-5*time.Hour))
+	insertInteraction(t, store, "Interfaces", true, "", "", now.Add(-4*time.Hour))
+	insertInteraction(t, store, "Interfaces", true, "", "", now.Add(-3*time.Hour))
+	insertInteraction(t, store, "Interfaces", true, "", "", now.Add(-2*time.Hour))
+
+	// Concept with no interactions at all.
+	got, err := store.GetActiveMisconceptionsBatch("L1", []string{"Goroutines", "Interfaces", "Channels"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !got["Goroutines"] {
+		t.Errorf("expected Goroutines=true, got %v", got["Goroutines"])
+	}
+	if got["Interfaces"] {
+		t.Errorf("expected Interfaces=false (resolved), got true")
+	}
+	if got["Channels"] {
+		t.Errorf("expected Channels=false (no interactions), got true")
+	}
+}
+
+// ─── GetFirstActiveMisconception ───────────────────────────────────────────
+
+func TestGetFirstActiveMisconception_NoneReturnsNil(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetFirstActiveMisconception("L1", "Goroutines")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestGetFirstActiveMisconception_ReturnsHighestCount(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	// Two distinct misconception types ; "confusion" appears twice ⇒ count=2,
+	// "missing" appears once ⇒ count=1. The highest-count group is returned.
+	insertInteraction(t, store, "Goroutines", false, "confusion", "d1", now.Add(-3*time.Hour))
+	insertInteraction(t, store, "Goroutines", false, "confusion", "d2", now.Add(-1*time.Hour))
+	insertInteraction(t, store, "Goroutines", false, "missing", "d3", now.Add(-2*time.Hour))
+
+	got, err := store.GetFirstActiveMisconception("L1", "Goroutines")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if got.MisconceptionType != "confusion" {
+		t.Errorf("type: want 'confusion' (highest count), got %q", got.MisconceptionType)
+	}
+}
+
+// ─── GetRecentConceptsByDomain ─────────────────────────────────────────────
+
+func TestGetRecentConceptsByDomain_EmptyDomainConcepts(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetRecentConceptsByDomain("L1", nil, 20)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestGetRecentConceptsByDomain_ZeroLimit(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetRecentConceptsByDomain("L1", []string{"A"}, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil on limit=0, got %v", got)
+	}
+}
+
+func TestGetRecentConceptsByDomain_NoInteractions(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetRecentConceptsByDomain("L1", []string{"A", "B"}, 20)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestGetRecentConceptsByDomain_DedupAndOrder(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	// Insert chronologically: B (oldest), A, B, C (newest).
+	insertInteraction(t, store, "B", true, "", "", now.Add(-4*time.Hour))
+	insertInteraction(t, store, "A", true, "", "", now.Add(-3*time.Hour))
+	insertInteraction(t, store, "B", true, "", "", now.Add(-2*time.Hour))
+	insertInteraction(t, store, "C", true, "", "", now.Add(-1*time.Hour))
+
+	got, err := store.GetRecentConceptsByDomain("L1", []string{"A", "B", "C"}, 20)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// Most-recent-first, dedup keeps first-seen (most recent) occurrence.
+	want := []string{"C", "B", "A"}
+	if len(got) != len(want) {
+		t.Fatalf("len: want %d, got %d (%v)", len(want), len(got), got)
+	}
+	for i, c := range want {
+		if got[i] != c {
+			t.Errorf("pos %d: want %q, got %q", i, c, got[i])
+		}
+	}
+}
+
+func TestGetRecentConceptsByDomain_FiltersOutOfDomain(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteraction(t, store, "OtherDomain", true, "", "", now.Add(-1*time.Hour))
+	insertInteraction(t, store, "A", true, "", "", now.Add(-2*time.Hour))
+
+	got, err := store.GetRecentConceptsByDomain("L1", []string{"A"}, 20)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0] != "A" {
+		t.Errorf("expected [A], got %v", got)
+	}
+}
+
+// ─── CountInteractionsSince ────────────────────────────────────────────────
+
+func TestCountInteractionsSince_AllConcepts_NoFilter(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteraction(t, store, "A", true, "", "", now.Add(-3*time.Hour))
+	insertInteraction(t, store, "B", true, "", "", now.Add(-1*time.Hour))
+	insertInteraction(t, store, "C", true, "", "", now.Add(-30*time.Minute))
+
+	// nil/empty domainConcepts → no Go-side filter, count everything since.
+	since := now.Add(-2 * time.Hour)
+	n, err := store.CountInteractionsSince("L1", since, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count want 2 (B+C since cutoff), got %d", n)
+	}
+}
+
+func TestCountInteractionsSince_AcrossCutoff(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	// 1 before cutoff, 2 at-or-after — only the 2 should be counted.
+	insertInteraction(t, store, "A", true, "", "", now.Add(-3*time.Hour))
+	insertInteraction(t, store, "A", true, "", "", now.Add(-30*time.Minute))
+	insertInteraction(t, store, "A", true, "", "", now.Add(-15*time.Minute))
+
+	since := now.Add(-1 * time.Hour)
+	n, err := store.CountInteractionsSince("L1", since, []string{"A", "B"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count: want 2, got %d", n)
+	}
+}
+
+func TestCountInteractionsSince_FiltersOutOfDomain(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteraction(t, store, "InDomain", true, "", "", now.Add(-30*time.Minute))
+	insertInteraction(t, store, "OutOfDomain", true, "", "", now.Add(-30*time.Minute))
+
+	n, err := store.CountInteractionsSince("L1", now.Add(-1*time.Hour), []string{"InDomain"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count: want 1 (only InDomain), got %d", n)
+	}
+}
+
+func TestCountInteractionsSince_FutureCutoffReturnsZero(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteraction(t, store, "A", true, "", "", now.Add(-1*time.Hour))
+
+	n, err := store.CountInteractionsSince("L1", now.Add(1*time.Hour), nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count: want 0, got %d", n)
+	}
+}
+
+// ─── GetActionHistoryForConcept ────────────────────────────────────────────
+
+func TestGetActionHistoryForConcept_NoInteractions(t *testing.T) {
+	store := setupTestDB(t)
+	h, err := store.GetActionHistoryForConcept("L1", "A", 50)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.MasteryChallengeCount != 0 || h.FeynmanCount != 0 || h.TransferCount != 0 || h.InteractionsAboveBKT != 0 {
+		t.Errorf("want zero counts, got %+v", h)
+	}
+}
+
+func TestGetActionHistoryForConcept_CountsByActivityType(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteractionWithType(t, store, "A", true, string(models.ActivityMasteryChallenge), now.Add(-5*time.Hour))
+	insertInteractionWithType(t, store, "A", true, string(models.ActivityMasteryChallenge), now.Add(-4*time.Hour))
+	insertInteractionWithType(t, store, "A", true, string(models.ActivityFeynmanPrompt), now.Add(-3*time.Hour))
+	insertInteractionWithType(t, store, "A", true, string(models.ActivityTransferProbe), now.Add(-2*time.Hour))
+	// A different type that's neither MC, Feynman nor Transfer — should not bump any counter.
+	insertInteractionWithType(t, store, "A", true, "PRACTICE", now.Add(-1*time.Hour))
+
+	h, err := store.GetActionHistoryForConcept("L1", "A", 50)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.MasteryChallengeCount != 2 {
+		t.Errorf("MC: want 2, got %d", h.MasteryChallengeCount)
+	}
+	if h.FeynmanCount != 1 {
+		t.Errorf("Feynman: want 1, got %d", h.FeynmanCount)
+	}
+	if h.TransferCount != 1 {
+		t.Errorf("Transfer: want 1, got %d", h.TransferCount)
+	}
+}
+
+func TestGetActionHistoryForConcept_StreakStopsOnFirstFailure(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	// Chronological: success, failure, success, success (most recent last).
+	// DESC scan order is "success, success, failure, success" — streak = 2.
+	insertInteractionWithType(t, store, "A", true, "PRACTICE", now.Add(-4*time.Hour))
+	insertInteractionWithType(t, store, "A", false, "PRACTICE", now.Add(-3*time.Hour))
+	insertInteractionWithType(t, store, "A", true, "PRACTICE", now.Add(-2*time.Hour))
+	insertInteractionWithType(t, store, "A", true, "PRACTICE", now.Add(-1*time.Hour))
+
+	h, err := store.GetActionHistoryForConcept("L1", "A", 50)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.InteractionsAboveBKT != 2 {
+		t.Errorf("streak: want 2, got %d", h.InteractionsAboveBKT)
+	}
+}
+
+func TestGetActionHistoryForConcept_NegativeLimitDefaults(t *testing.T) {
+	// recentLimit <= 0 should fall back to 50 (defensive default in the
+	// implementation). We just verify the call is non-erroring and the
+	// counts are computed.
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	insertInteractionWithType(t, store, "A", true, "PRACTICE", now.Add(-1*time.Hour))
+
+	h, err := store.GetActionHistoryForConcept("L1", "A", -5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.InteractionsAboveBKT != 1 {
+		t.Errorf("streak: want 1, got %d", h.InteractionsAboveBKT)
+	}
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+// insertInteractionWithType is a variant of insertInteraction that lets
+// the caller pick the activity_type column value. Used by
+// GetActionHistoryForConcept tests where the type drives counters.
+func insertInteractionWithType(t *testing.T, store *Store, concept string, success bool, activityType string, createdAt time.Time) {
+	t.Helper()
+	successInt := 0
+	if success {
+		successInt = 1
+	}
+	_, err := store.db.Exec(
+		`INSERT INTO interactions (learner_id, concept, activity_type, success, response_time, confidence, notes, misconception_type, misconception_detail, created_at)
+		 VALUES ('L1', ?, ?, ?, 60, 0.5, '', ?, ?, ?)`,
+		concept, activityType, successInt, nullString(""), nullString(""), createdAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/engine/orchestrator_escape_test.go
+++ b/engine/orchestrator_escape_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"tutor-mcp/models"
+)
+
+// TestOrchestrate_EscapePath_NoFringeAfterRetry covers the
+// "pipeline_exhausted: NoFringe persistant après retry" branch of
+// Orchestrate (engine/orchestrator.go:142-146). The scenario:
+//
+//   - Phase = INSTRUCTION ; the domain's only concept is mastered, so
+//     the external fringe in INSTRUCTION is empty (NoFringe).
+//   - Orchestrate retries with MAINTENANCE (noFringeFallbackPhase).
+//   - In MAINTENANCE, the mastered concept is NOT covered by
+//     goal_relevance — eligible-pool empty, NoFringe again.
+//   - Loop exits with the fallback Activity{Rest, "pipeline_exhausted…"}.
+func TestOrchestrate_EscapePath_NoFringeAfterRetry(t *testing.T) {
+	store := setupOrchStore(t)
+	domainID := seedOrchDomain(t, store, []string{"A"}, nil, models.PhaseInstruction)
+
+	// Set a goal_relevance vector that does NOT cover "A". This forces:
+	//   - INSTRUCTION → resolveRelevance returns eligible=false → NoFringe
+	//     (rationale: "aucun concept couvert par goal_relevance"), or
+	//     fringe empty because mastered.
+	//   - MAINTENANCE → mastered but not eligible → NoFringe.
+	setGoalRelevance(t, store, domainID, map[string]float64{"DUMMY": 1.0})
+
+	// Master "A" so external fringe is empty in INSTRUCTION.
+	setMastery(t, store, "A", 0.95)
+
+	activity, err := Orchestrate(store, defaultInput(domainID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if activity.Type != models.ActivityRest {
+		t.Errorf("type: want REST, got %q", activity.Type)
+	}
+	if !strings.HasPrefix(activity.Rationale, "pipeline_exhausted") {
+		t.Errorf("rationale prefix: want 'pipeline_exhausted...', got %q", activity.Rationale)
+	}
+	if activity.PromptForLLM == "" {
+		t.Errorf("expected non-empty PromptForLLM on escape, got empty")
+	}
+}
+
+// TestOrchestrate_EscapePath_MaintenanceFallbackToInstruction_BothNoFringe
+// is the symmetric scenario: starting from MAINTENANCE, the fallback is
+// INSTRUCTION, and the same "no eligible concept" outcome triggers the
+// pipeline_exhausted branch. Pinning the symmetry guarantees the fallback
+// table (noFringeFallbackPhase) is exercised in both directions.
+func TestOrchestrate_EscapePath_MaintenanceFallbackToInstruction_BothNoFringe(t *testing.T) {
+	store := setupOrchStore(t)
+	domainID := seedOrchDomain(t, store, []string{"A"}, nil, models.PhaseMaintenance)
+
+	// "A" is in goal_relevance but never mastered — so:
+	//   - MAINTENANCE: needs PMastery >= MasteryBKT() → none mastered → NoFringe.
+	//   - INSTRUCTION (fallback): A is in fringe BUT we strip it out via
+	//     anti-rep with a recent interaction below, AND prereq blocks…
+	// Easier: drop A out of goal_relevance entirely so both phases return NoFringe.
+	setGoalRelevance(t, store, domainID, map[string]float64{"DUMMY": 1.0})
+
+	activity, err := Orchestrate(store, defaultInput(domainID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if activity.Type != models.ActivityRest {
+		t.Errorf("type: want REST, got %q", activity.Type)
+	}
+	if !strings.HasPrefix(activity.Rationale, "pipeline_exhausted") {
+		t.Errorf("rationale: want pipeline_exhausted prefix, got %q", activity.Rationale)
+	}
+}
+
+// TestOrchestrate_GateEscape_OVERLOAD_ComposesCloseSession exercises the
+// OTHER escape path: Gate emits an EscapeAction (OVERLOAD). The
+// orchestrator routes it through composeEscapeActivity
+// (engine/orchestrator.go:445), which is at 0% coverage today.
+//
+// We force OVERLOAD by passing input.Now far in the past — the alert
+// engine treats input.Now as the session start (engine/alert.go:154,
+// `time.Since(sessionStart) > 45*time.Minute`), so a 1-hour-old
+// "session start" reliably triggers the alert.
+func TestOrchestrate_GateEscape_OVERLOAD_ComposesCloseSession(t *testing.T) {
+	store := setupOrchStore(t)
+	domainID := seedOrchDomain(t, store, []string{"A", "B"}, nil, models.PhaseInstruction)
+	setGoalRelevance(t, store, domainID, map[string]float64{"A": 0.9, "B": 0.5})
+
+	input := defaultInput(domainID)
+	// OVERLOAD threshold is 45 min ; pass an "older than 45 min" timestamp.
+	input.Now = time.Now().UTC().Add(-1 * time.Hour)
+
+	activity, err := Orchestrate(store, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if activity.Type != models.ActivityCloseSession {
+		t.Errorf("type: want CLOSE_SESSION, got %q", activity.Type)
+	}
+	if activity.Format != "session_overload" {
+		t.Errorf("format: want session_overload, got %q", activity.Format)
+	}
+	if !strings.Contains(activity.Rationale, "OVERLOAD") {
+		t.Errorf("rationale: want to mention OVERLOAD, got %q", activity.Rationale)
+	}
+	if activity.PromptForLLM == "" {
+		t.Errorf("expected composeEscapeActivity to set a non-empty PromptForLLM")
+	}
+}
+
+// TestContainsActivityType_Direct exercises the slices.Contains wrapper
+// directly. It is at 0% in the runtime path because the production path
+// happens to always pass an action whose Type IS in the gate's
+// ActionRestriction set (the gate restricts to {DEBUG_MISCONCEPTION} and
+// [5] ActionSelector also selects DEBUG_MISCONCEPTION when a misconception
+// is active). The function is still load-bearing — pin its behaviour
+// independently.
+func TestContainsActivityType_Direct(t *testing.T) {
+	tests := []struct {
+		name string
+		set  []models.ActivityType
+		t    models.ActivityType
+		want bool
+	}{
+		{"empty set returns false", nil, models.ActivityRecall, false},
+		{"single match", []models.ActivityType{models.ActivityDebugMisconception}, models.ActivityDebugMisconception, true},
+		{"single non-match", []models.ActivityType{models.ActivityDebugMisconception}, models.ActivityRecall, false},
+		{"multi-element first hit", []models.ActivityType{models.ActivityDebugMisconception, models.ActivityRecall}, models.ActivityDebugMisconception, true},
+		{"multi-element last hit", []models.ActivityType{models.ActivityDebugMisconception, models.ActivityRecall}, models.ActivityRecall, true},
+		{"multi-element no hit", []models.ActivityType{models.ActivityDebugMisconception, models.ActivityRecall}, models.ActivityFeynmanPrompt, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containsActivityType(tc.set, tc.t)
+			if got != tc.want {
+				t.Errorf("containsActivityType(%v, %q) = %v, want %v", tc.set, tc.t, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComposeEscapeActivity_Direct unit-tests the pure composer so the
+// shape of its output is pinned even if the runtime path through the
+// gate changes. This is the function that turns a Gate.EscapeAction into
+// a models.Activity (engine/orchestrator.go:445).
+func TestComposeEscapeActivity_Direct(t *testing.T) {
+	esc := EscapeAction{
+		Type:      models.ActivityCloseSession,
+		Format:    "session_overload",
+		Rationale: "OVERLOAD escape : close session",
+	}
+	got := composeEscapeActivity(esc)
+	if got.Type != esc.Type {
+		t.Errorf("Type: want %q, got %q", esc.Type, got.Type)
+	}
+	if got.Format != esc.Format {
+		t.Errorf("Format: want %q, got %q", esc.Format, got.Format)
+	}
+	if got.Rationale != esc.Rationale {
+		t.Errorf("Rationale: want %q, got %q", esc.Rationale, got.Rationale)
+	}
+	if got.PromptForLLM == "" {
+		t.Errorf("PromptForLLM: want non-empty (canned LLM instruction)")
+	}
+	// Concept and DifficultyTarget are zero-value by construction — the
+	// escape doesn't pick a concept.
+	if got.Concept != "" {
+		t.Errorf("Concept: want empty (escape has no concept), got %q", got.Concept)
+	}
+}

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package models
+
+import (
+	"sort"
+	"testing"
+)
+
+// ─── ParseGoalRelevance ────────────────────────────────────────────────────
+
+func TestParseGoalRelevance_EmptyJSONReturnsNil(t *testing.T) {
+	d := &Domain{ID: "d1", GoalRelevanceJSON: ""}
+	if got := d.ParseGoalRelevance(); got != nil {
+		t.Errorf("empty JSON: want nil, got %+v", got)
+	}
+}
+
+func TestParseGoalRelevance_MalformedJSONReturnsNilAndWarns(t *testing.T) {
+	// The "WARN-on-corruption" path: malformed JSON must not panic, must
+	// return nil, and must log a WARN. We don't assert the WARN itself
+	// (would couple the test to slog.Default), only that the function
+	// degrades silently.
+	d := &Domain{ID: "d1", GoalRelevanceJSON: "{not_valid_json"}
+	if got := d.ParseGoalRelevance(); got != nil {
+		t.Errorf("malformed JSON: want nil, got %+v", got)
+	}
+}
+
+func TestParseGoalRelevance_ValidStructureRoundTrips(t *testing.T) {
+	// A full structured payload with relevance map + for_graph_version.
+	json := `{"for_graph_version":2,"relevance":{"A":0.9,"B":0.4},"set_at":"2026-01-01T00:00:00Z"}`
+	d := &Domain{ID: "d1", GoalRelevanceJSON: json}
+	gr := d.ParseGoalRelevance()
+	if gr == nil {
+		t.Fatal("expected non-nil GoalRelevance")
+	}
+	if gr.ForGraphVersion != 2 {
+		t.Errorf("ForGraphVersion: want 2, got %d", gr.ForGraphVersion)
+	}
+	if gr.Relevance["A"] != 0.9 || gr.Relevance["B"] != 0.4 {
+		t.Errorf("Relevance map: %+v", gr.Relevance)
+	}
+}
+
+func TestParseGoalRelevance_EmptyJSONObject(t *testing.T) {
+	// Edge case: the JSON is structurally valid but has no fields. Should
+	// still parse to a zero-value GoalRelevance (not nil).
+	d := &Domain{ID: "d1", GoalRelevanceJSON: "{}"}
+	gr := d.ParseGoalRelevance()
+	if gr == nil {
+		t.Fatal("expected non-nil GoalRelevance for {}")
+	}
+	if gr.ForGraphVersion != 0 {
+		t.Errorf("ForGraphVersion: want 0, got %d", gr.ForGraphVersion)
+	}
+	if len(gr.Relevance) != 0 {
+		t.Errorf("Relevance: want empty, got %+v", gr.Relevance)
+	}
+}
+
+// ─── IsGoalRelevanceStale ──────────────────────────────────────────────────
+
+func TestIsGoalRelevanceStale_NilVectorAndZeroGraphVersion(t *testing.T) {
+	// No JSON, GraphVersion=0 → not stale (legacy domain, never had a
+	// relevance vector and graph_version isn't tracked yet).
+	d := &Domain{ID: "d1", GoalRelevanceJSON: "", GraphVersion: 0}
+	if d.IsGoalRelevanceStale() {
+		t.Error("nil + GraphVersion=0: want NOT stale")
+	}
+}
+
+func TestIsGoalRelevanceStale_NilVectorWithGraphVersion(t *testing.T) {
+	// No JSON but GraphVersion>0 → stale (the graph exists; the vector
+	// was never set against it).
+	d := &Domain{ID: "d1", GoalRelevanceJSON: "", GraphVersion: 1}
+	if !d.IsGoalRelevanceStale() {
+		t.Error("nil + GraphVersion=1: want stale")
+	}
+}
+
+func TestIsGoalRelevanceStale_VersionMatch(t *testing.T) {
+	d := &Domain{
+		ID:                "d1",
+		GoalRelevanceJSON: `{"for_graph_version":2,"relevance":{"A":0.5}}`,
+		GraphVersion:      2,
+	}
+	if d.IsGoalRelevanceStale() {
+		t.Error("for_graph_version == GraphVersion: want NOT stale")
+	}
+}
+
+func TestIsGoalRelevanceStale_VersionMismatch(t *testing.T) {
+	d := &Domain{
+		ID:                "d1",
+		GoalRelevanceJSON: `{"for_graph_version":1,"relevance":{"A":0.5}}`,
+		GraphVersion:      2,
+	}
+	if !d.IsGoalRelevanceStale() {
+		t.Error("for_graph_version < GraphVersion: want stale")
+	}
+}
+
+func TestIsGoalRelevanceStale_MalformedJSONFallsBackToNilBranch(t *testing.T) {
+	// Malformed JSON ⇒ ParseGoalRelevance returns nil ⇒ stale-when-
+	// GraphVersion>0 branch is taken.
+	d := &Domain{ID: "d1", GoalRelevanceJSON: "{garbage", GraphVersion: 1}
+	if !d.IsGoalRelevanceStale() {
+		t.Error("malformed JSON + GraphVersion=1: want stale")
+	}
+}
+
+// ─── UncoveredConcepts ─────────────────────────────────────────────────────
+
+func TestUncoveredConcepts_FullCoverage(t *testing.T) {
+	d := &Domain{
+		ID:                "d1",
+		Graph:             KnowledgeSpace{Concepts: []string{"A", "B"}},
+		GoalRelevanceJSON: `{"for_graph_version":1,"relevance":{"A":0.9,"B":0.4}}`,
+	}
+	if got := d.UncoveredConcepts(); len(got) != 0 {
+		t.Errorf("full coverage: want empty, got %v", got)
+	}
+}
+
+func TestUncoveredConcepts_PartialCoverage(t *testing.T) {
+	d := &Domain{
+		ID:                "d1",
+		Graph:             KnowledgeSpace{Concepts: []string{"A", "B", "C"}},
+		GoalRelevanceJSON: `{"for_graph_version":1,"relevance":{"A":0.9}}`,
+	}
+	got := d.UncoveredConcepts()
+	sort.Strings(got)
+	want := []string{"B", "C"}
+	if len(got) != len(want) {
+		t.Fatalf("len: want %d, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pos %d: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestUncoveredConcepts_EmptyVectorAllUncovered(t *testing.T) {
+	// No vector at all ⇒ every concept in Graph is uncovered.
+	d := &Domain{
+		ID:                "d1",
+		Graph:             KnowledgeSpace{Concepts: []string{"A", "B"}},
+		GoalRelevanceJSON: "",
+	}
+	got := d.UncoveredConcepts()
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Errorf("empty vector: want [A B], got %v", got)
+	}
+}
+
+func TestUncoveredConcepts_EmptyGraph(t *testing.T) {
+	d := &Domain{
+		ID:                "d1",
+		Graph:             KnowledgeSpace{Concepts: nil},
+		GoalRelevanceJSON: `{"for_graph_version":1,"relevance":{"A":0.9}}`,
+	}
+	if got := d.UncoveredConcepts(); len(got) != 0 {
+		t.Errorf("empty graph: want empty, got %v", got)
+	}
+}
+
+func TestUncoveredConcepts_MalformedJSONTreatsAllAsUncovered(t *testing.T) {
+	// Corrupt JSON ⇒ Parse returns nil ⇒ no concept is "covered" ⇒ every
+	// concept of the graph is reported as uncovered.
+	d := &Domain{
+		ID:                "d1",
+		Graph:             KnowledgeSpace{Concepts: []string{"A"}},
+		GoalRelevanceJSON: "{not_valid",
+	}
+	got := d.UncoveredConcepts()
+	if len(got) != 1 || got[0] != "A" {
+		t.Errorf("malformed JSON: want [A], got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the three coverage gaps tracked in #11 — all on the regulation hot path:

- `db/phase.go` — six persistence helpers had 0% coverage. Added table-driven unit tests against in-memory SQLite for each (happy path + at least one edge case per function: nonexistent-domain UPDATE no-op, idempotent re-write, empty input, dedup/order, across-cutoff, future-cutoff, streak-stops-on-failure, etc.).
- `models/domain.go` — `ParseGoalRelevance`, `IsGoalRelevanceStale`, `UncoveredConcepts` had 0%. Added pure-function tests pinning the empty/malformed/valid JSON branches, the WARN-on-corruption path, the graph-version match/mismatch branches, and partial-vs-full coverage for `UncoveredConcepts`.
- `engine/orchestrator.go` — the "pipeline_exhausted: NoFringe persistant après retry" escape path was untested. Added an integration scenario (mastered concept + goal_relevance excluding it) where the gate filters everything in INSTRUCTION, the retry to MAINTENANCE also yields NoFringe, and the fallback Activity composes correctly. Plus a symmetric MAINTENANCE→INSTRUCTION case, a direct OVERLOAD test exercising `composeEscapeActivity`, and unit tests for `composeEscapeActivity` and `containsActivityType`.

No production code changes — tests only.

## Coverage — before / after

| Package / file | Before | After |
|---|---|---|
| `db` package | 76.1% | 84.1% |
| `db/phase.go` (six functions) | all 0% | 87.5% / 90.0% / 85.7% / 90.0% / 85.7% / 90.9% |
| `models` package | n/a (no tests) | 75.0% |
| `models/domain.go` (three functions) | all 0% | 100% / 100% / 100% |
| `engine` package | 89.7% | 90.2% |
| `engine/orchestrator.go` `containsActivityType` | 0% | 100% |
| `engine/orchestrator.go` `composeEscapeActivity` | 0% | 100% |

`models` package overall sits at 75% because two helpers in unrelated files (`models/learner.go:NewConceptState`, `models/motivation.go:StatementFor`) remain uncovered — they are out of scope for this issue. Per acceptance criterion ("`models/domain.go` ≥ 80%"), `domain.go` itself is at 100%.

## Acceptance criteria

- [x] Each of the nine functions has at least one unit/integration test naming it.
- [x] `db/phase.go` per-function coverage ≥ 80% (lowest is 85.7%).
- [x] `models/domain.go` per-function coverage ≥ 80% (all three at 100%).
- [x] `engine/orchestrator.go` overall coverage rises (89.7% → 90.2% on the `engine` package; the two specifically-targeted functions go from 0% to 100%).

## Test plan

- [x] `go test ./db/... ./models/... ./engine/... -cover` — all green
- [x] `go test ./...` — full suite green
- [x] Per-function coverage spot-checked via `go tool cover -func=cover.out`

Fixes #11

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6zMVM5FhQsrYjPSx52wLJ)_