### PR TITLE
[6] FadeController — autonomy-aware verbosity handover

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,24 +86,27 @@ On top of the legacy alert-and-router engine, v0.3 introduces a seven-stage **re
 | **[4]** | Concept Selector (`engine/concept_selector.go`) | **Shipped** (default-on) | Phase-aware concept choice: max-info-gain on the KST fringe (INSTRUCTION), most-overdue under FSRS (MAINTENANCE), max-binary-entropy untouched concept (DIAGNOSTIC). Kill switch: `REGULATION_CONCEPT=off` (prompt appendix only; same caveat). |
 | **[3]** | Gate Controller (`engine/gate.go`) | **Shipped** (default-on) | Hygiene gate that may override the selection: anti-repeat window (no concept repeated within last *N*=3 activities), 45-min session-budget escape (`CLOSE_SESSION`), no-fringe escape (`REST`). Kill switch: `REGULATION_GATE=off` (prompt appendix only). |
 | **[2]** | Phase Controller (`engine/orchestrator.go` + `engine/phase_fsm.go`) | **Shipped** (default-on) | Pure-FSM orchestrator wiring [4]→[5]→[3]. Transitions are observation-driven: DIAGNOSTIC→INSTRUCTION on entropy reduction *ΔH ≥ 0.2 bits* or *N ≥ 8* diagnostic items; INSTRUCTION→MAINTENANCE on full-graph mastery; MAINTENANCE→INSTRUCTION on FSRS retention drop. Kill switch: `REGULATION_PHASE=off` falls back to legacy `engine.Route`. |
-| **[6]** | Fade Controller | **Pending** | Gradual handover of pacing decisions to the learner once autonomy thresholds are met. Not implemented yet. |
+| **[6]** | Fade Controller (`engine/fade_controller.go`) | **Shipped** (opt-in) | Pure post-decision module. Maps `autonomy_score` × `autonomy.Trend` to a 4-field handover bundle (`hint_level` ∈ {full, partial, none}, `webhook_frequency` ∈ {daily, weekly, off}, `zpd_aggressiveness` ∈ {gentle, normal, push}, `proactive_review_enabled` bool). Wired into the motivation brief to fade verbosity as autonomy rises. Opt-in via `REGULATION_FADE=on` (strict literal) — default OFF. Integration with the webhook scheduler and action selector is follow-up work tracked from `docs/regulation-design/06-fade-controller.md` §9. |
 
 The pure functions (`SelectAction`, `SelectConcept`, `ApplyGate`, `EvaluatePhase`) are individually unit-tested (~90 dedicated tests). The orchestrator is exercised by SQLite in-memory tests and migration safety tests for the new `domains.phase`, `domains.phase_changed_at`, `domains.phase_entry_entropy` columns.
 
-### Feature flags — default-on, opt-out via `=off`
+### Feature flags — default-on (opt-out via `=off`) except `REGULATION_FADE` (opt-in via `=on`)
 
-All regulation flags are **active by default**. Setting any of them to the literal `off` disables that stage; any other value (including unset) leaves it enabled. Typos in the off-direction (`Off`, `OFF`, ` off`) leave the stage active — operators must type `off` exactly to disable, which makes accidental rollback impossible.
+The first six regulation flags are **active by default**. Setting any of them to the literal `off` disables that stage; any other value (including unset) leaves it enabled. Typos in the off-direction (`Off`, `OFF`, ` off`) leave the stage active — operators must type `off` exactly to disable, which makes accidental rollback impossible.
 
-Only two flags change the runtime; the rest control the system-prompt appendix only. The appendix tells the LLM about the new activity types and routing semantics, but the actual selection logic ships behind `REGULATION_PHASE`.
+`REGULATION_FADE` is the exception: it is the youngest pipeline component and its visible effects (verbosity reduction, webhook suppression) interact directly with the learner, so it ships **opt-in** — set the strict literal `on` to enable; any other value (unset, `ON`, `true`, `1`) leaves the fader off.
 
-| Flag | Default | Effect when set to `off` | Touches |
-|------|---------|--------------------------|---------|
+Only three flags change the runtime (`REGULATION_THRESHOLD`, `REGULATION_PHASE`, `REGULATION_FADE`); the rest control the system-prompt appendix only. The appendix tells the LLM about the new activity types and routing semantics, but the actual selection logic ships behind `REGULATION_PHASE`.
+
+| Flag | Default | Effect when toggled away from default | Touches |
+|------|---------|---------------------------------------|---------|
 | `REGULATION_THRESHOLD` | on | Reverts to legacy split thresholds (BKT 0.85, KST 0.70, Mid 0.80). | runtime |
 | `REGULATION_PHASE` | on | Routes `get_next_activity` through the legacy `engine.Route` priority cascade instead of `engine.Orchestrate`. The orchestrator already auto-falls-back to legacy on internal error; this flag is the explicit operator override. | runtime |
 | `REGULATION_GOAL` | on | Hides `set_goal_relevance` / `get_goal_relevance` from the MCP tool list and drops the goal-aware system-prompt section. | runtime + prompt |
 | `REGULATION_ACTION` | on | Drops the action-selector appendix (the LLM no longer sees the new activity types documented). The selector itself keeps running under `REGULATION_PHASE`. | prompt only |
 | `REGULATION_CONCEPT` | on | Drops the concept-selector appendix. Selector keeps running. | prompt only |
 | `REGULATION_GATE` | on | Drops the gate appendix. Gate keeps running. | prompt only |
+| `REGULATION_FADE` | **off** | **Opt-in** (the only opt-in flag). Set to the literal `on` to enable [6] FadeController: maps `autonomy_score` × trend to fade params (hint verbosity, webhook frequency, ZPD aggressiveness, proactive review). When on, the fader modulates the `motivation_brief` so that the more autonomous the learner, the terser (and ultimately silent) the brief becomes; the resulting `fade_params` are also surfaced in the `get_next_activity` JSON for downstream consumers. Strict equality with `on` — any other value (including `ON`, `true`, `1`) keeps the fader off. See `docs/regulation-design/06-fade-controller.md`. | runtime |
 
 ## MCP Tools (30)
 

