### PR TITLE
fix(tools): validate concept membership in record_interaction & submit_answer

### DIFF
--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -47,6 +47,21 @@ func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// Resolve the active domain (honoring the optional domain_id) and
+		// validate the concept against its concept list. Without this guard
+		// the BKT/FSRS chain silently inserts orphan concept_states for
+		// hallucinated or stale concept names — see issue #23.
+		domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
+		if err != nil || domain == nil {
+			deps.Logger.Error("record_interaction: resolve domain", "err", err, "learner", learnerID)
+			r, _ := errorResult("no active domain — call init_domain first")
+			return r, nil, nil
+		}
+		if err := validateConceptInDomain(domain, params.Concept); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
 		cs, err := applyInteraction(deps, learnerID, interactionInput{
 			Concept:             params.Concept,
 			ActivityType:        params.ActivityType,
@@ -60,6 +75,7 @@ func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 			CalibrationID:       params.CalibrationID,
 			MisconceptionType:   params.MisconceptionType,
 			MisconceptionDetail: params.MisconceptionDetail,
+			DomainID:            domain.ID,
 		}, time.Now().UTC())
 		if err != nil {
 			deps.Logger.Error("record_interaction: applyInteraction failed", "err", err, "learner", learnerID)

--- a/tools/interaction_test.go
+++ b/tools/interaction_test.go
@@ -42,9 +42,10 @@ func TestRecordInteraction_MissingConcept(t *testing.T) {
 
 func TestRecordInteraction_HappyPath_Success(t *testing.T) {
 	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math") // concepts: ["a","b"]
 
 	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
-		"concept":               "derivative",
+		"concept":               "a",
 		"activity_type":         "RECALL_EXERCISE",
 		"success":               true,
 		"response_time_seconds": 12.0,
@@ -75,12 +76,12 @@ func TestRecordInteraction_HappyPath_Success(t *testing.T) {
 	if len(recents) != 1 {
 		t.Fatalf("expected 1 interaction, got %d", len(recents))
 	}
-	if !recents[0].Success || recents[0].Concept != "derivative" {
+	if !recents[0].Success || recents[0].Concept != "a" {
 		t.Fatalf("unexpected interaction: %+v", recents[0])
 	}
 
 	// DB: concept state upserted.
-	cs, err := store.GetConceptState("L_owner", "derivative")
+	cs, err := store.GetConceptState("L_owner", "a")
 	if err != nil {
 		t.Fatalf("expected concept state: %v", err)
 	}
@@ -90,10 +91,11 @@ func TestRecordInteraction_HappyPath_Success(t *testing.T) {
 }
 
 func TestRecordInteraction_FailureDecliningSignal(t *testing.T) {
-	_, deps := setupToolsTest(t)
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
 
 	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
-		"concept":               "calc",
+		"concept":               "a",
 		"activity_type":         "RECALL_EXERCISE",
 		"success":               false,
 		"response_time_seconds": 30.0,
@@ -111,9 +113,10 @@ func TestRecordInteraction_FailureDecliningSignal(t *testing.T) {
 
 func TestRecordInteraction_StoresMisconceptionOnFailure(t *testing.T) {
 	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
 
 	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
-		"concept":               "loops",
+		"concept":               "a",
 		"activity_type":         "RECALL_EXERCISE",
 		"success":               false,
 		"response_time_seconds": 20.0,
@@ -138,9 +141,10 @@ func TestRecordInteraction_StoresMisconceptionOnFailure(t *testing.T) {
 
 func TestRecordInteraction_MisconceptionIgnoredOnSuccess(t *testing.T) {
 	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
 
 	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
-		"concept":               "loops",
+		"concept":               "a",
 		"activity_type":         "RECALL_EXERCISE",
 		"success":               true,
 		"response_time_seconds": 5.0,
@@ -159,6 +163,48 @@ func TestRecordInteraction_MisconceptionIgnoredOnSuccess(t *testing.T) {
 	}
 	if recents[0].MisconceptionType != "" {
 		t.Fatalf("misconception should NOT be stored on success: %+v", recents[0])
+	}
+}
+
+func TestRecordInteraction_RejectsUnknownConcept(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	// makeOwnerDomain creates a domain with concepts ["a","b"].
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "ghost",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               true,
+		"response_time_seconds": 5.0,
+		"confidence":            0.8,
+		"notes":                 "",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown concept, got %q", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "ghost") {
+		t.Fatalf("expected error to mention the unknown concept name, got %q", resultText(res))
+	}
+
+	// And no orphan ConceptState row should have been created.
+	if cs, err := store.GetConceptState("L_owner", "ghost"); err == nil && cs != nil {
+		t.Fatalf("orphan concept_state row created for unknown concept: %+v", cs)
+	}
+}
+
+func TestRecordInteraction_NoActiveDomain(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	// L_owner has no domain at all — record_interaction must refuse.
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "anything",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               true,
+		"response_time_seconds": 5.0,
+		"confidence":            0.8,
+		"notes":                 "",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error when no active domain, got %q", resultText(res))
 	}
 }
 

--- a/tools/submit_answer.go
+++ b/tools/submit_answer.go
@@ -41,6 +41,13 @@ func registerSubmitAnswer(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// Validate concept membership before any sampling / persistence —
+		// rejects hallucinated or stale concept names early (issue #23).
+		if err := validateConceptInDomain(domain, params.Concept); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
 		chatMode, _ := deps.Store.GetChatModeEnabled(learnerID)
 
 		evalSystem := "Tu évalues une réponse d'apprenant. Retourne strictement un JSON: {\"correct\": bool, \"explanation\": string, \"error_type\"?: string}. Pas de texte hors JSON."

--- a/tools/submit_answer_test.go
+++ b/tools/submit_answer_test.go
@@ -5,10 +5,43 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"tutor-mcp/models"
 )
+
+func TestSubmitAnswer_RejectsUnknownConcept(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // concepts: ["a","b"]
+
+	res := callToolWithSampling(t, deps, registerSubmitAnswer, "L_owner",
+		"submit_answer",
+		map[string]any{
+			"answer":        "42",
+			"concept":       "ghost",
+			"activity_type": "PRACTICE",
+			"domain_id":     d.ID,
+		},
+		`{"correct": true, "explanation": "ok"}`,
+	)
+	if !res.IsError {
+		t.Fatalf("expected error for unknown concept, got %q", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "ghost") {
+		t.Fatalf("expected error to mention the unknown concept name, got %q", resultText(res))
+	}
+	// No orphan concept_state and no interaction must be created.
+	if cs, err := store.GetConceptState("L_owner", "ghost"); err == nil && cs != nil {
+		t.Fatalf("orphan concept_state row created for unknown concept: %+v", cs)
+	}
+	ints, _ := store.GetRecentInteractionsByLearner("L_owner", 5)
+	for _, i := range ints {
+		if i.Concept == "ghost" {
+			t.Fatalf("interaction recorded for unknown concept: %+v", i)
+		}
+	}
+}
 
 func TestSubmitAnswer_Correct_HappyPath(t *testing.T) {
 	store, deps := setupToolsTest(t)

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"fmt"
+
+	"tutor-mcp/models"
+)
+
+// validateConceptInDomain checks that concept is a member of d.Graph.Concepts.
+// It is the shared write-side guard for record_interaction, submit_answer, and
+// any other tool that mutates a learner's cognitive state on a per-concept
+// basis. The error string mirrors pick_concept's read-side guard so the LLM
+// can self-correct uniformly across read and write surfaces.
+func validateConceptInDomain(d *models.Domain, concept string) error {
+	if d == nil {
+		return fmt.Errorf("no active domain — call init_domain first")
+	}
+	for _, c := range d.Graph.Concepts {
+		if c == concept {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"concept %q is not part of domain %q (call get_learner_context to see the concept list)",
+		concept, d.Name,
+	)
+}


### PR DESCRIPTION
## Summary
- Shared `validateConceptInDomain` helper (`tools/validate.go`) mirrors the `pick_concept` check; lifted into a reusable validator.
- `record_interaction` and `submit_answer` now reject hallucinated/orphan concept names with a self-correctable error instead of silently inserting orphan `concept_states` rows.
- `params.DomainID` on `record_interaction` is now read and threaded through to `resolveDomain` (was previously silently ignored — partial fix to #24; full schema-side persistence still pending).
- New tests prove the gap on main and the closure on this branch: `TestRecordInteraction_RejectsUnknownConcept`, `TestRecordInteraction_NoActiveDomain`, `TestSubmitAnswer_RejectsUnknownConcept`.

Fixes #23
Refs #24

## Test plan
- [x] `go vet ./...` silent
- [x] `go test ./tools/... -run TestRecordInteraction -v` green
- [x] `go test ./tools/... -run TestSubmitAnswer -v` green
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_