### PR TITLE
fix(engine): wrap cron.New with cron.Recover so a panicking job doesn't crash the process

### DIFF
--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -27,10 +27,40 @@ type Scheduler struct {
 }
 
 func NewScheduler(store *db.Store, logger *slog.Logger) *Scheduler {
+	// cron.New() ships no recover middleware: an unrecovered panic in any
+	// scheduled job is a goroutine panic, which Go terminates the whole
+	// process for. The HTTP recoveryMiddleware does not cover scheduler
+	// goroutines, so without WithChain(Recover(...)) a single bad-data
+	// learner could DoS the entire tutor at scheduled job times. See #35.
+	cl := slogCronLogger{l: logger}
 	return &Scheduler{
-		store: store, cron: cron.New(), logger: logger,
+		store:  store,
+		cron:   cron.New(cron.WithChain(cron.Recover(cl))),
+		logger: logger,
 		client: &http.Client{Timeout: 10 * time.Second},
 	}
+}
+
+// slogCronLogger adapts robfig/cron's Logger interface onto an *slog.Logger.
+// cron only emits two kinds of messages: routine Info and Error (the latter
+// is what cron.Recover uses to report a recovered panic + stack).
+type slogCronLogger struct {
+	l *slog.Logger
+}
+
+func (s slogCronLogger) Info(msg string, keysAndValues ...interface{}) {
+	if s.l == nil {
+		return
+	}
+	s.l.Info("cron: "+msg, keysAndValues...)
+}
+
+func (s slogCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if s.l == nil {
+		return
+	}
+	args := append([]interface{}{"err", err}, keysAndValues...)
+	s.l.Error("cron: "+msg, args...)
 }
 
 func (s *Scheduler) Start() error {

--- a/engine/scheduler_panic_test.go
+++ b/engine/scheduler_panic_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// captureHandler is an slog.Handler that records every Record into an
+// internal slice (string-formatted, just enough for substring asserts).
+// Used to verify that cron's Recover middleware actually emitted a
+// "panic" error line after a panicking job fired.
+type captureHandler struct {
+	mu   sync.Mutex
+	logs []string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.WriteString(r.Level.String())
+	sb.WriteString(" ")
+	sb.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteString(" ")
+		sb.WriteString(a.Key)
+		sb.WriteString("=")
+		sb.WriteString(a.Value.String())
+		return true
+	})
+	h.mu.Lock()
+	h.logs = append(h.logs, sb.String())
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *captureHandler) contains(substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, line := range h.logs {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestScheduler_PanickingJobDoesNotCrashLoop is the issue #35 reproducer:
+// a job that panics must NOT take down the whole process. With the fix
+// (cron.WithChain(cron.Recover(...))) the panic is caught, logged via
+// the slog adapter, and a sibling sentinel job continues to fire.
+//
+// On unfixed code (cron.New() with no Recover), the goroutine panic
+// terminates the test process — the test cannot even report failure,
+// the binary exits non-zero. That's still a clear regression signal.
+func TestScheduler_PanickingJobDoesNotCrashLoop(t *testing.T) {
+	cap := &captureHandler{}
+	logger := slog.New(cap)
+
+	s := NewScheduler(nil, logger)
+
+	// Sentinel: keeps incrementing if the cron loop is alive.
+	var sentinelHits int64
+	if _, err := s.cron.AddFunc("@every 50ms", func() {
+		atomic.AddInt64(&sentinelHits, 1)
+	}); err != nil {
+		t.Fatalf("add sentinel job: %v", err)
+	}
+
+	// Panicking job: should be neutralised by cron.Recover.
+	if _, err := s.cron.AddFunc("@every 50ms", func() {
+		panic("boom from issue-35 reproducer")
+	}); err != nil {
+		t.Fatalf("add panicking job: %v", err)
+	}
+
+	s.cron.Start()
+	defer s.cron.Stop()
+
+	// Run long enough to observe at least one sentinel tick AFTER the
+	// panicking job has fired and been recovered. robfig/cron's @every
+	// schedule rolls forward (it does not preserve sub-second granularity
+	// reliably across versions), so 1.5s is the safe floor for "we saw the
+	// loop survive multiple wakeups".
+	time.Sleep(1500 * time.Millisecond)
+
+	hits := atomic.LoadInt64(&sentinelHits)
+	if hits < 1 {
+		t.Fatalf("sentinel job never fired; cron loop appears to have died (panic took it out)")
+	}
+
+	// And the slog bridge should have surfaced the panic via cron.Recover.
+	if !cap.contains("panic") {
+		t.Fatalf("expected captured slog output to mention 'panic' (cron.Recover bridge), got logs=%v", cap.logs)
+	}
+}


### PR DESCRIPTION
## Summary
- `engine/scheduler.go` now constructs cron via `cron.New(cron.WithChain(cron.Recover(cl)))` — every scheduled job is wrapped in a defer/recover. A panic in `BuildOLMSnapshot` / `dispatchQueued` / etc. is now logged with stack and the loop continues instead of terminating the whole process.
- New `slogCronLogger` adapter (~20 lines) bridges robfig/cron's `Logger` interface (`Info`/`Error`) onto the existing `*slog.Logger` with nil-guards. Recovered panics surface as a slog `ERROR` line.
- New `engine/scheduler_panic_test.go` proves the fix: registers a sentinel + a panicking job; asserts the sentinel keeps firing and the capture handler observed a `panic` log line. Compromise: robfig/cron@v3.0.1 rounds sub-second `@every` schedules to ~1s ticks, so the test sleeps 1.5s and asserts `>= 1` sentinel hit (still proves the goroutine survived the panic).

Fixes #35

## Test plan
- [x] `go vet ./...` silent
- [x] `go test ./engine/... -v` green (2.3s)
- [x] `go test ./...` full suite green from this branch
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_