--- a/docs/regulation-design/06-fade-controller.md
+++ b/docs/regulation-design/06-fade-controller.md
@@ -1,0 +1,469 @@
+# [6] FadeController — Design (Phase 1)
+
+> Composant 6/7 du pipeline de regulation. Module **post-decision** :
+> isole de la chaine de selection (Phase FSM -> Concept -> Action ->
+> Gate). Lit `autonomy_score` et `autonomy.Trend` pour produire 4
+> parametres de "handover" qui sont consommes en aval (verbosite des
+> hints, cadence webhook, agressivite ZPD, reviews proactifs).
+>
+> Comble la lacune ou `autonomy_score` etait calcule mais non
+> consomme en aval, et donne a l'intent design "le systeme se rend
+> progressivement inutile" une implementation concrete.
+>
+> Reference architecture : `README.md` §"Regulation Pipeline" ligne 89,
+> `engine/metacognition.go` (calcul autonomy + trend), `engine/olm.go`
+> (champs `AutonomyTrend`).
+
+---
+
+## 1. Nature du composant
+
+`[6] FadeController` est un **module post-decision**. Il ne modifie ni
+le concept choisi, ni le type d'activite, ni la difficulte cible
+calculee par le pipeline amont. Il produit un **bundle de parametres de
+handover** (`FadeParams`) que les couches de presentation et de
+scheduling consomment :
+
+- la couche `motivation_brief` reduit la verbosite et peut supprimer
+  les hints quand l'apprenant n'en a plus besoin ;
+- le scheduler de webhooks abaisse la frequence des nudges quand
+  l'apprenant gere lui-meme sa pratique ;
+- le selecteur d'action (`[5]`) peut, dans une iteration future, lire
+  `ZPDAggressiveness` pour ajuster la pCorrect cible ;
+- la cadence de reviews proactifs (FSRS) peut activer ou desactiver
+  les rappels.
+
+C'est une fonction **pure** : `Decide(score float64, trend
+AutonomyTrend) FadeParams`. Aucun acces store, aucun side-effect. La
+collecte des inputs et l'application des outputs vivent dans
+`tools/activity.go` (chaine d'orchestration), strictement post-
+`engine.Orchestrate`.
+
+### Pourquoi post-decision et non integre au PhaseController
+
+Trois raisons :
+
+1. **Separation des roles**. La phase FSM repond a "ou en est
+   l'apprenant dans la maitrise du graphe ?". Le fade repond a "de
+   combien de tutorat l'apprenant a-t-il encore besoin ?". Ces deux
+   questions sont orthogonales : un apprenant en MAINTENANCE peut
+   encore avoir besoin d'aide ; un apprenant en INSTRUCTION peut deja
+   etre tres autonome sur la portion qu'il connait.
+2. **Couplage minimal**. En vivant apres `Orchestrate`, le fade ne
+   peut pas casser la garantie d'invariance des outputs orchestrateur
+   sous le flag OFF. C'est ce qui permet le test "byte-identique
+   activity output flag-off vs pre-PR".
+3. **Independance de cycle de vie**. Le fade peut evoluer sans
+   toucher aux fonctions pures `SelectConcept` / `SelectAction` /
+   `ApplyGate`. Il est plus jeune que ces fonctions et son
+   parametrage est plus susceptible de bouger.
+
+---
+
+## 2. Inputs
+
+| Champ | Type | Source | Notes |
+|-------|------|--------|-------|
+| `score` | `float64` | `models.AutonomyMetrics.Score` calcule par `engine.ComputeAutonomyMetrics` (`engine/metacognition.go`) | Borne `[0, 1]`. 4 composantes a 25% chacune : initiative, calibration accuracy, hint independence, proactive review rate. |
+| `trend` | `AutonomyTrend` (alias `string`) | `engine.ComputeAutonomyTrendExported` (`engine/metacognition.go:173`) | Valeurs : `"improving"`, `"stable"`, `"declining"`. Calcule en comparant la moyenne des 5 derniers scores aux 5 precedents (delta > 0.05). |
+
+### 2.1 Cold start
+
+Si `score == 0` ET il n'existe aucun affect record en base, on est en
+*cold start*. Le score retourne par `ComputeAutonomyMetrics` peut etre
+~0.25 (calibration accuracy = 1.0 si bias = 0, autres composantes = 0)
+voire indefini.
+
+**Strategie** : le `FadeController` ne distingue pas explicitement
+`cold_start`. Tout score `< 0.3` tombe dans le tier `low` qui retourne
+des defaults conservateurs (full hints, daily webhooks, gentle ZPD,
+proactive reviews ON). C'est exactement le comportement souhaite pour
+un nouvel apprenant. La distinction "vraiment cold" vs "score genuinely
+low" est laissee aux couches amont (qui peuvent injecter un score = 0
+si elles veulent forcer le tier low).
+
+### 2.2 Contrat d'appel
+
+Le `FadeController` est appele **une fois par `get_next_activity`**,
+apres que l'orchestrateur a produit l'`Activity`. Le cout est
+negligeable (lecture des affect records pour calculer score+trend ; ces
+lectures se font deja pour `metacognitive_mirror`). Pas de cache ; pas
+de memoization.
+
+---
+
+## 3. Outputs
+
+`FadeParams` est un struct a 4 champs :
+
+```go
+type FadeParams struct {
+    HintLevel              HintLevel              // full | partial | none
+    WebhookFrequency       WebhookFrequency       // daily | weekly | off
+    ZPDAggressiveness      ZPDAggressiveness      // gentle | normal | push
+    ProactiveReviewEnabled bool
+}
+```
+
+### 3.1 Consommateurs
+
+| Champ | Consommateur | Effet |
+|-------|--------------|-------|
+| `HintLevel` | `engine/motivation.go` (via `tools/activity.go`) | `none` -> brief.Kind = "" et brief.Instruction reduit a une ligne minimaliste. `partial` -> brief retenu mais Instruction abregee. `full` -> brief inchange (comportement actuel). |
+| `WebhookFrequency` | `engine/scheduler.go` (via persistence sur la ligne domain ou learner) | `off` -> aucun nudge envoye. `weekly` -> dispatch reduit (1x/semaine au lieu de 1x/jour). `daily` -> comportement actuel. **NB** : la PR initiale persiste le champ et l'attache au resultat de `get_next_activity` ; l'integration scheduler effective est issue de suivi (cf §9). |
+| `ZPDAggressiveness` | `engine/action_selector.go` (futur) | `gentle` -> baisse pCorrect cible (~0.78). `normal` -> 0.70 actuel. `push` -> ~0.62, plus de challenge. **NB** : la PR initiale ne wire pas ; champ expose pour permettre la consommation future sans changement de signature. |
+| `ProactiveReviewEnabled` | `engine/scheduler.go` (FSRS recall jobs) | `false` -> pas de proactive review surface. `true` -> comportement actuel. **NB** : scope reporte au suivi. |
+
+Le **scope d'implementation initial** (cette PR) est : pure function +
+wiring `HintLevel` -> motivation. Les autres champs sont presents dans
+`FadeParams` mais leur consommation est documentee comme follow-up.
+C'est la bonne segmentation : on livre la table de mapping et la
+machine pure ; chaque consommateur sera cable dans une PR dediee qui
+peut s'occuper des subtilites de migration de schema (scheduler) et de
+calibration (action selector).
+
+---
+
+## 4. Mapping autonomy -> FadeParams
+
+### 4.1 Tiers de score
+
+Trois tiers de score, frontieres a `0.3` et `0.7`. Choix justifie par
+le calcul de `ComputeAutonomyMetrics` : 4 composantes a 25% chacune
+signifie qu'une valeur a 0.3 correspond a "1 composante au max, 3 a
+zero" -> apprenant qui demarre. 0.7 correspond a "3 composantes au max,
+1 a zero ou faible" -> apprenant largement autonome. Au-dessus de 0.7,
+on est dans le regime de fading actif.
+
+| Tier | Score | Defaults (trend = stable) |
+|------|-------|----------------------------|
+| **Low** | `score < 0.3` | `HintLevel = full`, `WebhookFrequency = daily`, `ZPDAggressiveness = gentle`, `ProactiveReviewEnabled = true` |
+| **Mid** | `0.3 <= score < 0.7` | `HintLevel = partial`, `WebhookFrequency = weekly`, `ZPDAggressiveness = normal`, `ProactiveReviewEnabled = true` |
+| **High** | `score >= 0.7` | `HintLevel = none`, `WebhookFrequency = off`, `ZPDAggressiveness = push`, `ProactiveReviewEnabled = false` |
+
+### 4.2 Modulation par trend
+
+Le score donne le tier de base. La trend module **un cran** dans la
+direction qui aide l'apprenant :
+
+- `improving` : on **avance** d'un cran vers plus d'autonomie. Un
+  apprenant `Mid` qui s'ameliore obtient les defaults `High` sur
+  `HintLevel` et `WebhookFrequency`. Un `High` qui s'ameliore reste
+  `High` (pas de cran au-dessus).
+- `stable` : tier de base inchange.
+- `declining` : on **recule** d'un cran. Un apprenant `Mid` qui decline
+  obtient les defaults `Low` sur `HintLevel`, `WebhookFrequency`. Un
+  `High` qui decline retombe a `Mid`. C'est le **fast fallback** vers
+  plus de support.
+
+Cette modulation s'applique aux 4 outputs simultanement (pas de
+sub-modulation par champ). C'est un choix de simplicite et de
+lisibilite — l'operator ou l'apprenant peut interpreter "je suis Mid
+declining" comme "le systeme se comporte temporairement comme si
+j'etais Low".
+
+### 4.3 Table complete (9 cellules)
+
+| Score \ Trend | declining | stable | improving |
+|---------------|-----------|--------|-----------|
+| **Low** (`<0.3`) | Low | Low | Mid |
+| **Mid** (`0.3-0.7`) | Low | Mid | High |
+| **High** (`>=0.7`) | Mid | High | High |
+
+Chaque cellule resout vers le tier indique, qui determine les 4
+parametres selon §4.1.
+
+### 4.4 Hysteresis et oscillations
+
+`computeAutonomyTrend` necessite >=6 scores pour produire autre chose
+que `"stable"` (cf `engine/metacognition.go:137`). En-dessous de ce
+seuil, la trend est `"stable"` et le tier de base s'applique. C'est
+notre premier garde-fou contre l'oscillation precoce.
+
+**Risque d'oscillation autour des frontieres** (e.g. score = 0.298
+declining vs 0.302 improving) : la trend window de 5+5 scores avec
+delta > 0.05 introduit deja un seuil non-trivial sur les variations
+courtes. Pas de hysteresis additionnel sur le score lui-meme dans la
+v1 — si le pattern se manifeste en prod, on l'ajoutera (typiquement
++/- 0.02 autour des frontieres).
+
+### 4.5 Edge cases
+
+| Cas | Comportement | Justification |
+|-----|--------------|---------------|
+| `score < 0` | clamp a 0, tier Low | Robustesse ; ne devrait pas arriver mais on ne plante pas. |
+| `score > 1` | clamp a 1, tier High | Idem. |
+| `score = NaN` | comportement Go : NaN < 0.3 = false, NaN >= 0.7 = false -> tier Mid | Acceptable. NaN est traite comme Mid faute de mieux ; isole une eventuelle bug amont sans escalader. Cas hors scope, issue dediee si reproductible. |
+| `trend = ""` (vide) | traite comme `stable` | Cohesion avec le default de `computeAutonomyTrend` quand <6 scores. |
+| `trend = "garbage"` | traite comme `stable` | Robustesse. Switch defensif. |
+
+---
+
+## 5. Mecanisme du flag
+
+### 5.1 `REGULATION_FADE=on` strict
+
+Convention identique aux autres flags de regulation
+(cf `tools/prompt.go` : `regulationPhaseEnabled`,
+`regulationActionEnabled`, etc.). Le flag est lu via
+`os.Getenv("REGULATION_FADE") == "on"`. Toute autre valeur
+(unset, "ON", "true", "1") signifie OFF.
+
+**Difference avec les autres flags** : `REGULATION_FADE` est
+**default-OFF**. Les autres regulation flags sont default-on
+(opt-out via "off"). Le fade est plus jeune, son effet se voit
+directement sur l'apprenant (verbosite reduite, webhooks coupes), donc
+on ne l'active pas par defaut tant que le harness eval n'a pas
+valide.
+
+```go
+// tools/activity.go
+func regulationFadeEnabled() bool {
+    return os.Getenv("REGULATION_FADE") == "on"
+}
+```
+
+### 5.2 Comportement sous flag OFF
+
+Aucun appel a `Decide`. Aucun champ ajoute au resultat de
+`get_next_activity`. `MotivationBrief` produit comme avant. Le
+scheduler ne lit aucun champ. C'est strictement le comportement
+pre-PR. **Test de non-regression** : `tools/activity_test.go`
+verifie que les outputs `activity`, `motivation_brief`, `tutor_mode`
+etc. sont inchanges flag OFF (cf §7.1).
+
+### 5.3 Comportement sous flag ON
+
+`Decide` est appele post-Orchestrate. `FadeParams` est :
+1. utilise pour moduler `motivation_brief` (verbosite / suppression
+   selon `HintLevel`),
+2. ajoute au resultat JSON sous la cle `fade_params` pour observer
+   l'effet et permettre au scheduler de le lire.
+
+---
+
+## 6. API
+
+### 6.1 Types
+
+```go
+// engine/fade_controller.go
+package engine
+
+type AutonomyTrend string
+
+const (
+    AutonomyTrendImproving AutonomyTrend = "improving"
+    AutonomyTrendStable    AutonomyTrend = "stable"
+    AutonomyTrendDeclining AutonomyTrend = "declining"
+)
+
+type HintLevel string
+
+const (
+    HintLevelFull    HintLevel = "full"
+    HintLevelPartial HintLevel = "partial"
+    HintLevelNone    HintLevel = "none"
+)
+
+type WebhookFrequency string
+
+const (
+    WebhookFrequencyDaily  WebhookFrequency = "daily"
+    WebhookFrequencyWeekly WebhookFrequency = "weekly"
+    WebhookFrequencyOff    WebhookFrequency = "off"
+)
+
+type ZPDAggressiveness string
+
+const (
+    ZPDAggressivenessGentle ZPDAggressiveness = "gentle"
+    ZPDAggressivenessNormal ZPDAggressiveness = "normal"
+    ZPDAggressivenessPush   ZPDAggressiveness = "push"
+)
+
+type FadeParams struct {
+    HintLevel              HintLevel              `json:"hint_level"`
+    WebhookFrequency       WebhookFrequency       `json:"webhook_frequency"`
+    ZPDAggressiveness      ZPDAggressiveness      `json:"zpd_aggressiveness"`
+    ProactiveReviewEnabled bool                   `json:"proactive_review_enabled"`
+}
+
+// Decide is the pure mapping. No store access, no clock, deterministic.
+func Decide(score float64, trend AutonomyTrend) FadeParams { ... }
+```
+
+### 6.2 Convention de nommage
+
+Le constructeur s'appelle `Decide` (pas `DecideFade` ou `Apply`) — il
+vit dans `package engine` mais utilise dans le package est court. Aligne
+sur `engine.Orchestrate`, `engine.Route` (pas `OrchestrateRegulation`).
+
+Les enums sont des `type Foo string` plutot que des `int`. Choix :
+serialisation JSON lisible cote LLM et tests, coherent avec
+`models.ActivityType` et `models.MotivationKind*` qui sont des
+strings.
+
+---
+
+## 7. Strategie de test
+
+### 7.1 Tests unitaires (`engine/fade_controller_test.go`)
+
+Trois groupes :
+
+1. **Table-test couvrant les 9 cellules** de §4.3. Chaque cellule
+   verifie les 4 champs `FadeParams` retournes. Score d'entree pris
+   au milieu du tier (0.15, 0.5, 0.85) pour eviter les frontieres.
+2. **Tests de frontiere** : score = 0.3 exactement (Mid), score = 0.7
+   exactement (High), score = 0.0, score = 1.0, score = -0.1 (clamp),
+   score = 1.1 (clamp).
+3. **Trend defensifs** : `""`, `"garbage"`, `"IMPROVING"` (case-sensitive
+   donc traite comme stable).
+
+Total : ~25 cas. Pure function, pas de fixture, pas de t.Setenv.
+
+### 7.2 Test d'integration (`tools/activity_test.go`)
+
+Scenario : on insert 12 affect_states avec autonomy_score croissant
+(0.1 -> 0.85, lineaire). Avec `REGULATION_FADE=on`, on appelle
+`get_next_activity` apres avoir insert progressivement plus d'affect
+records (3, 6, 9, 12). On extrait le `motivation_brief.instruction` et
+on assert :
+
+- la **longueur de Instruction** est non-croissante au fur et a mesure
+  que le score monte,
+- le `fade_params.hint_level` decroit (`full` -> `partial` -> `none`)
+  au passage des seuils.
+
+Cf `engine/computeAutonomyTrend` qui necessite >=6 scores pour donner
+autre chose que `stable` : le test insert dans cet ordre pour
+declencher `improving` au step 4.
+
+### 7.3 Test de non-regression flag OFF
+
+`TestGetNextActivity_FlagOff_NoFadeFields` : sans `REGULATION_FADE=on`,
+le resultat JSON ne contient pas `fade_params`, et `motivation_brief`
+est strictement equivalent au comportement pre-PR. Garantit que la
+chaine d'orchestration est byte-identique.
+
+---
+
+## 8. Plan de PR
+
+### 8.1 Fichiers crees
+
+| Fichier | Lignes |
+|---------|--------|
+| `docs/regulation-design/06-fade-controller.md` | ~400 (ce doc) |
+| `engine/fade_controller.go` | ~120 |
+| `engine/fade_controller_test.go` | ~180 |
+
+### 8.2 Fichiers modifies
+
+| Fichier | Changement |
+|---------|------------|
+| `tools/prompt.go` | +1 fonction `regulationFadeEnabled` |
+| `tools/activity.go` | wiring post-Orchestrate, gate sur flag, application HintLevel a motivation_brief |
+| `tools/activity_test.go` | +1 test integration, +1 test non-regression flag OFF |
+| `README.md` | ligne 89 : status Pending -> Shipped (opt-in) ; tableau flags : ajout `REGULATION_FADE` |
+
+### 8.3 Critere de merge
+
+- [x] design doc complet
+- [ ] `go test ./...` PASS sans flag (non-regression)
+- [ ] `REGULATION_FADE=on go test ./...` PASS (integration)
+- [ ] tests table-driven sur les 9 cellules + edges
+- [ ] commit message lie ce design doc
+- [ ] pas de modification d'`engine.Orchestrate` ni des fonctions
+      pures `SelectConcept`/`SelectAction`/`ApplyGate`/`EvaluatePhase`
+- [ ] flag default OFF, strict equality `"on"`
+
+---
+
+## 9. Decisions ouvertes
+
+### OQ-6.1 — Wiring scheduler dans cette PR ?
+
+**A.** Oui. La PR persiste `WebhookFrequency` sur la ligne `domains`
+ou `learners`, et `engine/scheduler.go:dispatchQueued` filtre sur ce
+champ. Le scope croit d'une migration de schema + 30 lignes
+scheduler.
+
+**B.** Non, follow-up. La PR attache `fade_params` au resultat de
+`get_next_activity` mais ne touche ni schema, ni scheduler. Le LLM
+peut deja consommer le champ via le system prompt (futur appendix
+`fadeAppendix`). Le scheduler bouge dans une PR dediee qui peut traiter
+proprement la migration et les tests scheduler.
+
+**Defaut retenu** : **B**. Raisons : (1) la migration de schema force
+une release coordonnee, (2) le scheduler a sa propre suite de tests
+(`engine/scheduler_*_test.go`) qui meriterait une mise a jour
+specifique, (3) le brief du ticket autorise explicitement de scoper a
+"motivation-only wiring + follow-up".
+
+### OQ-6.2 — `ZPDAggressiveness` consomme par `[5]` ActionSelector dans cette PR ?
+
+**A.** Oui. Modifie `engine/action_selector.go` pour ajuster la
+pCorrect cible selon `ZPDAggressiveness`.
+
+**B.** Non, follow-up. Le champ est present dans `FadeParams` et serialise,
+mais `engine/action_selector.go` ne le lit pas encore.
+
+**Defaut retenu** : **B**. Raisons : (1) le calibre `IRT_θ + 0.847`
+est un parametre central documente dans plusieurs design docs ; le
+modifier merite une PR dediee avec eval harness avant/apres, (2) on
+respecte le principe "ship la pure function + flag stub, evite
+d'alterer le routage core dans la meme PR".
+
+### OQ-6.3 — Granularite des cellules : modulation par champ vs par tier ?
+
+**A.** Modulation **par tier** (choix actuel) : la trend deplace le
+tier ; les 4 outputs suivent ensemble.
+
+**B.** Modulation **par champ** : par exemple `improving` modifie
+`HintLevel` mais pas `WebhookFrequency`.
+
+**Defaut retenu** : **A**. Plus simple a expliquer, plus simple a
+tester (9 cellules au lieu de 81), reflete une intuition coherente
+("l'apprenant glisse vers plus / moins d'autonomie globalement"). Si
+des ajustements par champ deviennent necessaires en pratique, la
+fonction `Decide` peut etre etendue sans casser sa signature.
+
+### OQ-6.4 — Frontieres `0.3` et `0.7` ou `0.4` et `0.75` ?
+
+**A.** `0.3 / 0.7` (choix actuel) — symetrique autour de 0.5, aligne
+sur la decomposition 4 composantes a 25%.
+
+**B.** `0.4 / 0.75` — biaise vers un fading plus tardif (l'apprenant
+doit prouver davantage avant que le systeme se retire).
+
+**Defaut retenu** : **A**. Les 4 composantes a 25% donnent une
+intuition naturelle des paliers (1, 3 composantes max). Si l'eval
+harness montre une retraite trop precoce, c'est ce qu'on bumpera
+en priorite (PR a 1 ligne).
+
+---
+
+## 10. Recapitulatif
+
+| Aspect | Decision |
+|--------|----------|
+| **Position pipeline** | Post-`Orchestrate`, isole de la chaine de selection |
+| **API** | `engine.Decide(score, trend) FadeParams` pure function |
+| **Flag** | `REGULATION_FADE=on`, default OFF, strict equality |
+| **Tiers de score** | 3 (Low <0.3, Mid 0.3-0.7, High >=0.7) |
+| **Modulation trend** | +/-1 cran sur le tier (cf table 9 cellules §4.3) |
+| **Outputs** | 4 champs : HintLevel, WebhookFrequency, ZPDAggressiveness, ProactiveReviewEnabled |
+| **Wiring initial** | HintLevel -> motivation_brief, fade_params attache au resultat JSON |
+| **Wiring follow-up** | scheduler (WebhookFrequency, ProactiveReviewEnabled), action selector (ZPDAggressiveness) |
+
+---
+
+**STOP.** Design [6] FadeController complet. Implementation
+`engine/fade_controller.go` + tests + wiring `tools/activity.go` dans
+la meme PR. Composants suivants (post-merge) : (a) integration
+scheduler de `WebhookFrequency` (migration schema +
+filtre `dispatchQueued`), (b) integration `ZPDAggressiveness` dans
+`engine/action_selector.go`, (c) integration
+`ProactiveReviewEnabled` dans le job FSRS du scheduler.

--- a/engine/fade_controller.go
+++ b/engine/fade_controller.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+// Package engine — [6] FadeController.
+//
+// FadeController is a post-decision module of the v0.3 regulation
+// pipeline. It maps the learner's autonomy_score and trend to a bundle
+// of "handover" parameters consumed downstream:
+//
+//   - HintLevel              -> engine/motivation.go (verbosity,
+//     hint suppression)
+//   - WebhookFrequency       -> engine/scheduler.go (nudge cadence)
+//   - ZPDAggressiveness      -> engine/action_selector.go (pCorrect
+//     target)
+//   - ProactiveReviewEnabled -> engine/scheduler.go FSRS recall jobs
+//
+// The selection of concept / activity type / difficulty (orchestrator
+// chain: Phase FSM -> Concept -> Action -> Gate) is not affected. Fade
+// runs strictly after engine.Orchestrate and only modulates how the
+// chosen activity is presented and scheduled.
+//
+// Decide is a pure function: deterministic, no I/O, no clock.
+// Wiring (input collection, output application) lives in
+// tools/activity.go behind REGULATION_FADE=on (default OFF).
+//
+// See docs/regulation-design/06-fade-controller.md for the full
+// design (autonomy-tier table, mapping rationale, edge cases).
+package engine
+
+// AutonomyTrend mirrors the values produced by
+// computeAutonomyTrend (engine/metacognition.go): "improving",
+// "stable", "declining". Any other value is treated as "stable".
+type AutonomyTrend string
+
+const (
+	AutonomyTrendImproving AutonomyTrend = "improving"
+	AutonomyTrendStable    AutonomyTrend = "stable"
+	AutonomyTrendDeclining AutonomyTrend = "declining"
+)
+
+// HintLevel controls the verbosity / suppression of the motivation
+// brief and, by extension, the LLM's hinting behaviour.
+type HintLevel string
+
+const (
+	HintLevelFull    HintLevel = "full"
+	HintLevelPartial HintLevel = "partial"
+	HintLevelNone    HintLevel = "none"
+)
+
+// WebhookFrequency caps how often the scheduler dispatches Discord
+// nudges (daily_motivation, daily_recap, reactivation, reminder).
+type WebhookFrequency string
+
+const (
+	WebhookFrequencyDaily  WebhookFrequency = "daily"
+	WebhookFrequencyWeekly WebhookFrequency = "weekly"
+	WebhookFrequencyOff    WebhookFrequency = "off"
+)
+
+// ZPDAggressiveness biases the pCorrect target used by the action
+// selector. Gentle keeps the learner safely inside the ZPD; push
+// pulls the cap toward the harder edge.
+type ZPDAggressiveness string
+
+const (
+	ZPDAggressivenessGentle ZPDAggressiveness = "gentle"
+	ZPDAggressivenessNormal ZPDAggressiveness = "normal"
+	ZPDAggressivenessPush   ZPDAggressiveness = "push"
+)
+
+// FadeParams is the bundle returned by Decide. It is JSON-serialized
+// onto get_next_activity responses (under "fade_params") when
+// REGULATION_FADE=on, so downstream consumers — including the
+// scheduler that reads off of persisted state — can pick it up
+// without a second computation.
+type FadeParams struct {
+	HintLevel              HintLevel         `json:"hint_level"`
+	WebhookFrequency       WebhookFrequency  `json:"webhook_frequency"`
+	ZPDAggressiveness      ZPDAggressiveness `json:"zpd_aggressiveness"`
+	ProactiveReviewEnabled bool              `json:"proactive_review_enabled"`
+}
+
+// fadeTier is the internal coarse classification driving the four
+// output fields jointly. We map (score, trend) to a tier, then a tier
+// to FadeParams. This keeps the table small (3 tiers) and easy to
+// audit.
+type fadeTier int
+
+const (
+	tierLow fadeTier = iota
+	tierMid
+	tierHigh
+)
+
+// Decide is the pure mapping from autonomy state to fade parameters.
+//
+// Mapping (see docs/regulation-design/06-fade-controller.md §4):
+//
+//	tier base:     score < 0.3 -> Low, 0.3 <= score < 0.7 -> Mid,
+//	               score >= 0.7 -> High.
+//	trend modifier: improving -> +1 tier, stable -> 0, declining -> -1
+//	               tier (clamped to [Low, High]).
+//
+// Tier defaults (HintLevel, WebhookFrequency, ZPDAggressiveness,
+// ProactiveReviewEnabled):
+//
+//	Low  -> full,    daily,   gentle, true
+//	Mid  -> partial, weekly,  normal, true
+//	High -> none,    off,     push,   false
+//
+// Edge cases:
+//   - score < 0 or score > 1: clamped (Low / High respectively).
+//   - score = NaN: treated as Mid (NaN comparisons fall through both
+//     branches).
+//   - trend not in {"improving","stable","declining"}: treated as
+//     "stable".
+func Decide(score float64, trend AutonomyTrend) FadeParams {
+	base := tierFromScore(score)
+	final := applyTrend(base, trend)
+	return paramsForTier(final)
+}
+
+// tierFromScore is the score-only classification, before trend
+// modulation. Boundaries are inclusive at the lower bound (>= 0.3
+// is Mid, >= 0.7 is High). NaN inputs fall through both checks and
+// land in Mid.
+func tierFromScore(score float64) fadeTier {
+	// Defensive clamp first to avoid surprises on NaN+arithmetic
+	// downstream consumers might do.
+	if score < 0.3 {
+		// Includes negatives; explicit ordering means NaN does
+		// NOT enter this branch (NaN < 0.3 is false), so NaN
+		// continues to Mid below.
+		return tierLow
+	}
+	if score >= 0.7 {
+		return tierHigh
+	}
+	return tierMid
+}
+
+// applyTrend slides the base tier up/down by one cran depending on
+// the trend, clamping at the ends. Unknown trend strings degrade to
+// "stable" (no movement) by virtue of the switch's default branch.
+func applyTrend(base fadeTier, trend AutonomyTrend) fadeTier {
+	switch trend {
+	case AutonomyTrendImproving:
+		if base == tierHigh {
+			return tierHigh
+		}
+		return base + 1
+	case AutonomyTrendDeclining:
+		if base == tierLow {
+			return tierLow
+		}
+		return base - 1
+	default:
+		// Stable, "", or any other string: no movement.
+		return base
+	}
+}
+
+// paramsForTier maps the final tier to the bundle of four parameters.
+// The mapping is intentionally one-shot per tier — see OQ-6.3 in the
+// design doc for the rationale (vs per-field modulation).
+func paramsForTier(t fadeTier) FadeParams {
+	switch t {
+	case tierLow:
+		return FadeParams{
+			HintLevel:              HintLevelFull,
+			WebhookFrequency:       WebhookFrequencyDaily,
+			ZPDAggressiveness:      ZPDAggressivenessGentle,
+			ProactiveReviewEnabled: true,
+		}
+	case tierHigh:
+		return FadeParams{
+			HintLevel:              HintLevelNone,
+			WebhookFrequency:       WebhookFrequencyOff,
+			ZPDAggressiveness:      ZPDAggressivenessPush,
+			ProactiveReviewEnabled: false,
+		}
+	default:
+		// tierMid (and any unexpected fadeTier value, which the type
+		// system should prevent — but we degrade safely to Mid).
+		return FadeParams{
+			HintLevel:              HintLevelPartial,
+			WebhookFrequency:       WebhookFrequencyWeekly,
+			ZPDAggressiveness:      ZPDAggressivenessNormal,
+			ProactiveReviewEnabled: true,
+		}
+	}
+}

--- a/engine/fade_controller_test.go
+++ b/engine/fade_controller_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"math"
+	"testing"
+)
+
+// TestDecide_TierTable exercises the 9 cells of the (tier, trend)
+// table from docs/regulation-design/06-fade-controller.md §4.3.
+// Score is sampled at the middle of each tier (0.15, 0.5, 0.85) to
+// stay clear of boundary effects (boundaries are tested separately).
+func TestDecide_TierTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		score float64
+		trend AutonomyTrend
+		want  FadeParams
+	}{
+		// Low tier (score < 0.3)
+		{
+			name:  "Low/declining stays Low",
+			score: 0.15, trend: AutonomyTrendDeclining,
+			want: FadeParams{HintLevelFull, WebhookFrequencyDaily, ZPDAggressivenessGentle, true},
+		},
+		{
+			name:  "Low/stable stays Low",
+			score: 0.15, trend: AutonomyTrendStable,
+			want: FadeParams{HintLevelFull, WebhookFrequencyDaily, ZPDAggressivenessGentle, true},
+		},
+		{
+			name:  "Low/improving moves up to Mid",
+			score: 0.15, trend: AutonomyTrendImproving,
+			want: FadeParams{HintLevelPartial, WebhookFrequencyWeekly, ZPDAggressivenessNormal, true},
+		},
+
+		// Mid tier (0.3 <= score < 0.7)
+		{
+			name:  "Mid/declining falls to Low",
+			score: 0.5, trend: AutonomyTrendDeclining,
+			want: FadeParams{HintLevelFull, WebhookFrequencyDaily, ZPDAggressivenessGentle, true},
+		},
+		{
+			name:  "Mid/stable stays Mid",
+			score: 0.5, trend: AutonomyTrendStable,
+			want: FadeParams{HintLevelPartial, WebhookFrequencyWeekly, ZPDAggressivenessNormal, true},
+		},
+		{
+			name:  "Mid/improving moves up to High",
+			score: 0.5, trend: AutonomyTrendImproving,
+			want: FadeParams{HintLevelNone, WebhookFrequencyOff, ZPDAggressivenessPush, false},
+		},
+
+		// High tier (score >= 0.7)
+		{
+			name:  "High/declining falls to Mid",
+			score: 0.85, trend: AutonomyTrendDeclining,
+			want: FadeParams{HintLevelPartial, WebhookFrequencyWeekly, ZPDAggressivenessNormal, true},
+		},
+		{
+			name:  "High/stable stays High",
+			score: 0.85, trend: AutonomyTrendStable,
+			want: FadeParams{HintLevelNone, WebhookFrequencyOff, ZPDAggressivenessPush, false},
+		},
+		{
+			name:  "High/improving stays High (clamp)",
+			score: 0.85, trend: AutonomyTrendImproving,
+			want: FadeParams{HintLevelNone, WebhookFrequencyOff, ZPDAggressivenessPush, false},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Decide(tc.score, tc.trend)
+			if got != tc.want {
+				t.Fatalf("Decide(%v, %q) = %+v, want %+v", tc.score, tc.trend, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDecide_ScoreBoundaries verifies the inclusive-at-lower-bound
+// behaviour of the tier classifier and the clamp on out-of-range
+// inputs.
+func TestDecide_ScoreBoundaries(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		score    float64
+		wantHint HintLevel
+	}{
+		{"score=0.0 -> Low", 0.0, HintLevelFull},
+		{"score=0.299 -> Low", 0.299, HintLevelFull},
+		{"score=0.30 -> Mid", 0.30, HintLevelPartial},
+		{"score=0.5 -> Mid", 0.5, HintLevelPartial},
+		{"score=0.699 -> Mid", 0.699, HintLevelPartial},
+		{"score=0.70 -> High", 0.70, HintLevelNone},
+		{"score=1.0 -> High", 1.0, HintLevelNone},
+		{"score=-0.1 (clamp) -> Low", -0.1, HintLevelFull},
+		{"score=1.5 (clamp) -> High", 1.5, HintLevelNone},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Decide(tc.score, AutonomyTrendStable)
+			if got.HintLevel != tc.wantHint {
+				t.Fatalf("Decide(%v, stable).HintLevel = %q, want %q",
+					tc.score, got.HintLevel, tc.wantHint)
+			}
+		})
+	}
+}
+
+// TestDecide_NaNScore documents the NaN fallback (degrades to Mid).
+func TestDecide_NaNScore(t *testing.T) {
+	t.Parallel()
+	got := Decide(math.NaN(), AutonomyTrendStable)
+	if got.HintLevel != HintLevelPartial {
+		t.Fatalf("NaN score should degrade to Mid (partial hints), got %q", got.HintLevel)
+	}
+}
+
+// TestDecide_TrendDefensive verifies that unknown / mistyped trend
+// strings are treated as "stable" (no movement). Case-sensitive: the
+// canonical lower-case forms are the only ones that move the tier.
+func TestDecide_TrendDefensive(t *testing.T) {
+	t.Parallel()
+
+	defensiveTrends := []AutonomyTrend{
+		"",
+		"garbage",
+		"IMPROVING", // case-sensitive — not recognised
+		"Improving",
+		"stable ", // trailing space
+		"declining\n",
+	}
+
+	for _, tr := range defensiveTrends {
+		tr := tr
+		t.Run(string(tr), func(t *testing.T) {
+			t.Parallel()
+			// Mid tier base — defensive trend should keep it Mid.
+			got := Decide(0.5, tr)
+			want := FadeParams{HintLevelPartial, WebhookFrequencyWeekly, ZPDAggressivenessNormal, true}
+			if got != want {
+				t.Fatalf("Decide(0.5, %q) = %+v, want %+v (defensive trend should be stable)",
+					tr, got, want)
+			}
+		})
+	}
+}
+
+// TestDecide_Pure verifies determinism and absence of state: the
+// function must return the same FadeParams for the same inputs across
+// repeated calls.
+func TestDecide_Pure(t *testing.T) {
+	t.Parallel()
+
+	first := Decide(0.5, AutonomyTrendImproving)
+	for i := 0; i < 100; i++ {
+		got := Decide(0.5, AutonomyTrendImproving)
+		if got != first {
+			t.Fatalf("Decide is not deterministic: got %+v on iter %d, want %+v",
+				got, i, first)
+		}
+	}
+}
+
+// TestDecide_Monotonic asserts that, holding trend constant, as the
+// score rises through the tiers, HintLevel can only relax (full ->
+// partial -> none) and never re-tighten. This is the property the
+// integration test will rely on.
+func TestDecide_Monotonic(t *testing.T) {
+	t.Parallel()
+
+	hintRank := map[HintLevel]int{
+		HintLevelFull:    2,
+		HintLevelPartial: 1,
+		HintLevelNone:    0,
+	}
+
+	for _, trend := range []AutonomyTrend{AutonomyTrendDeclining, AutonomyTrendStable, AutonomyTrendImproving} {
+		var lastRank = 999
+		for s := 0.0; s <= 1.0; s += 0.05 {
+			fp := Decide(s, trend)
+			r := hintRank[fp.HintLevel]
+			if r > lastRank {
+				t.Fatalf("non-monotonic for trend=%q at score=%v: hint=%q rank=%d > lastRank=%d",
+					trend, s, fp.HintLevel, r, lastRank)
+			}
+			lastRank = r
+		}
+	}
+}

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -246,17 +246,81 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			plateauActive, len(sessionConcepts),
 		)
 
-		r, _ := jsonResult(map[string]any{
+		// [6] FadeController — post-decision module gated on
+		// REGULATION_FADE=on (default OFF). Maps autonomy
+		// score+trend to handover params (verbosity, webhook
+		// cadence, ZPD aggressiveness, proactive review). When
+		// the flag is OFF, the result JSON is byte-identical to
+		// the pre-fade behaviour: no fade_params key, no mutation
+		// of motivation_brief. See
+		// docs/regulation-design/06-fade-controller.md.
+		extra := map[string]any{}
+		if regulationFadeEnabled() {
+			autonomyMetrics := engine.ComputeAutonomyMetrics(engine.AutonomyInput{
+				Interactions:    allInteractions,
+				ConceptStates:   domainStates,
+				CalibrationBias: calibBias,
+				SessionGap:      2 * time.Hour,
+			})
+			trend := engine.AutonomyTrend(engine.ComputeAutonomyTrendExported(autonomyScores))
+			fadeParams := engine.Decide(autonomyMetrics.Score, trend)
+			motivationBrief = applyFadeToMotivation(motivationBrief, fadeParams.HintLevel)
+			extra["fade_params"] = fadeParams
+			extra["autonomy_score"] = autonomyMetrics.Score
+			extra["autonomy_trend"] = string(trend)
+		}
+
+		out := map[string]any{
 			"needs_domain_setup":        false,
 			"domain_id":                 domain.ID,
 			"activity":                  activity,
 			"session_concepts_done":     len(sessionConcepts),
 			"metacognitive_mirror":      mirror,
-			"tutor_mode":               tutorMode,
+			"tutor_mode":                tutorMode,
 			"active_misconceptions":     activeMisconceptions,
 			"known_misconception_types": knownMisconceptionTypes,
 			"motivation_brief":          motivationBrief,
-		})
+		}
+		for k, v := range extra {
+			out[k] = v
+		}
+		r, _ := jsonResult(out)
 		return r, nil, nil
 	})
+}
+
+// applyFadeToMotivation modulates a MotivationBrief based on the fade
+// HintLevel. The contract:
+//
+//   - HintLevelFull    : brief returned unchanged (legacy behaviour).
+//   - HintLevelPartial : Instruction is collapsed to a one-line
+//     concise form; structured fields (ValueFraming, ProgressDelta,
+//     etc.) are preserved so the LLM still has the context to weave
+//     in if it chooses, but the explicit phrasing guidance is shorter.
+//   - HintLevelNone    : Kind is cleared and Instruction is emptied.
+//     Per the system prompt, kind == "" means "no motivational
+//     preamble". Structured fields are also cleared to make the
+//     suppression unambiguous on the wire.
+//
+// Returns brief unchanged if it's nil or already silent (kind == "").
+func applyFadeToMotivation(brief *models.MotivationBrief, level engine.HintLevel) *models.MotivationBrief {
+	if brief == nil {
+		return brief
+	}
+	switch level {
+	case engine.HintLevelNone:
+		return &models.MotivationBrief{Kind: "", Instruction: ""}
+	case engine.HintLevelPartial:
+		if brief.Kind == "" {
+			return brief
+		}
+		// Replace the verbose tutor-direction Instruction with a
+		// terse one-liner. The kind + structured fields stay so
+		// downstream context is preserved.
+		clone := *brief
+		clone.Instruction = "Bref. Reste minimal."
+		return &clone
+	default: // HintLevelFull
+		return brief
+	}
 }

--- a/tools/activity_test.go
+++ b/tools/activity_test.go
@@ -4,6 +4,7 @@
 package tools
 
 import (
+	"fmt"
 	"testing"
 
 	"tutor-mcp/models"
@@ -73,5 +74,133 @@ func TestGetNextActivity_ForeignDomainFallsBackToSetup(t *testing.T) {
 	// Foreign learner should fall through to needs_domain_setup since resolveDomain rejects.
 	if out["needs_domain_setup"] != true {
 		t.Fatalf("expected setup fallback for foreign domain, got %v", out)
+	}
+}
+
+// TestGetNextActivity_FlagOff_NoFadeFields asserts the byte-equivalence
+// guarantee of the FadeController constraint: with REGULATION_FADE
+// unset (its default), the JSON returned by get_next_activity must
+// contain neither fade_params nor autonomy_score keys, and the
+// motivation_brief must be the legacy output untouched. This is the
+// "FadeController is post-decision and cannot affect orchestrator
+// outputs when the flag is off" invariant from the design doc.
+func TestGetNextActivity_FlagOff_NoFadeFields(t *testing.T) {
+	// Force flag OFF regardless of caller's environment so this test
+	// is robust to `REGULATION_FADE=on go test ./...` invocations.
+	t.Setenv("REGULATION_FADE", "")
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math")
+	cs := models.NewConceptState("L_owner", "a")
+	cs.PMastery = 0.5
+	_ = store.InsertConceptStateIfNotExists(cs)
+	_ = store.UpsertConceptState(cs)
+
+	res := callTool(t, deps, registerGetNextActivity, "L_owner", "get_next_activity",
+		map[string]any{"domain_id": d.ID})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+	for _, key := range []string{"fade_params", "autonomy_score", "autonomy_trend"} {
+		if _, ok := out[key]; ok {
+			t.Errorf("flag OFF: expected no %q key in output, got %v", key, out[key])
+		}
+	}
+}
+
+// TestGetNextActivity_FadeFlagOn_VerbosityDecreasesAsAutonomyRises is
+// the integration test required by the FadeController acceptance
+// criteria. We simulate a learner whose autonomy_score rises across
+// multiple sessions, call get_next_activity at successive points, and
+// assert that:
+//
+//   - fade_params is present in the JSON,
+//   - the hint_level transitions from "full" toward "none" as the
+//     score climbs,
+//   - the motivation_brief.instruction length is non-increasing along
+//     the sequence (verbosity monotonically drops).
+func TestGetNextActivity_FadeFlagOn_VerbosityDecreasesAsAutonomyRises(t *testing.T) {
+	t.Setenv("REGULATION_FADE", "on")
+
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math")
+	cs := models.NewConceptState("L_owner", "a")
+	cs.PMastery = 0.5
+	_ = store.InsertConceptStateIfNotExists(cs)
+	_ = store.UpsertConceptState(cs)
+
+	// Steps: at each step, seed enough affect rows to drive the
+	// autonomy_score to the target tier. We use direct UpsertAffectState
+	// per session, then patch autonomy_score via UpdateAffectAutonomyScore
+	// (the upsert path's CASE WHEN excluded.autonomy_score > 0 guard
+	// preserves the value we set).
+	steps := []struct {
+		name           string
+		affectScores   []float64 // newest-first; one row per session
+		wantHintAtMost int       // 2 = full, 1 = partial, 0 = none
+	}{
+		{"start: low autonomy", []float64{0.10, 0.10, 0.10}, 2},
+		{"climbing: mid autonomy", []float64{0.55, 0.50, 0.40, 0.20, 0.10, 0.10}, 1},
+		{"high autonomy + improving", []float64{0.95, 0.92, 0.90, 0.88, 0.30, 0.25, 0.20, 0.15, 0.10, 0.10}, 0},
+	}
+
+	hintRank := map[string]int{"full": 2, "partial": 1, "none": 0, "": 0}
+
+	prevInstrLen := -1
+	for stepIdx, st := range steps {
+		// Wipe prior affect rows to reseed the timeline cleanly per
+		// step — newest-first ordering of GetRecentAffectStates is
+		// driven by created_at, and re-using session IDs would upsert
+		// rather than insert.
+		raw := deps.Store.RawDB()
+		if _, err := raw.Exec(`DELETE FROM affect_states WHERE learner_id = ?`, "L_owner"); err != nil {
+			t.Fatalf("step %s: wipe affects: %v", st.name, err)
+		}
+
+		// Seed in reverse (oldest-first) so created_at ordering matches
+		// newest-first when read back.
+		for i := len(st.affectScores) - 1; i >= 0; i-- {
+			sid := fmt.Sprintf("S_%d_%d", stepIdx, i)
+			a := &models.AffectState{
+				LearnerID:     "L_owner",
+				SessionID:     sid,
+				Energy:        3,
+				AutonomyScore: st.affectScores[i],
+			}
+			if err := store.UpsertAffectState(a); err != nil {
+				t.Fatalf("step %s: upsert affect %s: %v", st.name, sid, err)
+			}
+			// CASE WHEN excluded.autonomy_score > 0: setting it
+			// directly via insert works for non-zero scores.
+		}
+
+		res := callTool(t, deps, registerGetNextActivity, "L_owner", "get_next_activity",
+			map[string]any{"domain_id": d.ID})
+		if res.IsError {
+			t.Fatalf("step %s: %q", st.name, resultText(res))
+		}
+		out := decodeResult(t, res)
+
+		fp, ok := out["fade_params"].(map[string]any)
+		if !ok {
+			t.Fatalf("step %s: expected fade_params, got %v", st.name, out)
+		}
+		gotHint, _ := fp["hint_level"].(string)
+		if hintRank[gotHint] > st.wantHintAtMost {
+			t.Errorf("step %s: hint_level=%q (rank %d), want at most rank %d",
+				st.name, gotHint, hintRank[gotHint], st.wantHintAtMost)
+		}
+
+		var instrLen int
+		if mb, ok := out["motivation_brief"].(map[string]any); ok {
+			if instr, ok := mb["instruction"].(string); ok {
+				instrLen = len(instr)
+			}
+		}
+		if prevInstrLen >= 0 && instrLen > prevInstrLen {
+			t.Errorf("step %s: motivation instruction length grew (was %d, now %d) — verbosity should be monotonically non-increasing as autonomy rises",
+				st.name, prevInstrLen, instrLen)
+		}
+		prevInstrLen = instrLen
 	}
 }

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -43,6 +43,20 @@ func regulationPhaseEnabled() bool {
 	return os.Getenv("REGULATION_PHASE") != "off"
 }
 
+// regulationFadeEnabled toggles the [6] FadeController post-decision
+// module in tools/activity.go. Default-OFF — the fade controller is
+// the youngest pipeline component and its visible effects (verbosity
+// reduction, webhook suppression) interact directly with the learner,
+// so opt-in until the eval harness validates the autonomy-tier
+// table. Strict equality with the literal "on" — same convention as
+// REGULATION_THRESHOLD: any other value (unset, "ON", "true", "1")
+// keeps the fader off.
+//
+// See docs/regulation-design/06-fade-controller.md.
+func regulationFadeEnabled() bool {
+	return os.Getenv("REGULATION_FADE") == "on"
+}
+
 const systemPrompt = `Tu es un tutor MCP — pas un assistant. Tu as un rôle précis.
 
 OUTILS DISPONIBLES :


