### PR TITLE
fix(tools): reject prereqs that reference undeclared concepts in init_domain & add_concepts

### DIFF
--- a/tools/domain.go
+++ b/tools/domain.go
@@ -29,7 +29,15 @@ const (
 )
 
 // validateConcepts enforces the size caps on a concept list and its
-// prerequisite graph. Returns the first error found (one short message).
+// prerequisite graph, AND cross-checks that every prerequisite key/value
+// references a concept declared in `concepts`. The `concepts` slice is the
+// universe of valid concept names — for init_domain it is the user-supplied
+// concepts[]; for add_concepts callers must pass the merged existing+new
+// set so prereq arrows pointing at already-declared concepts remain valid.
+//
+// Without this cross-check a malformed graph silently locks concepts behind
+// unknown prereqs (concept_selector treats missing prereqs as mastery=0
+// forever — see engine/concept_selector.go).
 func validateConcepts(concepts []string, prereqs map[string][]string) error {
 	if len(concepts) > maxConceptsPerCall {
 		return fmt.Errorf("too many concepts: %d (max %d)", len(concepts), maxConceptsPerCall)
@@ -45,9 +53,19 @@ func validateConcepts(concepts []string, prereqs map[string][]string) error {
 	if len(prereqs) > maxConceptsPerCall {
 		return fmt.Errorf("too many prerequisite entries: %d (max %d)", len(prereqs), maxConceptsPerCall)
 	}
+
+	// Build the universe of declared concepts for cross-referencing.
+	universe := make(map[string]bool, len(concepts))
+	for _, c := range concepts {
+		universe[c] = true
+	}
+
 	for k, vs := range prereqs {
 		if len(k) > maxConceptNameLen {
 			return fmt.Errorf("prerequisite key too long (max %d chars)", maxConceptNameLen)
+		}
+		if !universe[k] {
+			return fmt.Errorf("prerequisite %q references concept not declared in concepts[]", k)
 		}
 		if len(vs) > maxPrereqEntriesPerNode {
 			return fmt.Errorf("too many prerequisites for %q (max %d)", k, maxPrereqEntriesPerNode)
@@ -55,6 +73,9 @@ func validateConcepts(concepts []string, prereqs map[string][]string) error {
 		for _, v := range vs {
 			if len(v) > maxConceptNameLen {
 				return fmt.Errorf("prerequisite value too long (max %d chars)", maxConceptNameLen)
+			}
+			if !universe[v] {
+				return fmt.Errorf("prerequisite %q references concept not declared in concepts[]", v)
 			}
 		}
 	}
@@ -228,12 +249,9 @@ func registerAddConcepts(server *mcp.Server, deps *Deps) {
 			r, _ := errorResult("at least one concept is required")
 			return r, nil, nil
 		}
-		if err := validateConcepts(params.Concepts, params.Prerequisites); err != nil {
-			r, _ := errorResult(err.Error())
-			return r, nil, nil
-		}
 
-		// Resolve domain
+		// Resolve domain — needed so we can validate prerequisites
+		// against the merged (existing + new) concept universe.
 		domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
 		if err != nil {
 			deps.Logger.Error("add_concepts: failed to resolve domain", "err", err, "learner", learnerID)
@@ -254,6 +272,13 @@ func registerAddConcepts(server *mcp.Server, deps *Deps) {
 				existingSet[c] = true
 				added++
 			}
+		}
+
+		// Validate against the MERGED universe — prereqs may legitimately
+		// reference concepts that already exist on the domain.
+		if err := validateConcepts(domain.Graph.Concepts, params.Prerequisites); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
 		}
 
 		// Merge prerequisites

--- a/tools/init_domain_test.go
+++ b/tools/init_domain_test.go
@@ -195,3 +195,50 @@ func TestAddConcepts_DomainNotFound(t *testing.T) {
 		t.Fatalf("got %q", resultText(res))
 	}
 }
+
+func TestInitDomain_RejectsUnknownPrereqValue(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerInitDomain, "L_owner", "init_domain", map[string]any{
+		"name": "x", "concepts": []string{"a"},
+		"prerequisites": map[string][]string{"a": {"ghost"}}})
+	if !res.IsError {
+		t.Fatalf("expected validation error for prereq pointing at unknown concept, got %q", resultText(res))
+	}
+}
+
+func TestInitDomain_RejectsUnknownPrereqKey(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	// prereq KEY references a concept not in concepts[]
+	res := callTool(t, deps, registerInitDomain, "L_owner", "init_domain", map[string]any{
+		"name": "x", "concepts": []string{"a"},
+		"prerequisites": map[string][]string{"ghost": {"a"}}})
+	if !res.IsError {
+		t.Fatalf("expected validation error for prereq key not in concepts[]")
+	}
+}
+
+func TestAddConcepts_RejectsUnknownPrereqValue(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // contains a, b
+
+	// Adding c with a prereq that references "ghost" should fail —
+	// "ghost" is not in the merged universe (existing[a,b] + new[c]).
+	res := callTool(t, deps, registerAddConcepts, "L_owner", "add_concepts", map[string]any{
+		"domain_id":     d.ID,
+		"concepts":      []string{"c"},
+		"prerequisites": map[string][]string{"c": {"ghost"}},
+	})
+	if !res.IsError {
+		t.Fatalf("expected validation error for unknown prereq in add_concepts, got %q", resultText(res))
+	}
+
+	// But referencing existing concept "a" must still succeed.
+	res = callTool(t, deps, registerAddConcepts, "L_owner", "add_concepts", map[string]any{
+		"domain_id":     d.ID,
+		"concepts":      []string{"c"},
+		"prerequisites": map[string][]string{"c": {"a"}},
+	})
+	if res.IsError {
+		t.Fatalf("expected success when prereq points at existing concept, got %q", resultText(res))
+	}
+}


### PR DESCRIPTION
## Summary
- `validateConcepts` (`tools/domain.go`) now builds a concept universe and rejects any prereq key/value that is not in it. Message: `prerequisite %q references concept not declared in concepts[]`.
- `add_concepts` validation moved to run AFTER the merge of existing + new concepts, so prereqs pointing at already-declared concepts still validate as a positive control.
- New tests prove both the failing case (key OR value pointing outside the concept universe) and the positive control: `TestInitDomain_RejectsUnknownPrereqValue`, `TestInitDomain_RejectsUnknownPrereqKey`, `TestAddConcepts_RejectsUnknownPrereqValue`.

Fixes #26

## Test plan
- [x] `go vet ./...` silent
- [x] All three new tests verified failing on `main` and passing here
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

#27 (duplicate concept names) intentionally left untouched — separate issue, separate PR.

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_