### PR TITLE
fix(tools): restore French diacritics in feynman_challenge learner-facing strings

### DIFF
--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -48,17 +48,17 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 				"eligible":  false,
 				"mastery":   cs.PMastery,
 				"threshold": algorithms.MasteryBKT(),
-				"message":   "Concept pas encore maitrise. Continue la pratique reguliere.",
+				"message":   "Concept pas encore maîtrisé. Continue la pratique régulière.",
 			})
 			return r, nil, nil
 		}
 
 		promptText := fmt.Sprintf(
-			"Explique le concept '%s' comme si tu l'enseignais a quelqu'un qui n'y connait rien. "+
+			"Explique le concept '%s' comme si tu l'enseignais à quelqu'un qui n'y connaît rien. "+
 				"Pas de jargon technique — utilise des analogies, des exemples concrets. "+
-				"L'objectif est de verifier que tu as vraiment compris, pas que tu sais reciter.\n\n"+
-				"Apres ton explication, je vais identifier les points flous ou incomplets "+
-				"et les transformer en micro-concepts a travailler.",
+				"L'objectif est de vérifier que tu as vraiment compris, pas que tu sais réciter.\n\n"+
+				"Après ton explication, je vais identifier les points flous ou incomplets "+
+				"et les transformer en micro-concepts à travailler.",
 			params.ConceptID,
 		)
 
@@ -66,10 +66,10 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 			"eligible":    true,
 			"prompt_text": promptText,
 			"concept_id":  params.ConceptID,
-			"instructions_for_llm": "Apres l'explication de l'apprenant, identifie les gaps conceptuels specifiques. " +
-				"Pour chaque gap, genere un label court et une description. " +
-				"Demande confirmation a l'apprenant avant d'injecter les gaps dans le graphe via add_concepts(). " +
-				"Les nouveaux micro-concepts doivent avoir le concept source comme prerequis.",
+			"instructions_for_llm": "Après l'explication de l'apprenant, identifie les gaps conceptuels spécifiques. " +
+				"Pour chaque gap, génère un label court et une description. " +
+				"Demande confirmation à l'apprenant avant d'injecter les gaps dans le graphe via add_concepts(). " +
+				"Les nouveaux micro-concepts doivent avoir le concept source comme prérequis.",
 			"gap_template": map[string]interface{}{
 				"label":          "<nom court du gap>",
 				"description":    "<ce qui manque dans l'explication>",

--- a/tools/registration_test.go
+++ b/tools/registration_test.go
@@ -10,6 +10,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -132,6 +133,98 @@ func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
 
 	if len(failures) > 0 {
 		t.Fatalf("found %d stripped-accent French stem(s) in tool descriptions:\n%s",
+			len(failures), strings.Join(failures, "\n"))
+	}
+}
+
+// learnerFacingStrippedStems are stripped-French stems that have appeared in
+// learner-facing string literals (handler-returned map values, error
+// messages, prompts) — anywhere outside `Description:` / `jsonschema:`.
+//
+// These are matched as whole words inside *any* string literal in the files
+// listed by stringLiteralLintFiles. Whole-word boundaries (\b) keep us safe
+// from collisions with English fragments and from Go identifier matches
+// (which are not BasicLit anyway). Trailing-s is allowed so plural French
+// stems are caught too.
+var learnerFacingStrippedStems = []string{
+	"maitrise",   // "maîtrise" / "maîtrisé"
+	"Apres",      // "Après"
+	"verifier",   // "vérifier"
+	"prerequis",  // "prérequis"
+	"reguliere",  // "régulière"
+	"regulier",   // "régulier"
+	"specifique", // "spécifique" / "spécifiques"
+	"genere",     // "génère"
+	"reciter",    // "réciter"
+	"connait",    // "connaît"
+	"enleve",     // "enlève"
+	"reflechi",   // "réfléchi"
+}
+
+// stringLiteralLintFiles is the set of source files whose every string
+// literal is checked against learnerFacingStrippedStems. The narrower
+// `Description:` / `jsonschema:` lint above runs across all tool files; this
+// stricter walk targets handlers known to emit learner-facing strings inside
+// returned maps / formatted prompts (see issue #28). Add files here as new
+// regressions are caught.
+var stringLiteralLintFiles = []string{
+	"feynman.go",
+}
+
+// TestToolStringLiterals_NoStrippedFrenchDiacritics widens the diacritic lint
+// to every string literal (any *ast.BasicLit of kind STRING) in the files
+// listed in stringLiteralLintFiles, not just `Description:` / `jsonschema:`
+// tags. This catches handler-returned map values like
+// `"message": "Concept pas encore maitrise..."` that the narrower lint
+// missed (see issue #28).
+func TestToolStringLiterals_NoStrippedFrenchDiacritics(t *testing.T) {
+	// Pre-compile whole-word regexps for each stem. Trailing-s is allowed
+	// (so "specifique" matches "specifiques") because plural French stems
+	// are a single transformation away from the singular.
+	stemREs := make(map[string]*regexp.Regexp, len(learnerFacingStrippedStems))
+	for _, stem := range learnerFacingStrippedStems {
+		stemREs[stem] = regexp.MustCompile(`\b` + regexp.QuoteMeta(stem) + `s?\b`)
+	}
+
+	fset := token.NewFileSet()
+	var failures []string
+
+	for _, path := range stringLiteralLintFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			val := lit.Value
+			// Skip raw struct tags so we don't double-fire with the
+			// narrower lint above on `jsonschema:` / `json:` literals.
+			if strings.Contains(val, "jsonschema:") || strings.Contains(val, "json:\"") {
+				return true
+			}
+			for _, stem := range learnerFacingStrippedStems {
+				if stemREs[stem].MatchString(val) {
+					pos := fset.Position(lit.Pos())
+					failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
+				}
+			}
+			return true
+		})
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("found %d stripped-accent French stem(s) in tool string literals:\n%s",
 			len(failures), strings.Join(failures, "\n"))
 	}
 }


### PR DESCRIPTION
## Summary
- `tools/feynman.go` — restored diacritics on the 3 learner-facing literals (`message`, `promptText` template, `instructions_for_llm`). Logic untouched.
- `tools/registration_test.go` — new `TestToolStringLiterals_NoStrippedFrenchDiacritics` widens the lint to walk every `*ast.BasicLit` (kind STRING) in a per-file allowlist (`feynman.go` for now), with whole-word regex on 12 stripped-French stems. Skips literals containing `jsonschema:` / `json:"` to avoid double-firing with the existing narrower lint.
- Per-file allowlist (rather than glob) deliberately avoids pulling in **pre-existing violations in `tools/negotiation.go:122-123`** (`prerequis respectes`, `prerequis non maitrises`) — flagged for a separate follow-up issue, not in scope here.

Fixes #28

## Test plan
- [x] Pre-fix, the new test reported 10 violations in `feynman.go` (proving the test catches the regression)
- [x] Post-fix, `go test ./tools/ -run TestToolStringLiterals -v` green
- [x] `go test ./tools/ -run TestFeynman -v` green (existing tests unchanged)
- [x] `go test ./...` full suite green
- [x] `go vet ./...` silent
- [x] `go build -o tutor-mcp .` builds

## Follow-up note
A new issue should be opened to extend `stringLiteralLintFiles` to `negotiation.go` (and possibly all of `tools/`), then fix the two stripped literals there. Doing it in a separate PR keeps this one tightly scoped to the bug at hand.

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_