### PR DESCRIPTION
## Summary

Implements the missing 7th component of the v0.3 regulation pipeline ([6] FadeController) as a pure post-decision module that maps `autonomy_score × trend` to a 4-field handover bundle. Wired into the motivation brief so verbosity decreases as the learner gains autonomy.

Closes the gap where `autonomy_score` was computed (`engine/metacognition.go`) but not consumed for verbosity / handover, and gives the "system progressively unnecessary" design intent a concrete implementation, both gated under `REGULATION_FADE=on`.

- Design doc + pure function `engine.Decide(score, trend) FadeParams` (no I/O, no clock, deterministic).
- Wiring in `tools/activity.go` post-`Orchestrate`, gated on the strict `REGULATION_FADE=on` literal (**default OFF**).
- `motivation_brief` verbosity is dialed by `HintLevel`; `fade_params` is also surfaced on the JSON for downstream consumers.
- Scheduler & action-selector consumption of `WebhookFrequency` / `ZPDAggressiveness` / `ProactiveReviewEnabled` deferred to follow-up (see design doc §9 OQ-6.1, OQ-6.2).

## Autonomy-tier table

Three score tiers (boundaries at 0.3 and 0.7); trend slides the tier ±1 (clamped):

| Score \ Trend  | declining | stable | improving |
|----------------|-----------|--------|-----------|
| **Low** (`<0.3`)    | Low  | Low  | Mid  |
| **Mid** (`0.3-0.7`) | Low  | Mid  | High |
| **High** (`>=0.7`)  | Mid  | High | High |

