### PR TITLE
fix(tools): reject duplicate concept names in init_domain & add_concepts

### DIFF
--- a/tools/domain.go
+++ b/tools/domain.go
@@ -55,8 +55,13 @@ func validateConcepts(concepts []string, prereqs map[string][]string) error {
 	}
 
 	// Build the universe of declared concepts for cross-referencing.
+	// Reject duplicates: a repeated concept inflates TotalGoalRelevant
+	// and skews mastery ratios in the FSM observables (issue #27).
 	universe := make(map[string]bool, len(concepts))
 	for _, c := range concepts {
+		if universe[c] {
+			return fmt.Errorf("duplicate concept name %q", c)
+		}
 		universe[c] = true
 	}
 
@@ -259,19 +264,28 @@ func registerAddConcepts(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
-		// Merge new concepts into existing graph
+		// Reject duplicates BEFORE merging: (a) intra-batch duplicates and
+		// (b) batch entries that already live in the existing graph. A
+		// silent skip would let the caller believe the add succeeded while
+		// inflating their TotalGoalRelevant view (issue #27).
 		existingSet := make(map[string]bool)
 		for _, c := range domain.Graph.Concepts {
 			existingSet[c] = true
 		}
+		batchSet := make(map[string]bool, len(params.Concepts))
+		for _, c := range params.Concepts {
+			if existingSet[c] || batchSet[c] {
+				r, _ := errorResult(fmt.Sprintf("duplicate concept name %q", c))
+				return r, nil, nil
+			}
+			batchSet[c] = true
+		}
 
 		added := 0
 		for _, c := range params.Concepts {
-			if !existingSet[c] {
-				domain.Graph.Concepts = append(domain.Graph.Concepts, c)
-				existingSet[c] = true
-				added++
-			}
+			domain.Graph.Concepts = append(domain.Graph.Concepts, c)
+			existingSet[c] = true
+			added++
 		}
 
 		// Validate against the MERGED universe — prereqs may legitimately

--- a/tools/init_domain_test.go
+++ b/tools/init_domain_test.go
@@ -154,7 +154,10 @@ func TestAddConcepts_HappyPath(t *testing.T) {
 	}
 }
 
-func TestAddConcepts_DuplicateNotReadded(t *testing.T) {
+func TestAddConcepts_DuplicateRejected(t *testing.T) {
+	// Issue #27: duplicates of existing concepts are now hard-rejected
+	// (previously silently no-op'd). This guards against inflated
+	// TotalGoalRelevant counts in the FSM observables.
 	store, deps := setupToolsTest(t)
 	d := makeOwnerDomain(t, store, "L_owner", "math")
 
@@ -163,12 +166,8 @@ func TestAddConcepts_DuplicateNotReadded(t *testing.T) {
 		"concepts":      []string{"a"},
 		"prerequisites": map[string][]string{},
 	})
-	if res.IsError {
-		t.Fatalf("expected success, got %q", resultText(res))
-	}
-	out := decodeResult(t, res)
-	if out["added"].(float64) != 0 {
-		t.Fatalf("expected added=0 for duplicate, got %v", out["added"])
+	if !res.IsError || !strings.Contains(resultText(res), "duplicate concept name") {
+		t.Fatalf("expected duplicate error, got %q", resultText(res))
 	}
 }
 
@@ -193,6 +192,32 @@ func TestAddConcepts_DomainNotFound(t *testing.T) {
 	})
 	if !res.IsError || !strings.Contains(resultText(res), "domain not found") {
 		t.Fatalf("got %q", resultText(res))
+	}
+}
+
+func TestInitDomain_RejectsDuplicateConcepts(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerInitDomain, "L_owner", "init_domain", map[string]any{
+		"name": "x", "concepts": []string{"a", "b", "a"},
+		"prerequisites": map[string][]string{},
+	})
+	if !res.IsError || !strings.Contains(resultText(res), "duplicate concept name") {
+		t.Fatalf("expected duplicate error, got %q", resultText(res))
+	}
+}
+
+func TestAddConcepts_RejectsDuplicateInBatch(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // contains a, b
+
+	// Duplicate WITHIN the new batch.
+	res := callTool(t, deps, registerAddConcepts, "L_owner", "add_concepts", map[string]any{
+		"domain_id":     d.ID,
+		"concepts":      []string{"c", "c"},
+		"prerequisites": map[string][]string{},
+	})
+	if !res.IsError || !strings.Contains(resultText(res), "duplicate concept name") {
+		t.Fatalf("expected duplicate-in-batch error, got %q", resultText(res))
 	}
 }
 


### PR DESCRIPTION
## Summary
- `validateConcepts` (`tools/domain.go`) now also fails on a duplicate inside `concepts[]`, returning `duplicate concept name %q` on the first dup.
- `add_concepts` validation extended to cover (a) duplicates *within* the new batch, and (b) new concepts already present in the existing graph. Previously the second case was silently skipped — now it's a hard rejection.
- New tests prove both behaviors: `TestInitDomain_RejectsDuplicateConcepts`, `TestAddConcepts_RejectsDuplicateInBatch`. Existing `TestAddConcepts_DuplicateNotReadded` was renamed/converted to `TestAddConcepts_DuplicateRejected` to match the new error semantics.

Fixes #27

## Behavior change to flag
`add_concepts` previously returned `added=0` when a new concept was already present — silent no-op. It now returns an error. Any caller relying on the idempotent silent-skip (we don't see one in the codebase) would see a fresh error. Worth a note in `CHANGELOG.md` under the next release.

## Test plan
- [x] `go vet ./...` silent
- [x] `go test ./tools/ -run TestInitDomain -v` green (#26 tests still pass)
- [x] `go test ./tools/ -run TestAddConcepts -v` green
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_