### PR TITLE
fix(tools): filter orphan concepts out of get_pending_alerts; emit needs_domain_setup when no domain exists

### DIFF
--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -33,27 +33,50 @@ func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, 20)
 		sessionStart, _ := deps.Store.GetSessionStart(learnerID)
 
-		// Filter to domain concepts if domain specified
-		domain, domainErr := resolveDomain(deps.Store, learnerID, params.DomainID)
-		if domainErr == nil && domain != nil {
-			domainConcepts := make(map[string]bool)
+		// Resolve which domain(s) constrain this alert computation. The
+		// README contract for the Alert Engine is that orphan concept
+		// history (states/interactions on concepts no longer in any
+		// active domain — e.g. survivors of a deleted domain) must NEVER
+		// surface as alerts. Mirrors the multi-domain filter pattern in
+		// get_cockpit_state.
+		if params.DomainID != "" {
+			// Single-domain branch: explicit domain_id given, scope to
+			// that domain's concepts (or refuse if the lookup fails or
+			// the domain doesn't belong to this learner).
+			domain, domainErr := resolveDomain(deps.Store, learnerID, params.DomainID)
+			if domainErr != nil || domain == nil {
+				deps.Logger.Error("get_pending_alerts: domain not found", "err", domainErr, "learner", learnerID, "domain_id", params.DomainID)
+				r, _ := errorResult("domain not found")
+				return r, nil, nil
+			}
+			domainConcepts := make(map[string]bool, len(domain.Graph.Concepts))
 			for _, c := range domain.Graph.Concepts {
 				domainConcepts[c] = true
 			}
-			var filteredStates []*models.ConceptState
-			for _, cs := range states {
-				if domainConcepts[cs.Concept] {
-					filteredStates = append(filteredStates, cs)
+			states = filterStatesByConcepts(states, domainConcepts)
+			interactions = filterInteractionsByConcepts(interactions, domainConcepts)
+		} else {
+			// No domain_id given: compute alerts over the union of
+			// concepts across all non-archived domains. If the learner
+			// has zero active domains, return a clean empty payload with
+			// needs_domain_setup so the LLM can self-correct.
+			activeDomains, _ := deps.Store.GetDomainsByLearner(learnerID, false)
+			if len(activeDomains) == 0 {
+				r, _ := jsonResult(map[string]interface{}{
+					"alerts":             []models.Alert{},
+					"has_critical":       false,
+					"needs_domain_setup": true,
+				})
+				return r, nil, nil
+			}
+			activeConcepts := make(map[string]bool)
+			for _, d := range activeDomains {
+				for _, c := range d.Graph.Concepts {
+					activeConcepts[c] = true
 				}
 			}
-			var filteredInteractions []*models.Interaction
-			for _, i := range interactions {
-				if domainConcepts[i.Concept] {
-					filteredInteractions = append(filteredInteractions, i)
-				}
-			}
-			states = filteredStates
-			interactions = filteredInteractions
+			states = filterStatesByConcepts(states, activeConcepts)
+			interactions = filterInteractionsByConcepts(interactions, activeConcepts)
 		}
 
 		alerts := engine.ComputeAlerts(states, interactions, sessionStart)
@@ -70,8 +93,9 @@ func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 		}
 
 		r, _ := jsonResult(map[string]interface{}{
-			"alerts":       alerts,
-			"has_critical": hasCritical,
+			"alerts":             alerts,
+			"has_critical":       hasCritical,
+			"needs_domain_setup": false,
 		})
 		return r, nil, nil
 	})