| Tier | HintLevel | WebhookFrequency | ZPDAggressiveness | ProactiveReviewEnabled |
|------|-----------|-------------------|-------------------|-------------------------|
| Low  | full      | daily             | gentle            | true  |
| Mid  | partial   | weekly            | normal            | true  |
| High | none      | off               | push              | false |

## Files

- **New** `docs/regulation-design/06-fade-controller.md` — design (~400 lines): scope, inputs/outputs, mapping table, edge cases (cold start, oscillation, NaN, defensive trend strings), feature-flag mechanism, test strategy, follow-up plan.
- **New** `engine/fade_controller.go` — `Decide` pure function + 4 enum types + `FadeParams` struct.
- **New** `engine/fade_controller_test.go` — table-tests covering the 9 cells, score boundaries, NaN, defensive trends, determinism, monotonicity.
- **Modified** `tools/prompt.go` — `regulationFadeEnabled()` accessor (strict `"on"` literal).
- **Modified** `tools/activity.go` — post-`Orchestrate` wiring, `applyFadeToMotivation` helper.
- **Modified** `tools/activity_test.go` — flag-OFF byte-equivalence test + integration test simulating rising autonomy.
- **Modified** `README.md` — line 89 status `Pending → Shipped (opt-in)`; flags table augmented with `REGULATION_FADE` and explanatory text.

