### PR TITLE
fix(auth): clearer error when JWT_SECRET is not base64-encoded; align README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The setup has two phases: **deploy the server**, then **connect a client**.
 
 ```bash
 # Required
-export JWT_SECRET="your-secret-key"
+export JWT_SECRET="$(openssl rand -base64 32)"
 
 # Optional
 export PORT=3000                       # default: 3000
@@ -351,6 +351,8 @@ export LOG_LEVEL=debug                 # debug | info | warn | error
 
 go build -o tutor-mcp && ./tutor-mcp
 ```
+
+> `JWT_SECRET` must be a base64-encoded value (32 random bytes recommended). Use `openssl rand -base64 32` to generate one — a plain string will be rejected.
 
 For real use, put the runtime behind a public reverse proxy with TLS — see [Server Configuration](#server-configuration).
 

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -23,7 +23,7 @@ func LoadJWTSecret() error {
 	}
 	decoded, err := base64.StdEncoding.DecodeString(secret)
 	if err != nil {
-		return fmt.Errorf("JWT_SECRET must be base64-encoded: %w", err)
+		return fmt.Errorf("JWT_SECRET must be base64-encoded (try: openssl rand -base64 32): %w", err)
 	}
 	jwtSecret = decoded
 	return nil

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -7,6 +7,7 @@ package auth
 import (
 	"encoding/base64"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +75,20 @@ func TestVerifyJWT_RejectsAlgNone(t *testing.T) {
 	setTestSecret(t)
 	if _, err := VerifyJWT(tok, "https://issuer.example"); err == nil {
 		t.Fatal("alg=none must be rejected")
+	}
+}
+
+func TestLoadJWTSecret_PlainStringErrorMentionsOpenssl(t *testing.T) {
+	// A plain (non-base64) value is the exact failure mode users hit when
+	// following the README literally — see issue #22. The error message must
+	// be actionable and point them at `openssl rand -base64 32`.
+	t.Setenv("JWT_SECRET", "hello")
+	err := LoadJWTSecret()
+	if err == nil {
+		t.Fatal("expected error for plain (non-base64) JWT_SECRET")
+	}
+	if !strings.Contains(err.Error(), "openssl rand -base64 32") {
+		t.Fatalf("error message %q must mention `openssl rand -base64 32` to be actionable", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- README quickstart now uses `export JWT_SECRET="$(openssl rand -base64 32)"` and explicitly states the value must be base64-encoded — the previous example (`"your-secret-key"`) crashed the binary on first boot.
- `auth/jwt.go` runtime error now points users at `openssl rand -base64 32` so the failure mode is self-correctable.
- New reproducer test `TestLoadJWTSecret_PlainStringErrorMentionsOpenssl` (`auth/jwt_test.go`) — fails on main, passes here.

Fixes #22

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./auth/... -run TestLoadJWTSecret -v` green
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_