--- a/tools/alerts_test.go
+++ b/tools/alerts_test.go
@@ -5,6 +5,9 @@ package tools
 
 import (
 	"testing"
+	"time"
+
+	"tutor-mcp/models"
 )
 
 func TestGetPendingAlerts_NoAuth(t *testing.T) {
@@ -42,5 +45,117 @@ func TestGetPendingAlerts_FilterByDomain(t *testing.T) {
 	})
 	if res.IsError {
 		t.Fatalf("got %q", resultText(res))
+	}
+}
+
+// orphanMasteryState builds a ConceptState shaped to trigger the
+// MASTERY_READY branch of engine.ComputeAlerts (CardState != "new" and
+// PMastery >= MasteryBKT()=0.85). Used to assert the orphan-filter
+// contract: this state should be skipped when the concept is not in any
+// active domain.
+func orphanMasteryState(learnerID, concept string) *models.ConceptState {
+	now := time.Now().UTC()
+	cs := models.NewConceptState(learnerID, concept)
+	cs.CardState = "review"
+	cs.PMastery = 0.95
+	cs.LastReview = &now
+	cs.Stability = 30
+	cs.ElapsedDays = 0
+	return cs
+}
+
+// Reproducer for issue #29: when the learner has no active domain at
+// all, get_pending_alerts must NOT surface alerts on orphan concept
+// states (the README contract). It must also signal needs_domain_setup
+// so the LLM can self-correct.
+func TestGetPendingAlerts_NoActiveDomain_ReturnsCleanEmpty(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	// Insert a concept_state that *would* trigger MASTERY_READY for a
+	// concept that is not in any domain. No init_domain call — learner
+	// has zero active domains.
+	if err := store.InsertConceptStateIfNotExists(orphanMasteryState("L_owner", "ghost")); err != nil {
+		t.Fatalf("seed orphan state: %v", err)
+	}
+
+	res := callTool(t, deps, registerGetPendingAlerts, "L_owner", "get_pending_alerts", map[string]any{})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+
+	alerts, _ := out["alerts"].([]any)
+	if len(alerts) > 0 {
+		t.Fatalf("expected no alerts on orphan concept (no active domain), got %v", alerts)
+	}
+	if got, _ := out["needs_domain_setup"].(bool); !got {
+		t.Errorf("expected needs_domain_setup=true when learner has no domain, got %v", out["needs_domain_setup"])
+	}
+	if out["has_critical"] != false {
+		t.Errorf("expected has_critical=false, got %v", out["has_critical"])
+	}
+}
+
+// Reproducer for issue #29: when the learner has multiple non-archived
+// domains and no domain_id filter is given, alerts must be computed only
+// over the union of concepts across active domains — orphan concepts
+// (e.g. survivors of a deleted domain) must be filtered out, mirroring
+// get_cockpit_state's multi-domain pattern. Also: alerts on concepts
+// belonging to *any* active domain must surface (i.e. the handler
+// shouldn't pick a single arbitrary domain in this case).
+func TestGetPendingAlerts_MultipleActiveDomains_FiltersOutOrphan(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	// Two active domains with disjoint concept sets. D2 is created last,
+	// so a single-domain fallback in resolveDomain would only see {x,y}
+	// and silently drop a legitimate alert on "a".
+	if _, err := store.CreateDomain("L_owner", "d1", "", models.KnowledgeSpace{
+		Concepts:      []string{"a", "b"},
+		Prerequisites: map[string][]string{"b": {"a"}},
+	}); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := store.CreateDomain("L_owner", "d2", "", models.KnowledgeSpace{
+		Concepts:      []string{"x", "y"},
+		Prerequisites: map[string][]string{"y": {"x"}},
+	}); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	// Seed a MASTERY_READY-trigger state on "a" (D1) and on "ghost"
+	// (no domain). Only "a" should surface.
+	if err := store.InsertConceptStateIfNotExists(orphanMasteryState("L_owner", "a")); err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+	if err := store.InsertConceptStateIfNotExists(orphanMasteryState("L_owner", "ghost")); err != nil {
+		t.Fatalf("seed ghost: %v", err)
+	}
+
+	// Call with no domain_id — handler should aggregate concepts from
+	// ALL active domains and ignore "ghost".
+	res := callTool(t, deps, registerGetPendingAlerts, "L_owner", "get_pending_alerts", map[string]any{})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+
+	alerts, _ := out["alerts"].([]any)
+	sawA := false
+	for _, a := range alerts {
+		m, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["concept"] == "ghost" {
+			t.Fatalf("orphan concept 'ghost' surfaced in alerts: %v", alerts)
+		}
+		if m["concept"] == "a" {
+			sawA = true
+		}
+	}
+	if !sawA {
+		t.Fatalf("expected alert on 'a' (in active domain D1) to surface across multiple domains, got %v", alerts)
+	}
+	// needs_domain_setup must be false when active domains exist.
+	if got, _ := out["needs_domain_setup"].(bool); got {
+		t.Errorf("expected needs_domain_setup=false when active domains exist, got true")
 	}
 }


### PR DESCRIPTION
## Summary
- `get_pending_alerts` now honors the README contract that alert computation never surfaces history from concepts no longer in any active domain.
- Two explicit branches: when `domain_id` is given, scope alerts to that domain (also returns `domain not found` instead of silently falling through to no-filter); when `domain_id` is empty, build a union of concepts across all non-archived domains and filter `states` and `interactions` before `engine.ComputeAlerts`. Mirrors the multi-domain pattern from `tools/cockpit.go:211-218`.
- Zero active domains → clean empty payload with `needs_domain_setup=true` so the LLM can self-correct.
- `needs_domain_setup` is always present in the response (true/false) so callers can branch consistently.

Fixes #29

## Test plan
- [x] `go vet ./...` silent
- [x] New tests `TestGetPendingAlerts_NoActiveDomain_ReturnsCleanEmpty` and `TestGetPendingAlerts_MultipleActiveDomains_FiltersOutOrphan` confirmed failing on main, passing here
- [x] Existing `TestGetPendingAlerts_NoAuth` / `TestGetPendingAlerts_NoDataReturnsEmpty` / `TestGetPendingAlerts_FilterByDomain` still pass
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_