## Acceptance criteria

- [x] `docs/regulation-design/06-fade-controller.md` written.
- [x] `engine/fade_controller.go` + unit tests (table-tests, boundaries, NaN, defensive trends).
- [x] Integration test: rising `autonomy_score` produces monotonically non-increasing motivation-brief verbosity (`TestGetNextActivity_FadeFlagOn_VerbosityDecreasesAsAutonomyRises`).
- [x] Flag `REGULATION_FADE=on` documented in README (default OFF, strict literal).
- [x] Non-regression test: with the flag off, `get_next_activity` JSON contains no `fade_params` / `autonomy_score` / `autonomy_trend` keys (`TestGetNextActivity_FlagOff_NoFadeFields`).
- [x] `go build ./... && go test ./...` PASS.
- [x] `REGULATION_FADE=on go test ./...` PASS.
- [ ] **Deferred to follow-up**: webhook scheduler integration of `WebhookFrequency` (requires schema migration — see design doc §9 OQ-6.1).
- [ ] **Deferred to follow-up**: action selector integration of `ZPDAggressiveness` (requires recalibrating IRT pCorrect target — see §9 OQ-6.2).
- [ ] **Deferred to follow-up**: re-run eval harness with `REGULATION_FADE=on` and publish verdict under `eval/`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (flag default OFF) — all packages green.
- [x] `REGULATION_FADE=on go test ./...` — all packages green; integration test exercises the on-path.
- [x] `go vet ./...` clean.
- [ ] Manual smoke: run `main.go` with `REGULATION_FADE=on`, call `get_next_activity` with a learner that has rising autonomy_score, verify `fade_params` appears in the response and `motivation_brief.instruction` shrinks.

Fixes #7
