### PR TITLE
chore(tools): restore French diacritics + document language conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,32 @@ main.go              HTTP server, MCP handler, OAuth, scheduler startup
 └── tools/                30 MCP tool handlers + system prompt + flag-gated appendices
 ```
 
+## Language conventions
+
+The codebase mixes English and French on purpose. The split is along a single
+axis: **who reads the string?**
+
+- **English** — everything developers and operators read: source code,
+  identifiers, comments, log messages, error returns surfaced to clients/CI,
+  this README and every doc under `docs/`. Keep `slog` calls, panics, and Go
+  errors in English.
+- **French** — everything the **learner** ends up seeing, directly or via the
+  LLM's routing/prompting layer:
+  - MCP tool descriptions and `jsonschema` parameter descriptions
+    (`tools/*.go`) — the LLM uses these to choose which tool to call, and
+    paraphrases them back to the learner.
+  - The system prompt (`tools/prompt.go`).
+  - OLM (open learner model) messages (`engine/olm.go`).
+  - Rationales the orchestrator surfaces to the learner
+    (`engine/orchestrator.go`).
+  - DB-stored literal strings that flow through to learner-facing UI
+    (`db/store.go`).
+
+When in doubt: if a string is destined for the learner, write it in correct
+French with full diacritics (`é`, `è`, `à`, `ç`, `ô`, `î`, …). The lint test
+in `tools/registration_test.go` enforces diacritic consistency across tool
+descriptions; widen it if you add new learner-facing surfaces.
+
 ## Running
 
 ### Setup workflow

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -17,13 +17,13 @@ import (
 )
 
 type GetNextActivityParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilise le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
 }
 
 func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_next_activity",
-		Description: "Determine la prochaine activite optimale pour l'apprenant selon son etat cognitif. Tient compte de la session en cours pour eviter de repeter le meme concept.",
+		Description: "Détermine la prochaine activité optimale pour l'apprenant selon son état cognitif. Tient compte de la session en cours pour éviter de répéter le même concept.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetNextActivityParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -39,8 +39,8 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 				"needs_domain_setup": true,
 				"activity": models.Activity{
 					Type:         models.ActivitySetupDomain,
-					Rationale:    "aucun domaine configure",
-					PromptForLLM: "L'apprenant n'a pas encore de domaine. Analyse son objectif, decompose-le en concepts et appelle init_domain().",
+					Rationale:    "aucun domaine configuré",
+					PromptForLLM: "L'apprenant n'a pas encore de domaine. Analyse son objectif, décompose-le en concepts et appelle init_domain().",
 				},
 			})
 			return r, nil, nil
@@ -187,7 +187,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 		case "scaffolding":
 			activity.DifficultyTarget *= 0.75
 		case "recontextualize":
-			activity.Rationale += " · recontextualisation demandee"
+			activity.Rationale += " · recontextualisation demandée"
 		}
 
 		// Apply calibration bias adjustment
@@ -222,7 +222,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 						misconceptionPrompt += " — " + m.LastErrorDetail
 					}
 				}
-				misconceptionPrompt += ". Cible ces confusions dans ton explication et ton exercice. Ne mentionne pas explicitement les misconceptions — concois l'exercice pour qu'il les confronte naturellement."
+				misconceptionPrompt += ". Cible ces confusions dans ton explication et ton exercice. Ne mentionne pas explicitement les misconceptions — conçois l'exercice pour qu'il les confronte naturellement."
 				activity.PromptForLLM += misconceptionPrompt
 			}
 

--- a/tools/affect.go
+++ b/tools/affect.go
@@ -17,17 +17,17 @@ import (
 
 type RecordAffectParams struct {
 	SessionID           string `json:"session_id" jsonschema:"Identifiant unique de la session"`
-	Energy              int    `json:"energy,omitempty" jsonschema:"Energie disponible: 1=fatigue, 2=neutre, 3=motive, 4=en feu"`
+	Energy              int    `json:"energy,omitempty" jsonschema:"Énergie disponible: 1=fatigué, 2=neutre, 3=motivé, 4=en feu"`
 	Confidence          int    `json:"confidence,omitempty" jsonschema:"Confiance sur le sujet: 1=anxieux, 2=flou, 3=ok, 4=confiant"`
 	Satisfaction        int    `json:"satisfaction,omitempty" jsonschema:"Ressenti global (fin de session): 1=frustrant, 2=difficile, 3=bien, 4=flow"`
-	PerceivedDifficulty int    `json:"perceived_difficulty,omitempty" jsonschema:"Difficulte percue (fin de session): 1=trop dur, 2=challengeant, 3=ok, 4=trop facile"`
+	PerceivedDifficulty int    `json:"perceived_difficulty,omitempty" jsonschema:"Difficulté perçue (fin de session): 1=trop dur, 2=challengeant, 3=ok, 4=trop facile"`
 	NextSessionIntent   int    `json:"next_session_intent,omitempty" jsonschema:"Prochaine session: 1=maintenant, 2=demain, 3=cette semaine, 4=je sais pas"`
 }
 
 func registerRecordAffect(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_affect",
-		Description: "Enregistre l'etat emotionnel de l'apprenant. Appeler en debut de session (energy, confidence) et en fin (satisfaction, perceived_difficulty, next_session_intent).",
+		Description: "Enregistre l'état émotionnel de l'apprenant. Appeler en début de session (energy, confidence) et en fin (satisfaction, perceived_difficulty, next_session_intent).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordAffectParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -14,13 +14,13 @@ import (
 )
 
 type GetPendingAlertsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilise le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
 }
 
 func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_pending_alerts",
-		Description: "Recupere les alertes en attente pour l'apprenant. Appeler en premier a chaque reponse.",
+		Description: "Récupère les alertes en attente pour l'apprenant. Appeler en premier à chaque réponse.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetPendingAlertsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/autonomy.go
+++ b/tools/autonomy.go
@@ -20,7 +20,7 @@ type GetAutonomyMetricsParams struct {
 func registerGetAutonomyMetrics(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_autonomy_metrics",
-		Description: "Score d'autonomie courant avec ses 4 composantes et la tendance. Consultable par l'apprenant et le systeme.",
+		Description: "Score d'autonomie courant avec ses 4 composantes et la tendance. Consultable par l'apprenant et le système.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetAutonomyMetricsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/availability.go
+++ b/tools/availability.go
@@ -19,7 +19,7 @@ type GetAvailabilityModelParams struct{}
 func registerGetAvailabilityModel(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_availability_model",
-		Description: "Recupere le modele de disponibilite de l'apprenant (creneaux, duree moyenne, frequence).",
+		Description: "Récupère le modèle de disponibilité de l'apprenant (créneaux, durée moyenne, fréquence).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetAvailabilityModelParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/calibration.go
+++ b/tools/calibration.go
@@ -16,15 +16,15 @@ import (
 )
 
 type CalibrationCheckParams struct {
-	ConceptID        string  `json:"concept_id" jsonschema:"Le concept a evaluer"`
-	PredictedMastery float64 `json:"predicted_mastery" jsonschema:"Auto-evaluation de l'apprenant: 1=aucune maitrise, 5=maitrise parfaite"`
+	ConceptID        string  `json:"concept_id" jsonschema:"Le concept à évaluer"`
+	PredictedMastery float64 `json:"predicted_mastery" jsonschema:"Auto-évaluation de l'apprenant: 1=aucune maîtrise, 5=maîtrise parfaite"`
 	DomainID         string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 }
 
 func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "calibration_check",
-		Description: "Enregistre l'auto-evaluation de l'apprenant sur un concept avant un exercice. Retourne un prediction_id pour comparaison post-exercice.",
+		Description: "Enregistre l'auto-évaluation de l'apprenant sur un concept avant un exercice. Retourne un prediction_id pour comparaison post-exercice.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CalibrationCheckParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -61,7 +61,7 @@ func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 		}
 
 		promptText := fmt.Sprintf(
-			"Tu as estime ta maitrise de '%s' a %.0f/5. Voyons ca avec un exercice.",
+			"Tu as estimé ta maîtrise de '%s' à %.0f/5. Voyons ça avec un exercice.",
 			params.ConceptID, params.PredictedMastery,
 		)
 
@@ -74,14 +74,14 @@ func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 }
 
 type RecordCalibrationResultParams struct {
-	PredictionID string  `json:"prediction_id" jsonschema:"ID de la prediction retournee par calibration_check"`
-	ActualScore  float64 `json:"actual_score" jsonschema:"Score reel entre 0 et 1 (0=echec total, 1=reussite parfaite)"`
+	PredictionID string  `json:"prediction_id" jsonschema:"ID de la prédiction retournée par calibration_check"`
+	ActualScore  float64 `json:"actual_score" jsonschema:"Score réel entre 0 et 1 (0=échec total, 1=réussite parfaite)"`
 }
 
 func registerRecordCalibrationResult(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_calibration_result",
-		Description: "Compare la prediction de l'apprenant avec le resultat reel. Met a jour le biais de calibration.",
+		Description: "Compare la prédiction de l'apprenant avec le résultat réel. Met à jour le biais de calibration.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordCalibrationResultParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/cockpit.go
+++ b/tools/cockpit.go
@@ -37,7 +37,7 @@ func cockpitUIMeta() mcp.Meta {
 
 type GetCockpitStateParams struct {
 	DomainID        string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si absent, affiche tous les domaines actifs."`
-	IncludeArchived bool   `json:"include_archived,omitempty" jsonschema:"Si true, inclut les domaines archives dans la reponse."`
+	IncludeArchived bool   `json:"include_archived,omitempty" jsonschema:"Si true, inclut les domaines archivés dans la réponse."`
 }
 
 type conceptProgress struct {
@@ -63,7 +63,7 @@ type domainCockpit struct {
 func registerGetCockpitState(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_cockpit_state",
-		Description: "Retourne l'etat brut du cockpit en JSON (progression par concept, alertes, signaux, prochaine action). USAGE PROGRAMMATIQUE — scripts d'eval, reporting. NE PAS UTILISER quand l'apprenant demande d'ouvrir/voir/afficher son cockpit : utiliser open_cockpit qui rend une UI native.",
+		Description: "Retourne l'état brut du cockpit en JSON (progression par concept, alertes, signaux, prochaine action). USAGE PROGRAMMATIQUE — scripts d'éval, reporting. NE PAS UTILISER quand l'apprenant demande d'ouvrir/voir/afficher son cockpit : utiliser open_cockpit qui rend une UI native.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetCockpitStateParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -100,11 +100,11 @@ func registerGetCockpitState(server *mcp.Server, deps *Deps) {
 			allDomains, err := deps.Store.GetDomainsByLearner(learnerID, params.IncludeArchived)
 			if err != nil {
 				deps.Logger.Error("get_cockpit_state: failed to get domains", "err", err, "learner", learnerID)
-				r, _ := errorResult("aucun domaine configure")
+				r, _ := errorResult("aucun domaine configuré")
 				return r, nil, nil
 			}
 			if len(allDomains) == 0 {
-				r, _ := errorResult("aucun domaine configure")
+				r, _ := errorResult("aucun domaine configuré")
 				return r, nil, nil
 			}
 			domains = allDomains
@@ -178,7 +178,7 @@ func registerGetCockpitState(server *mcp.Server, deps *Deps) {
 
 			// Next action for this domain
 			frontier := algorithms.ComputeFrontier(graph, mastery)
-			nextAction := "continuer la revision"
+			nextAction := "continuer la révision"
 			if len(frontier) > 0 {
 				nextAction = fmt.Sprintf("nouveau concept: %s", frontier[0])
 			}

--- a/tools/cockpit_test.go
+++ b/tools/cockpit_test.go
@@ -24,7 +24,7 @@ func TestGetCockpitState_NoAuth(t *testing.T) {
 func TestGetCockpitState_NoDomain(t *testing.T) {
 	_, deps := setupToolsTest(t)
 	res := callTool(t, deps, registerGetCockpitState, "L_owner", "get_cockpit_state", map[string]any{})
-	if !res.IsError || !strings.Contains(resultText(res), "aucun domaine configure") {
+	if !res.IsError || !strings.Contains(resultText(res), "aucun domaine configuré") {
 		t.Fatalf("got %q", resultText(res))
 	}
 }

--- a/tools/context.go
+++ b/tools/context.go
@@ -18,13 +18,13 @@ import (
 )
 
 type GetLearnerContextParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilise le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
 }
 
 func registerGetLearnerContext(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_learner_context",
-		Description: "Recupere le contexte complet de l'apprenant pour le debut de session.",
+		Description: "Récupère le contexte complet de l'apprenant pour le début de session.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetLearnerContextParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/domain.go
+++ b/tools/domain.go
@@ -75,23 +75,23 @@ func validateValueFramings(vf *ValueFramingsInput) error {
 
 type ValueFramingsInput struct {
 	Financial    string `json:"financial,omitempty" jsonschema:"Gain financier (1-2 phrases)"`
-	Employment   string `json:"employment,omitempty" jsonschema:"Gain employabilite / carriere (1-2 phrases)"`
+	Employment   string `json:"employment,omitempty" jsonschema:"Gain employabilité / carrière (1-2 phrases)"`
 	Intellectual string `json:"intellectual,omitempty" jsonschema:"Gain intellectuel / beau raisonnement (1-2 phrases)"`
-	Innovation   string `json:"innovation,omitempty" jsonschema:"Gain creation / innovation (1-2 phrases)"`
+	Innovation   string `json:"innovation,omitempty" jsonschema:"Gain création / innovation (1-2 phrases)"`
 }
 
 type InitDomainParams struct {
 	Name          string              `json:"name" jsonschema:"Nom du domaine d'apprentissage"`
 	Concepts      []string            `json:"concepts" jsonschema:"Liste des concepts du domaine"`
-	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Graphe de prerequis (concept -> liste de prerequis)"`
+	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Graphe de prérequis (concept -> liste de prérequis)"`
 	PersonalGoal  string              `json:"personal_goal,omitempty" jsonschema:"Objectif personnel de l'apprenant dans ce domaine (optionnel)"`
-	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 axes de valeur (financier/emploi/intellectuel/innovation). 1-2 phrases authored par axe. Optionnel — peut etre rempli a la volee par la suite."`
+	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 axes de valeur (financier/emploi/intellectuel/innovation). 1-2 phrases authored par axe. Optionnel — peut être rempli à la volée par la suite."`
 }
 
 func registerInitDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "init_domain",
-		Description: "Initialise un domaine d'apprentissage avec ses concepts et prerequis. Ne detruit pas la progression existante.",
+		Description: "Initialise un domaine d'apprentissage avec ses concepts et prérequis. Ne détruit pas la progression existante.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params InitDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -212,14 +212,14 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 
 type AddConceptsParams struct {
 	DomainID      string              `json:"domain_id" jsonschema:"ID du domaine cible"`
-	Concepts      []string            `json:"concepts" jsonschema:"Nouveaux concepts a ajouter"`
-	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Nouveaux prerequis (concept -> liste de prerequis). Peut inclure des liens vers des concepts existants."`
+	Concepts      []string            `json:"concepts" jsonschema:"Nouveaux concepts à ajouter"`
+	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Nouveaux prérequis (concept -> liste de prérequis). Peut inclure des liens vers des concepts existants."`
 }
 
 func registerAddConcepts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "add_concepts",
-		Description: "Ajoute des concepts a un domaine existant sans detruire la progression. Utiliser pour enrichir un domaine en cours de route.",
+		Description: "Ajoute des concepts à un domaine existant sans détruire la progression. Utiliser pour enrichir un domaine en cours de route.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AddConceptsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -14,14 +14,14 @@ import (
 )
 
 type FeynmanChallengeParams struct {
-	ConceptID string `json:"concept_id" jsonschema:"Le concept a expliquer avec la methode Feynman"`
+	ConceptID string `json:"concept_id" jsonschema:"Le concept à expliquer avec la méthode Feynman"`
 	DomainID  string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 }
 
 func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "feynman_challenge",
-		Description: "Demande a l'apprenant d'expliquer un concept maitrise avec ses propres mots. Le LLM identifie les gaps et les injecte dans le graphe BKT.",
+		Description: "Demande à l'apprenant d'expliquer un concept maîtrisé avec ses propres mots. Le LLM identifie les gaps et les injecte dans le graphe BKT.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params FeynmanChallengeParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -16,25 +16,25 @@ import (
 )
 
 type RecordInteractionParams struct {
-	Concept             string  `json:"concept" jsonschema:"Le concept concerne"`
-	ActivityType        string  `json:"activity_type" jsonschema:"Type d'activite (RECALL_EXERCISE, NEW_CONCEPT, etc.)"`
-	Success             bool    `json:"success" jsonschema:"L'exercice a ete reussi"`
-	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"Temps de reponse en secondes"`
-	Confidence          float64 `json:"confidence" jsonschema:"Confiance estimee entre 0 et 1"`
-	ErrorType           string  `json:"error_type,omitempty" jsonschema:"Type d'erreur si echec: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP (optionnel)"`
+	Concept             string  `json:"concept" jsonschema:"Le concept concerné"`
+	ActivityType        string  `json:"activity_type" jsonschema:"Type d'activité (RECALL_EXERCISE, NEW_CONCEPT, etc.)"`
+	Success             bool    `json:"success" jsonschema:"L'exercice a été réussi"`
+	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"Temps de réponse en secondes"`
+	Confidence          float64 `json:"confidence" jsonschema:"Confiance estimée entre 0 et 1"`
+	ErrorType           string  `json:"error_type,omitempty" jsonschema:"Type d'erreur si échec: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP (optionnel)"`
 	Notes               string  `json:"notes" jsonschema:"Notes optionnelles sur l'interaction"`
 	DomainID            string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
-	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"Nombre d'indices demandes pendant l'echange (optionnel, defaut 0)"`
-	SelfInitiated       bool    `json:"self_initiated,omitempty" jsonschema:"true si la session a demarre sans alerte webhook"`
-	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"ID de la prediction de calibration associee (optionnel)"`
-	MisconceptionType   string  `json:"misconception_type,omitempty" jsonschema:"Label libre de la misconception detectee (optionnel, ignore si success=true)"`
+	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"Nombre d'indices demandés pendant l'échange (optionnel, défaut 0)"`
+	SelfInitiated       bool    `json:"self_initiated,omitempty" jsonschema:"true si la session a démarré sans alerte webhook"`
+	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"ID de la prédiction de calibration associée (optionnel)"`
+	MisconceptionType   string  `json:"misconception_type,omitempty" jsonschema:"Label libre de la misconception détectée (optionnel, ignoré si success=true)"`
 	MisconceptionDetail string  `json:"misconception_detail,omitempty" jsonschema:"Description de la misconception en une phrase (optionnel)"`
 }
 
 func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_interaction",
-		Description: "Enregistre le resultat d'un exercice et met a jour l'etat cognitif de l'apprenant. Supporte error_type pour ajuster le BKT selon le type d'erreur.",
+		Description: "Enregistre le résultat d'un exercice et met à jour l'état cognitif de l'apprenant. Supporte error_type pour ajuster le BKT selon le type d'erreur.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordInteractionParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/manage_domain.go
+++ b/tools/manage_domain.go
@@ -12,13 +12,13 @@ import (
 )
 
 type ArchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine a archiver"`
+	DomainID string `json:"domain_id" jsonschema:"ID du domaine à archiver"`
 }
 
 func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "archive_domain",
-		Description: "Archive un domaine — il disparait du cockpit et du routing mais la progression est preservee. Utiliser unarchive_domain pour le reactiver.",
+		Description: "Archive un domaine — il disparaît du cockpit et du routing mais la progression est préservée. Utiliser unarchive_domain pour le réactiver.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ArchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -53,20 +53,20 @@ func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 			"archived":    true,
 			"domain_id":   domain.ID,
 			"domain_name": domain.Name,
-			"message":     fmt.Sprintf("Domaine '%s' archive. La progression est preservee. Utilise unarchive_domain pour le reactiver.", domain.Name),
+			"message":     fmt.Sprintf("Domaine '%s' archivé. La progression est préservée. Utilise unarchive_domain pour le réactiver.", domain.Name),
 		})
 		return r, nil, nil
 	})
 }
 
 type UnarchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine a reactiver"`
+	DomainID string `json:"domain_id" jsonschema:"ID du domaine à réactiver"`
 }
 
 func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "unarchive_domain",
-		Description: "Reactive un domaine archive — il reapparait dans le cockpit et le routing avec toute sa progression preservee.",
+		Description: "Réactive un domaine archivé — il réapparaît dans le cockpit et le routing avec toute sa progression préservée.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UnarchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -100,21 +100,21 @@ func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 			"archived":    false,
 			"domain_id":   domain.ID,
 			"domain_name": domain.Name,
-			"message":     fmt.Sprintf("Domaine '%s' reactive.", domain.Name),
+			"message":     fmt.Sprintf("Domaine '%s' réactivé.", domain.Name),
 		})
 		return r, nil, nil
 	})
 }
 
 type DeleteDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine a supprimer definitivement"`
-	Confirm  bool   `json:"confirm" jsonschema:"Doit etre true pour confirmer la suppression"`
+	DomainID string `json:"domain_id" jsonschema:"ID du domaine à supprimer définitivement"`
+	Confirm  bool   `json:"confirm" jsonschema:"Doit être true pour confirmer la suppression"`
 }
 
 func registerDeleteDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete_domain",
-		Description: "Supprime definitivement un domaine. Les concept_states et interactions sont preserves. Necessite confirm=true.",
+		Description: "Supprime définitivement un domaine. Les concept_states et interactions sont préservés. Nécessite confirm=true.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params DeleteDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/mastery.go
+++ b/tools/mastery.go
@@ -14,14 +14,14 @@ import (
 )
 
 type CheckMasteryParams struct {
-	Concept  string `json:"concept" jsonschema:"Le concept a verifier pour la maitrise"`
+	Concept  string `json:"concept" jsonschema:"Le concept à vérifier pour la maîtrise"`
 	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 }
 
 func registerCheckMastery(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "check_mastery",
-		Description: "Verifie si un concept est pret pour le mastery challenge (BKT >= 0.85).",
+		Description: "Vérifie si un concept est prêt pour le mastery challenge (BKT >= 0.85).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CheckMasteryParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/mirror.go
+++ b/tools/mirror.go
@@ -20,7 +20,7 @@ type GetMetacognitiveMirrorParams struct {
 func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_metacognitive_mirror",
-		Description: "Retourne un message miroir factuel si un pattern de dependance est consolide. Null sinon.",
+		Description: "Retourne un message miroir factuel si un pattern de dépendance est consolidé. Null sinon.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMetacognitiveMirrorParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/misconceptions.go
+++ b/tools/misconceptions.go
@@ -21,7 +21,7 @@ type GetMisconceptionsParams struct {
 func registerGetMisconceptions(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_misconceptions",
-		Description: "Liste les misconceptions detectees par concept, avec leur statut (active/resolved) et frequence. Permet de suivre les confusions recurrentes de l'apprenant.",
+		Description: "Liste les misconceptions détectées par concept, avec leur statut (active/resolved) et fréquence. Permet de suivre les confusions récurrentes de l'apprenant.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMisconceptionsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -18,7 +18,7 @@ import (
 
 type LearningNegotiationParams struct {
 	SessionID        string `json:"session_id" jsonschema:"ID de la session courante"`
-	LearnerConcept   string `json:"learner_concept,omitempty" jsonschema:"Concept propose par l'apprenant (optionnel)"`
+	LearnerConcept   string `json:"learner_concept,omitempty" jsonschema:"Concept proposé par l'apprenant (optionnel)"`
 	LearnerRationale string `json:"learner_rationale,omitempty" jsonschema:"Justification de l'apprenant (optionnel)"`
 	DomainID         string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 }
@@ -33,7 +33,7 @@ type tradeoff struct {
 func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "learning_negotiation",
-		Description: "Expose le plan de session avec justifications. L'apprenant peut proposer une alternative — le systeme accepte ou explique les compromis.",
+		Description: "Expose le plan de session avec justifications. L'apprenant peut proposer une alternative — le système accepte ou explique les compromis.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params LearningNegotiationParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/olm.go
+++ b/tools/olm.go
@@ -12,14 +12,14 @@ import (
 )
 
 type GetOLMSnapshotParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilise le dernier domaine actif si absent)"`
-	Scope    string `json:"scope,omitempty" jsonschema:"'session' (defaut, snapshot d'un domaine), 'global' (agregation multi-domaine), ou 'graph' (OLMGraph complet d'un domaine — utilise par le cockpit pour switcher entre domaines actifs)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine actif si absent)"`
+	Scope    string `json:"scope,omitempty" jsonschema:"'session' (défaut, snapshot d'un domaine), 'global' (agrégation multi-domaine), ou 'graph' (OLMGraph complet d'un domaine — utilisé par le cockpit pour switcher entre domaines actifs)"`
 }
 
 func registerGetOLMSnapshot(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_olm_snapshot",
-		Description: "Retourne un snapshot transparent de l'etat d'apprentissage : distribution mastery, concept en focus, signaux metacognitifs actifs, progression vers le goal. Apprenant et tuteur regardent les memes donnees. Appeler avant queue_webhook_message(kind='olm:<domain_id>') ou pour reflet metacognitif en session.",
+		Description: "Retourne un snapshot transparent de l'état d'apprentissage : distribution mastery, concept en focus, signaux métacognitifs actifs, progression vers le goal. Apprenant et tuteur regardent les mêmes données. Appeler avant queue_webhook_message(kind='olm:<domain_id>') ou pour reflet métacognitif en session.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetOLMSnapshotParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/profile.go
+++ b/tools/profile.go
@@ -14,20 +14,20 @@ import (
 
 type UpdateLearnerProfileParams struct {
 	Device          string  `json:"device,omitempty" jsonschema:"Appareil principal (ex: laptop, phone, tablet)"`
-	Background      string  `json:"background,omitempty" jsonschema:"Contexte professionnel ou academique de l'apprenant"`
-	Style           string  `json:"learning_style,omitempty" jsonschema:"Style d'apprentissage prefere (ex: visuel, pratique, theorique)"`
-	Objective       string  `json:"objective,omitempty" jsonschema:"Objectif d'apprentissage mis a jour"`
-	Language        string  `json:"language,omitempty" jsonschema:"Langue preferee pour les exercices"`
-	Level           string  `json:"level,omitempty" jsonschema:"Niveau actuel (debutant, intermediaire, avance)"`
-	CalibrationBias float64 `json:"calibration_bias,omitempty" jsonschema:"Biais de calibration (positif=sur-estime, negatif=sous-estime)"`
-	AffectBaseline  string  `json:"affect_baseline,omitempty" jsonschema:"Baseline emotionnelle de l'apprenant"`
+	Background      string  `json:"background,omitempty" jsonschema:"Contexte professionnel ou académique de l'apprenant"`
+	Style           string  `json:"learning_style,omitempty" jsonschema:"Style d'apprentissage préféré (ex: visuel, pratique, théorique)"`
+	Objective       string  `json:"objective,omitempty" jsonschema:"Objectif d'apprentissage mis à jour"`
+	Language        string  `json:"language,omitempty" jsonschema:"Langue préférée pour les exercices"`
+	Level           string  `json:"level,omitempty" jsonschema:"Niveau actuel (débutant, intermédiaire, avancé)"`
+	CalibrationBias float64 `json:"calibration_bias,omitempty" jsonschema:"Biais de calibration (positif=sur-estimé, négatif=sous-estimé)"`
+	AffectBaseline  string  `json:"affect_baseline,omitempty" jsonschema:"Baseline émotionnelle de l'apprenant"`
 	AutonomyScore   float64 `json:"autonomy_score,omitempty" jsonschema:"Score d'autonomie actuel (0-1)"`
 }
 
 func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_learner_profile",
-		Description: "Met a jour les metadonnees persistantes de l'apprenant (device, background, style, objectif, niveau). Seuls les champs fournis sont modifies.",
+		Description: "Met à jour les métadonnées persistantes de l'apprenant (device, background, style, objectif, niveau). Seuls les champs fournis sont modifiés.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UpdateLearnerProfileParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -43,112 +43,112 @@ func regulationPhaseEnabled() bool {
 	return os.Getenv("REGULATION_PHASE") != "off"
 }
 
-const systemPrompt = `Tu es un tutor MCP — pas un assistant. Tu as un role precis.
+const systemPrompt = `Tu es un tutor MCP — pas un assistant. Tu as un rôle précis.
 
 OUTILS DISPONIBLES :
 - get_learner_context(domain_id?) : contexte de session, liste des domaines, progress_narrative
 - get_pending_alerts(domain_id?) : alertes critiques
-- get_next_activity(domain_id?) : prochaine activite optimale + miroir metacognitif + tutor_mode + motivation_brief
-- record_interaction(concept, success, confidence, error_type?, hints_requested?, self_initiated?, calibration_id?, domain_id?) : enregistre + met a jour BKT/FSRS/IRT/PFA
-- record_affect(session_id, energy?, confidence?, satisfaction?, perceived_difficulty?, next_session_intent?) : check-in emotionnel debut/fin de session
-- record_session_close(domain_id?, implementation_intention?) : cloture la session, retourne recap_brief (wins, struggles, prompt_for_implementation_intent)
+- get_next_activity(domain_id?) : prochaine activité optimale + miroir métacognitif + tutor_mode + motivation_brief
+- record_interaction(concept, success, confidence, error_type?, hints_requested?, self_initiated?, calibration_id?, domain_id?) : enregistre + met à jour BKT/FSRS/IRT/PFA
+- record_affect(session_id, energy?, confidence?, satisfaction?, perceived_difficulty?, next_session_intent?) : check-in émotionnel début/fin de session
+- record_session_close(domain_id?, implementation_intention?) : clôture la session, retourne recap_brief (wins, struggles, prompt_for_implementation_intent)
 - queue_webhook_message(kind, scheduled_for, content, expires_at?, priority?) : mettre en queue un nudge que le scheduler postera sur le webhook Discord (daily_motivation | daily_recap | reactivation | reminder)
-- calibration_check(concept_id, predicted_mastery, domain_id?) : auto-evaluation avant exercice
-- record_calibration_result(prediction_id, actual_score) : compare prediction vs resultat
+- calibration_check(concept_id, predicted_mastery, domain_id?) : auto-évaluation avant exercice
+- record_calibration_result(prediction_id, actual_score) : compare prédiction vs résultat
 - get_autonomy_metrics(domain_id?) : score d'autonomie et ses 4 composantes
-- get_metacognitive_mirror(domain_id?) : message miroir factuel si pattern consolide
-- check_mastery(concept, domain_id?) : verifie si mastery challenge eligible
-- feynman_challenge(concept_id, domain_id?) : methode Feynman — expliquer pour identifier les gaps
+- get_metacognitive_mirror(domain_id?) : message miroir factuel si pattern consolidé
+- check_mastery(concept, domain_id?) : vérifie si mastery challenge éligible
+- feynman_challenge(concept_id, domain_id?) : méthode Feynman — expliquer pour identifier les gaps
 - transfer_challenge(concept_id, context_type?, domain_id?) : tester le transfert hors contexte
-- record_transfer_result(concept_id, context_type, score, session_id?) : enregistrer le resultat du transfert
-- learning_negotiation(session_id, learner_concept?, learner_rationale?, domain_id?) : negocier le plan de session
+- record_transfer_result(concept_id, context_type, score, session_id?) : enregistrer le résultat du transfert
+- learning_negotiation(session_id, learner_concept?, learner_rationale?, domain_id?) : négocier le plan de session
 - get_cockpit_state(domain_id?) : dashboard complet + autonomie + calibration + affect
-- get_availability_model() : creneaux et frequence
-- init_domain(name, concepts, prerequisites, personal_goal?, value_framings?) : cree un domaine (value_framings = 4 axes de gain: financial/employment/intellectual/innovation)
+- get_availability_model() : créneaux et fréquence
+- init_domain(name, concepts, prerequisites, personal_goal?, value_framings?) : crée un domaine (value_framings = 4 axes de gain: financial/employment/intellectual/innovation)
 - add_concepts(domain_id?, concepts, prerequisites) : ajoute des concepts
-- update_learner_profile(device?, background?, learning_style?, objective?, language?, level?, calibration_bias?, affect_baseline?, autonomy_score?) : metadonnees persistantes
-- get_misconceptions(domain_id?, concept?) : liste les misconceptions detectees par concept
+- update_learner_profile(device?, background?, learning_style?, objective?, language?, level?, calibration_bias?, affect_baseline?, autonomy_score?) : métadonnées persistantes
+- get_misconceptions(domain_id?, concept?) : liste les misconceptions détectées par concept
 
-REGLES ABSOLUES — a chaque reponse, dans cet ordre :
+REGLES ABSOLUES — à chaque réponse, dans cet ordre :
 
 1. DEBUT DE SESSION
    → Appelle get_learner_context()
-   → Genere un session_id unique pour cette session
-   → Appelle record_affect(session_id, energy, confidence) avec le check-in de debut
-   → Si needs_domain_setup : analyse l'objectif, decompose en concepts, appelle init_domain()
-   → Presente le contexte et propose de commencer
+   → Génère un session_id unique pour cette session
+   → Appelle record_affect(session_id, energy, confidence) avec le check-in de début
+   → Si needs_domain_setup : analyse l'objectif, décompose en concepts, appelle init_domain()
+   → Présente le contexte et propose de commencer
    → Si l'apprenant donne des infos sur lui, appelle update_learner_profile()
 
 2. AVANT CHAQUE EXERCICE
    → Appelle get_pending_alerts(domain_id)
-   → Si alert critique : agis dessus en priorite
+   → Si alert critique : agis dessus en priorité
    → Sinon : appelle get_next_activity(domain_id) — contient miroir + tutor_mode
    → Si tutor_mode != normal : adapte ton registre (scaffolding/lighter/recontextualize)
-   → Si metacognitive_mirror est present : transmets le message tel quel, sans reformuler
+   → Si metacognitive_mirror est présent : transmets le message tel quel, sans reformuler
    → Appelle calibration_check(concept_id, predicted_mastery) avant l'exercice
-     (demande a l'apprenant d'estimer sa maitrise 1-5)
+     (demande à l'apprenant d'estimer sa maîtrise 1-5)
 
 3. APRES CHAQUE EXERCICE
    → Appelle record_calibration_result(prediction_id, actual_score)
    → Appelle record_interaction() avec hints_requested et self_initiated
-   → Ne genere jamais d'exercice sans avoir enregistre le precedent
+   → Ne génère jamais d'exercice sans avoir enregistré le précédent
 
 4. FIN DE SESSION
    → Appelle record_affect(session_id, satisfaction, perceived_difficulty, next_session_intent)
-   → Reagis au calibration_bias_delta retourne
+   → Réagis au calibration_bias_delta retourné
    → Appelle record_session_close(domain_id) — lit les signaux pour le mot de fin
-   → Si recap_brief.prompt_for_implementation_intent : pose UNE question concrete
-     ("Quand et ou tu pratiques ensuite ?") et rappelle record_session_close avec implementation_intention
+   → Si recap_brief.prompt_for_implementation_intent : pose UNE question concrète
+     ("Quand et où tu pratiques ensuite ?") et rappelle record_session_close avec implementation_intention
    → Puis appelle queue_webhook_message 2x : (a) daily_motivation pour demain 8h UTC,
-     (b) daily_recap pour demain 21h UTC. Textes chaleureux, relies au personal_goal,
-     max ~300 caracteres chacun. JAMAIS de %reussite brut ni de KPI sec — ton de mentor, pas d'analytics.
+     (b) daily_recap pour demain 21h UTC. Textes chaleureux, reliés au personal_goal,
+     max ~300 caractères chacun. JAMAIS de %réussite brut ni de KPI sec — ton de mentor, pas d'analytics.
 
 5. ENRICHISSEMENT DU DOMAINE
-   → Si l'apprenant decouvre un concept non prevu, utilise add_concepts()
+   → Si l'apprenant découvre un concept non prévu, utilise add_concepts()
    → Ne rappelle jamais init_domain() pour ajouter des concepts
 
 6. COCKPIT
    → Si l'apprenant demande sa progression
    → Appelle get_cockpit_state() — inclut autonomie, calibration, affect
-   → Genere l'interface visuelle complete
+   → Génère l'interface visuelle complète
 
 7. AUTONOMIE
    → Si l'apprenant demande son autonomie : appelle get_autonomy_metrics()
-   → Si l'apprenant veut negocier le plan : appelle learning_negotiation()
-   → Les negotiations acceptees comptent comme self_initiated
+   → Si l'apprenant veut négocier le plan : appelle learning_negotiation()
+   → Les négotiations acceptées comptent comme self_initiated
 
 8. FEYNMAN & TRANSFERT
    → Sur MASTERY_READY : propose feynman_challenge() ou transfer_challenge()
-   → Sur TRANSFER_BLOCKED : declenche feynman_challenge()
-   → Apres un feynman_challenge : demande confirmation avant d'injecter les gaps via add_concepts()
+   → Sur TRANSFER_BLOCKED : déclenche feynman_challenge()
+   → Après un feynman_challenge : demande confirmation avant d'injecter les gaps via add_concepts()
 
 9. MIROIR METACOGNITIF
    → Le miroir est factuel, jamais normatif — transmets sans juger
    → Toujours termine par la question ouverte — ne la remplace pas
-   → Ne s'active que sur patterns consolides (3+ sessions)
+   → Ne s'active que sur patterns consolidés (3+ sessions)
 
 10. COUCHE MOTIVATION (motivation_brief + progress_narrative)
-    → Si motivation_brief.kind != "" : integre le signal dans ton message, jamais en paragraphe separe.
-      Ne recite jamais les champs verbatim, traduis en langage naturel.
+    → Si motivation_brief.kind != "" : intègre le signal dans ton message, jamais en paragraphe séparé.
+      Ne récite jamais les champs verbatim, traduis en langage naturel.
       - why_this_exercise : relie exercice → concept → goal_link en UNE phrase
       - competence_value : rappelle le gain sur value_framing.axis (financial/employment/intellectual/innovation)
-        en UNE phrase reliee au concept. Pas de chiffres invente. Si statement est fourni, inspire-t'en sans copier
-      - growth_mindset : reframe l'echec en effort/strategie (hints utilises, auto-correction), jamais en aptitude
-      - affect_reframe : valide l'emotion (frustration/fatigue) PUIS reframe court
-      - milestone : celebre brievement, sans emphase
-      - plateau_recontext : propose un angle d'attaque different
-    → Si motivation_brief.kind == "" : fais l'exercice sans preambule motivationnel — le silence est un choix
-    → Si progress_narrative present : ouvre la session par 1-2 phrases racontant la trajectoire.
+        en UNE phrase reliée au concept. Pas de chiffres inventés. Si statement est fourni, inspire-t'en sans copier
+      - growth_mindset : reframe l'échec en effort/stratégie (hints utilisés, auto-correction), jamais en aptitude
+      - affect_reframe : valide l'émotion (frustration/fatigue) PUIS reframe court
+      - milestone : célèbre brièvement, sans emphase
+      - plateau_recontext : propose un angle d'attaque différent
+    → Si motivation_brief.kind == "" : fais l'exercice sans préambule motivationnel — le silence est un choix
+    → Si progress_narrative présent : ouvre la session par 1-2 phrases racontant la trajectoire.
       Si dormancy_imminent : ton accueillant, aucun reproche
     → Ne surcharge pas : un seul angle motivationnel par message
 
 11. COMPORTEMENT
-    → Tu ne laisses pas l'apprenant deriver de sa trajectoire
+    → Tu ne laisses pas l'apprenant dériver de sa trajectoire
     → Tu confirmes explicitement quand la trajectoire est bonne
     → Tu n'expliques jamais tes raisonnements algorithmiques
-    → Tu parles comme un coach — direct, precis, sans fioriture
-    → Tu ne poses jamais plus d'une question a la fois
-    → Tu vises a te rendre progressivement inutile`
+    → Tu parles comme un coach — direct, précis, sans fioriture
+    → Tu ne poses jamais plus d'une question à la fois
+    → Tu vises à te rendre progressivement inutile`
 
 // goalDecomposerAppendix is appended to systemPrompt when REGULATION_GOAL=on.
 // It documents the two new MCP tools surfaced by component [1] of the
@@ -172,15 +172,15 @@ Quand appeler set_goal_relevance :
 const actionSelectorAppendix = `
 
 ACTION-AWARE (REGULATION_ACTION=on) :
-4 nouveaux types d'activite peuvent etre emis par get_next_activity quand l'orchestrateur de regulation est cable :
-- PRACTICE : exercice standard de pratique. La difficulte cible la ZPD via IRT (pCorrect ~ 0.70).
-- DEBUG_MISCONCEPTION : confronte une croyance fausse detectee. Distinct de DEBUGGING_CASE qui sert a casser un plateau via la variete de format ; ici la confrontation est ciblee sur la misconception active.
-- FEYNMAN_PROMPT : l'apprenant explique le concept pour consolider la maitrise et reveler les gaps residuels.
+4 nouveaux types d'activité peuvent être émis par get_next_activity quand l'orchestrateur de régulation est câblé :
+- PRACTICE : exercice standard de pratique. La difficulté cible la ZPD via IRT (pCorrect ~ 0.70).
+- DEBUG_MISCONCEPTION : confronte une croyance fausse détectée. Distinct de DEBUGGING_CASE qui sert à casser un plateau via la variété de format ; ici la confrontation est ciblée sur la misconception active.
+- FEYNMAN_PROMPT : l'apprenant explique le concept pour consolider la maîtrise et révéler les gaps résiduels.
 - TRANSFER_PROBE : application dans un contexte nouveau pour tester le transfert hors de la situation initiale.
 
-Cascade interne (a titre informatif, [5] decide pour toi) :
-- misconception active > retention basse > brackets de mastery (0.30 / 0.70 / 0.85 stable sur N=3 interactions).
-- En haut de l'echelle, rotation MasteryChallenge -> Feynman -> Transfer -> cycle.`
+Cascade interne (à titre informatif, [5] décide pour toi) :
+- misconception active > rétention basse > brackets de mastery (0.30 / 0.70 / 0.85 stable sur N=3 interactions).
+- En haut de l'échelle, rotation MasteryChallenge -> Feynman -> Transfer -> cycle.`
 
 // conceptSelectorAppendix is appended to systemPrompt when REGULATION_CONCEPT=on.
 // It documents the goal-aware concept routing introduced by [4]
@@ -193,17 +193,17 @@ const conceptSelectorAppendix = `
 CONCEPT-AWARE (REGULATION_CONCEPT=on) :
 Le composant [4] ConceptSelector choisit le prochain concept en fonction de la phase courante et du vecteur goal_relevance.
 
-Cascade interne par phase (informatif, [4] decide pour toi) :
-- INSTRUCTION (defaut) : argmax(goal_relevance × (1 - mastery)) sur la frange externe (prereqs satisfaits, mastery < seuil unifie).
-- MAINTENANCE : argmax((1 - retention) × goal_relevance) sur les concepts maitrises.
-- DIAGNOSTIC : argmax(BKT info-gain) sur les concepts non-satures (v1 ignore goal_relevance).
+Cascade interne par phase (informatif, [4] décide pour toi) :
+- INSTRUCTION (défaut) : argmax(goal_relevance × (1 - mastery)) sur la frange externe (prereqs satisfaits, mastery < seuil unifié).
+- MAINTENANCE : argmax((1 - retention) × goal_relevance) sur les concepts maîtrisés.
+- DIAGNOSTIC : argmax(BKT info-gain) sur les concepts non-saturés (v1 ignore goal_relevance).
 
 CONTRAT IMPORTANT — concepts non couverts par set_goal_relevance :
-Les concepts presents dans le graphe mais ABSENTS du vecteur goal_relevance ne sont PAS selectionnables. Ils sont exclus de la frange et de la pool MAINTENANCE. Si la frange devient vide ainsi (NoFringe), l'orchestrateur le signale et tu dois :
+Les concepts présents dans le graphe mais ABSENTS du vecteur goal_relevance ne sont PAS sélectionnables. Ils sont exclus de la frange et de la pool MAINTENANCE. Si la frange devient vide ainsi (NoFringe), l'orchestrateur le signale et tu dois :
 1. Appeler get_goal_relevance pour identifier les concepts manquants (champ uncovered_concepts).
 2. Appeler set_goal_relevance avec un score pour chacun.
 
-C'est la regle apres tout add_concepts : les nouveaux concepts ne deviennent eligibles qu'apres decomposition. Aucun defaut silencieux n'est applique — c'est intentionnel pour rendre le contrat decomposeur explicite.`
+C'est la règle après tout add_concepts : les nouveaux concepts ne deviennent éligibles qu'après décomposition. Aucun défaut silencieux n'est appliqué — c'est intentionnel pour rendre le contrat décomposeur explicite.`
 
 // gateAppendix is appended to systemPrompt when REGULATION_GATE=on.
 // Documents the visible effects of [3] Gate Controller (the new
@@ -212,18 +212,18 @@ C'est la regle apres tout add_concepts : les nouveaux concepts ne deviennent eli
 const gateAppendix = `
 
 GATE-AWARE (REGULATION_GATE=on) :
-Le composant [3] Gate Controller filtre les candidats avant le routage. Trois nouveautes visibles cote LLM :
+Le composant [3] Gate Controller filtre les candidats avant le routage. Trois nouveautés visibles côté LLM :
 
-1. Nouveau type d'activite : CLOSE_SESSION
-   Emis quand l'apprenant a depasse la duree maximum de session (alerte OVERLOAD, ~45 min).
-   Distinction semantique avec REST :
-   - REST = pause INTRA-session ; l'apprenant continuera apres dans la meme session.
-   - CLOSE_SESSION = fin de session forcee ; emets le recap_brief et appelle record_session_close.
-   Quand tu recois CLOSE_SESSION, ne propose pas un nouvel exercice — la session se termine.
+1. Nouveau type d'activité : CLOSE_SESSION
+   Émis quand l'apprenant a dépassé la durée maximum de session (alerte OVERLOAD, ~45 min).
+   Distinction sémantique avec REST :
+   - REST = pause INTRA-session ; l'apprenant continuera après dans la même session.
+   - CLOSE_SESSION = fin de session forcée ; émets le recap_brief et appelle record_session_close.
+   Quand tu reçois CLOSE_SESSION, ne propose pas un nouvel exercice — la session se termine.
 
-2. Vetos de selection (transparents pour toi) : le Gate exclut certains concepts du pool sur la base de prereqs KST non satisfaits, repetitions recentes (sauf alerte FORGETTING qui passe outre, et sauf misconception active qui passe outre aussi), et OVERLOAD. Tu n'as rien a faire de specifique — la liste des concepts disponibles arrive deja filtree.
+2. Vétos de sélection (transparents pour toi) : le Gate exclut certains concepts du pool sur la base de prereqs KST non satisfaits, répétitions récentes (sauf alerte FORGETTING qui passe outre, et sauf misconception active qui passe outre aussi), et OVERLOAD. Tu n'as rien à faire de spécifique — la liste des concepts disponibles arrive déjà filtrée.
 
-3. Misconception lock : si un concept est ramene avec ActivityType=DEBUG_MISCONCEPTION, c'est que le Gate a verrouille ce concept sur le format debug. Concentre l'echange sur la confrontation de l'erreur — pas de pratique standard tant que la misconception n'est pas resolue (resolution = 3 interactions consecutives sans cette misconception).`
+3. Misconception lock : si un concept est ramené avec ActivityType=DEBUG_MISCONCEPTION, c'est que le Gate a verrouillé ce concept sur le format debug. Concentre l'échange sur la confrontation de l'erreur — pas de pratique standard tant que la misconception n'est pas résolue (résolution = 3 interactions consécutives sans cette misconception).`
 
 // buildSystemPrompt assembles the prompt at request time so that flag-gated
 // sections (goal-aware tools, future regulation components) appear only

--- a/tools/queue_webhook.go
+++ b/tools/queue_webhook.go
@@ -17,10 +17,10 @@ import (
 
 type QueueWebhookMessageParams struct {
 	Kind         string `json:"kind" jsonschema:"Type de nudge : daily_motivation | daily_recap | reactivation | reminder"`
-	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 timestamp UTC de la fenetre de tir (ex: 2026-04-13T08:00:00Z)"`
-	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 timestamp UTC apres lequel le message ne doit plus etre envoye"`
-	Content      string `json:"content" jsonschema:"Contenu Markdown pret a poster sur le webhook Discord (max ~300 caracteres recommande)"`
-	Priority     int    `json:"priority,omitempty" jsonschema:"Priorite (plus grand = plus prioritaire, defaut 0)"`
+	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 timestamp UTC de la fenêtre de tir (ex: 2026-04-13T08:00:00Z)"`
+	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 timestamp UTC après lequel le message ne doit plus être envoyé"`
+	Content      string `json:"content" jsonschema:"Contenu Markdown prêt à poster sur le webhook Discord (max ~300 caractères recommandé)"`
+	Priority     int    `json:"priority,omitempty" jsonschema:"Priorité (plus grand = plus prioritaire, défaut 0)"`
 }
 
 const maxWebhookContentLen = 1500
@@ -28,7 +28,7 @@ const maxWebhookContentLen = 1500
 func registerQueueWebhookMessage(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "queue_webhook_message",
-		Description: "Met en queue un message de nudge que le scheduler postera sur le webhook Discord de l'apprenant a la fenetre voulue. Le LLM compose le texte (chaleureux, sans KPI brut) ; le scheduler dispatche.",
+		Description: "Met en queue un message de nudge que le scheduler postera sur le webhook Discord de l'apprenant à la fenêtre voulue. Le LLM compose le texte (chaleureux, sans KPI brut) ; le scheduler dispatche.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params QueueWebhookMessageParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/registration_test.go
+++ b/tools/registration_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// strippedFrenchStems is a denylist of French stems that have lost their
+// diacritics. We only flag French words whose accented form is canonical and
+// for which the stripped form has no plausible English collision.
+//
+// Each entry must match a substring inside a Go string literal taken from a
+// `Description:` field (or `jsonschema:` tag). Keep this list small and
+// audited — false positives block CI.
+var strippedFrenchStems = []string{
+	"Determine la",     // "Détermine la" — French phrase
+	"Recupere",         // "Récupère"
+	"Genere ",          // "Génère " (with trailing space to avoid hitting English "Genere..." ids)
+	"activite ",        // "activité "
+	"activite.",        // "activité."
+	"disponibilite",    // "disponibilité"
+	"creneaux",         // "créneaux"
+	"duree moyenne",    // "durée moyenne"
+	"frequence)",       // "fréquence)"
+	"prediction de l'", // "prédiction de l'apprenant" — French only
+	"resultat reel",    // "résultat réel"
+	"etat cognitif",    // "état cognitif"
+	"etat emotionnel",  // "état émotionnel"
+	"debut de session", // "début de session"
+	"reponse en sec",   // "réponse en secondes"
+	"detectees par",    // "détectées par"
+	"maitrise",         // "maîtrise" / "maîtrisé"
+	"prerequis ",       // "prérequis " (space-bounded to avoid English "prerequisites")
+	"prerequis (",      // "prérequis ("
+	"prerequis)",       // "prérequis)"
+	"prerequis.",       // "prérequis."
+	"detruire",         // "détruire" / "détruit"
+	"definitivement",   // "définitivement"
+	"preserves.",       // "préservés."
+	"preservee",        // "préservée"
+	"reactiver",        // "réactiver"
+	"domaine archive",  // French past participle "domaine archivé"
+	"Reactive un",      // French "Réactive un domaine"
+	"systeme",          // "système"
+	"methode Feynman",  // "méthode Feynman"
+	"inedite",          // "inédite"
+	"fenetre",          // "fenêtre"
+	"caracteres recommande", // "caractères recommandé"
+	"Cloture",          // "Clôture"
+	"structures pour",  // French "structurés pour"
+	"metadonnees",      // "métadonnées"
+	"modifies.",        // "modifiés."
+	"Necessite",        // "Nécessite"
+}
+
+// TestToolDescriptions_NoStrippedFrenchDiacritics walks every tool source file
+// and asserts no `Description:` value (or `jsonschema:` tag) contains a known
+// stripped-accent French stem. The denylist is conservative: it only flags
+// stems that are unambiguously French (no plausible English collision).
+func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	var failures []string
+
+	for _, path := range files {
+		// Skip test files — denylist literals appear there legitimately.
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.KeyValueExpr:
+				// Catch `Description: "..."` literals.
+				key, ok := x.Key.(*ast.Ident)
+				if !ok || key.Name != "Description" {
+					return true
+				}
+				lit, ok := x.Value.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				val := lit.Value
+				for _, stem := range strippedFrenchStems {
+					if strings.Contains(val, stem) {
+						pos := fset.Position(lit.Pos())
+						failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
+					}
+				}
+			case *ast.BasicLit:
+				// Catch raw struct-tag string literals containing
+				// `jsonschema:"..."`.
+				if x.Kind != token.STRING {
+					return true
+				}
+				val := x.Value
+				if !strings.Contains(val, "jsonschema:") {
+					return true
+				}
+				for _, stem := range strippedFrenchStems {
+					if strings.Contains(val, stem) {
+						pos := fset.Position(x.Pos())
+						failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("found %d stripped-accent French stem(s) in tool descriptions:\n%s",
+			len(failures), strings.Join(failures, "\n"))
+	}
+}
+
+func formatFailure(file string, line int, stem, val string) string {
+	return "  " + file + ":" + itoa(line) + ": stripped stem " + quote(stem) + " in " + truncate(val, 120)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+func quote(s string) string {
+	return "\"" + s + "\""
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -15,8 +15,8 @@ import (
 )
 
 type ImplementationIntentionInput struct {
-	Trigger      string `json:"trigger" jsonschema:"Clause 'quand' (ex: 'demain matin au cafe')"`
-	Action       string `json:"action" jsonschema:"Clause 'alors je' (ex: 'ferai 1 exercice de derivees')"`
+	Trigger      string `json:"trigger" jsonschema:"Clause 'quand' (ex: 'demain matin au café')"`
+	Action       string `json:"action" jsonschema:"Clause 'alors je' (ex: 'ferai 1 exercice de dérivées')"`
 	ScheduledFor string `json:"scheduled_for,omitempty" jsonschema:"ISO 8601 timestamp optionnel (UTC)"`
 }
 
@@ -28,7 +28,7 @@ type RecordSessionCloseParams struct {
 func registerRecordSessionClose(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_session_close",
-		Description: "Cloture la session : enregistre optionnellement une implementation intention (if-then) et retourne des signaux structures pour composer le message de fin (concepts pratiques, wins, intent prompt, message queue filler).",
+		Description: "Clôture la session : enregistre optionnellement une implementation intention (if-then) et retourne des signaux structurés pour composer le message de fin (concepts pratiqués, wins, intent prompt, message queue filler).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordSessionCloseParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -124,11 +124,11 @@ func buildRecapBrief(deps *Deps, learnerID string, domain *models.Domain) *model
 	promptIntent := !has
 
 	instruction := "Clos la session en 2-3 phrases. Mentionne un win tangible ou une belle tentative. " +
-		"Si prompt_for_implementation_intention est vrai, pose une question concrete du type 'Quand et ou tu pratiques ensuite ?' " +
-		"et attends la reponse pour rappeler record_session_close avec implementation_intention. " +
-		"Puis appelle get_olm_snapshot pour recuperer l'etat cognitif structure de l'apprenant, " +
+		"Si prompt_for_implementation_intention est vrai, pose une question concrète du type 'Quand et où tu pratiques ensuite ?' " +
+		"et attends la réponse pour rappeler record_session_close avec implementation_intention. " +
+		"Puis appelle get_olm_snapshot pour récupérer l'état cognitif structuré de l'apprenant, " +
 		"et appelle queue_webhook_message 3 fois : daily_motivation pour demain 8h UTC (chaleureux, lien au personal_goal) ; " +
-		"olm:<domain_id> pour demain 13h UTC (factuel — distribution + focus + UNE ligne metacog si active + progression vers le goal — pas de pep talk, le contenu doit COLLER au snapshot get_olm_snapshot) ; " +
+		"olm:<domain_id> pour demain 13h UTC (factuel — distribution + focus + UNE ligne métacog si active + progression vers le goal — pas de pep talk, le contenu doit COLLER au snapshot get_olm_snapshot) ; " +
 		"daily_recap pour demain 21h UTC (recap doux). " +
 		"Sans KPI brut."
 

--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -15,7 +15,7 @@ import (
 )
 
 type TransferChallengeParams struct {
-	ConceptID   string `json:"concept_id" jsonschema:"Le concept a tester en transfert"`
+	ConceptID   string `json:"concept_id" jsonschema:"Le concept à tester en transfert"`
 	ContextType string `json:"context_type,omitempty" jsonschema:"Type de contexte: real_world, interview, teaching, debugging, creative (optionnel)"`
 	DomainID    string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 }
@@ -23,7 +23,7 @@ type TransferChallengeParams struct {
 func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "transfer_challenge",
-		Description: "Genere une situation inedite pour tester le transfert d'un concept maitrise hors du contexte initial.",
+		Description: "Génère une situation inédite pour tester le transfert d'un concept maîtrisé hors du contexte initial.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params TransferChallengeParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -49,7 +49,7 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 			r, _ := jsonResult(map[string]interface{}{
 				"eligible": false,
 				"mastery":  cs.PMastery,
-				"message":  "Concept pas encore maitrise. Le transfert challenge requiert BKT >= 0.85.",
+				"message":  "Concept pas encore maîtrisé. Le transfert challenge requiert BKT >= 0.85.",
 			})
 			return r, nil, nil
 		}
@@ -66,12 +66,12 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 		}
 
 		promptText := fmt.Sprintf(
-			"Genere une situation totalement nouvelle qui teste le transfert du concept '%s' "+
+			"Génère une situation totalement nouvelle qui teste le transfert du concept '%s' "+
 				"dans un contexte de type '%s'. "+
-				"La situation ne doit PAS ressembler aux exercices precedents. "+
-				"L'objectif: verifier que l'apprenant peut appliquer ce concept dans un contexte qu'il n'a jamais vu.\n\n"+
-				"Apres la reponse de l'apprenant, evalue le transfer_score (0-1) et "+
-				"appelle record_transfer_result avec le resultat.",
+				"La situation ne doit PAS ressembler aux exercices précédents. "+
+				"L'objectif: vérifier que l'apprenant peut appliquer ce concept dans un contexte qu'il n'a jamais vu.\n\n"+
+				"Après la réponse de l'apprenant, évalue le transfer_score (0-1) et "+
+				"appelle record_transfer_result avec le résultat.",
 			params.ConceptID, contextType,
 		)
 
@@ -89,7 +89,7 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 // ─── record_transfer_result ─────────────────────────────────────────────────
 
 type RecordTransferResultParams struct {
-	ConceptID   string  `json:"concept_id" jsonschema:"Le concept teste"`
+	ConceptID   string  `json:"concept_id" jsonschema:"Le concept testé"`
 	ContextType string  `json:"context_type" jsonschema:"Type de contexte du challenge"`
 	Score       float64 `json:"score" jsonschema:"Score de transfert entre 0 et 1"`
 	SessionID   string  `json:"session_id,omitempty" jsonschema:"ID de session (optionnel)"`
@@ -98,7 +98,7 @@ type RecordTransferResultParams struct {
 func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_transfer_result",
-		Description: "Enregistre le resultat d'un transfer challenge.",
+		Description: "Enregistre le résultat d'un transfer challenge.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordTransferResultParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {


### PR DESCRIPTION
Closes parts 1 & 2 of #12. Part 3 (description-template harmonization) tracked in #19.

## Summary

- **Part 1 — Diacritics.** Restored proper French accents across every `Description:` field and `jsonschema:` parameter description in `tools/*.go`, plus a few learner-facing string literals in the same files (rationales, prompt fragments, error messages, the system prompt and its flag-gated appendices, OLM tool descriptions). The codebase is UTF-8 clean; the stripped-accent forms had no upside and degraded LLM routing legibility.
- **Part 1 — Lint.** Added `tools/registration_test.go::TestToolDescriptions_NoStrippedFrenchDiacritics`. It walks every `tools/*.go` source file with `go/ast`, picks out `Description:` literals and `jsonschema:` struct tags, and fails on any occurrence of a stem from a small audited denylist (`Determine la`, `Recupere`, `Genere `, `disponibilite`, `creneaux`, `prerequis ` (space-bounded so it does not fire on the JSON key `prerequisites`), `methode Feynman`, `systeme`, `metadonnees`, …). Each entry is unambiguously French (no plausible English collision). The test fails on the pre-edit state and passes after the restoration.
- **Part 2 — Conventions.** Added a "Language conventions" section to `README.md` (between "Architecture" and "Running") documenting the EN-for-developers / FR-for-learner split, with concrete file pointers (`tools/*.go` descriptions, `tools/prompt.go`, `engine/olm.go`, `engine/orchestrator.go`, `db/store.go`).
- One existing test (`tools/cockpit_test.go::TestGetCockpitState_NoDomain`) asserted the unaccented "aucun domaine configure" error string; updated to the now-canonical "aucun domaine configuré".

## Out of scope

Part 3 of #12 — harmonizing tool-description granularity to a `USAGE / QUAND / NE PAS UTILISER` template across all ~30 tools — is tracked in #19. That work needs a wording decision before mass edits and would balloon this PR's diff, so it is intentionally deferred.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` green (existing suites + new lint test).
- [x] Lint test fails on baseline (verified by stashing `tools/activity.go` and re-running — caught `Determine la`, `activite `, `etat cognitif`).
- [x] Lint test passes after the restoration.
- [x] `go vet ./...` clean.
- [ ] Reviewer spot-checks a handful of tool descriptions for natural French.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X6zMVM5FhQsrYjPSx52wLJ)_