### PR TITLE
fix(auth): require client authentication on refresh_token grant

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -411,19 +411,23 @@ func (s *OAuthServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Confidential clients must authenticate on refresh too. Public clients
-	// (no client_id supplied) keep the existing PKCE-only flow.
+	// Per RFC 6749 §6 the client must authenticate on every refresh_token
+	// grant. The previous "if clientID != ''" bypass let a stolen refresh
+	// token be redeemed by any anonymous caller (issue #30 part 1). An empty
+	// client_id is now treated like malformed credentials → invalid_client.
 	clientID, clientSecret := extractClientCredentials(r)
-	if clientID != "" {
-		client, err := s.store.GetOAuthClient(clientID)
-		if err != nil {
-			writeTokenError(w, "invalid_client", http.StatusUnauthorized)
-			return
-		}
-		if err := verifyClientAuth(client, clientSecret); err != nil {
-			writeTokenError(w, "invalid_client", http.StatusUnauthorized)
-			return
-		}
+	if clientID == "" {
+		writeTokenError(w, "invalid_client", http.StatusUnauthorized)
+		return
+	}
+	client, err := s.store.GetOAuthClient(clientID)
+	if err != nil {
+		writeTokenError(w, "invalid_client", http.StatusUnauthorized)
+		return
+	}
+	if err := verifyClientAuth(client, clientSecret); err != nil {
+		writeTokenError(w, "invalid_client", http.StatusUnauthorized)
+		return
 	}
 
 	rt, err := s.store.GetRefreshToken(refreshToken)

--- a/auth/oauth_extra_test.go
+++ b/auth/oauth_extra_test.go
@@ -419,11 +419,15 @@ func TestHandleToken_RefreshToken_MissingToken(t *testing.T) {
 
 func TestHandleToken_RefreshToken_UnknownToken(t *testing.T) {
 	setTestSecret(t)
-	s, _ := newTestServer(t)
+	s, store := newTestServer(t)
+	// A registered public client is required: refresh_token grant now
+	// always authenticates the client (issue #30).
+	seedClient(t, store, "cid-pub", "https://app.example/cb")
 
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", "no-such-token")
+	form.Set("client_id", "cid-pub")
 	req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
@@ -440,6 +444,9 @@ func TestHandleToken_RefreshToken_UnknownToken(t *testing.T) {
 func TestHandleToken_RefreshToken_Success(t *testing.T) {
 	setTestSecret(t)
 	s, store := newTestServer(t)
+	// Public client (no secret) — required since refresh_token grant now
+	// always authenticates the client (issue #30).
+	seedClient(t, store, "cid-pub", "https://app.example/cb")
 	learner := seedLearner(t, store, "u-rt@e.com", "pw")
 	rt, err := store.CreateRefreshToken(learner)
 	if err != nil {
@@ -449,6 +456,7 @@ func TestHandleToken_RefreshToken_Success(t *testing.T) {
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", rt.Token)
+	form.Set("client_id", "cid-pub")
 	req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -320,3 +320,40 @@ func TestAuthorizePost_CSRFMatch_InvalidCreds(t *testing.T) {
 		t.Fatalf("status = %d, want 401 for invalid creds", rec.Code)
 	}
 }
+
+// ─── refresh_token grant: client authentication required (issue #30) ────────
+
+// TestRefreshTokenGrant_RejectsMissingClientID locks down the RFC 6749 §6
+// requirement: a refresh_token grant must authenticate the client. A POST to
+// /token with a valid refresh_token but no client_id (and no Basic auth) must
+// be rejected with 401 invalid_client. Previously the handler bypassed
+// verifyClientAuth when client_id was empty, allowing any holder of a stolen
+// refresh token to mint new access/refresh tokens with no client identity.
+func TestRefreshTokenGrant_RejectsMissingClientID(t *testing.T) {
+	s, store := newTestServer(t)
+	learnerID := seedLearner(t, store, "rt-noclient@example.com", "pw")
+	rt, err := store.CreateRefreshToken(learnerID)
+	if err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {rt.Token},
+	}
+	req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.HandleToken(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 invalid_client when client_id is omitted, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_client") {
+		t.Fatalf("body missing invalid_client: %q", rec.Body.String())
+	}
+	// And the refresh token must NOT have been rotated/consumed.
+	if _, err := store.GetRefreshToken(rt.Token); err != nil {
+		t.Fatalf("refresh token must remain valid after rejected request: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Removes the `if clientID != ""` bypass in `auth/oauth.go:407-462` (`handleRefreshTokenGrant`) that allowed a stolen refresh token to be redeemed without proving anything about the originating client (RFC 6749 §6 violation).

- Empty `client_id` on the refresh-token grant now returns `invalid_client` (401), same as malformed Basic auth.
- Registered clients still authenticate via `verifyClientAuth` — public clients pass with no secret, confidential ones still require their secret.
- Two existing tests that relied on the bypass were updated to send proper auth: `TestHandleToken_RefreshToken_Success` and `TestHandleToken_RefreshToken_UnknownToken` (both now seed a public client `cid-pub` and include `client_id` in the form). `TestHandleToken_RefreshToken_MissingToken` untouched — the empty-`refresh_token` 400 short-circuit fires before client auth.
- New reproducer `TestRefreshTokenGrant_RejectsMissingClientID` confirmed failing on main (200 + minted tokens) and now passes (401 + refresh token preserved).

## Scope — partial fix only
This is **part 1 of #30**. Two follow-ups intentionally deferred:
1. **Token-to-client binding** — adding a `client_id` column on `refresh_tokens` (schema migration), persisting at issuance, rejecting redemption when the row's client_id doesn't match the authenticated caller.
2. **Rotation-breach detection** — RFC 6749 §10.4 / RFC 6819 §5.2.2.3: revoke the entire chain when a previously-rotated token is presented.

Both follow-ups need careful migration design and are out of scope for this PR. **Use `Refs #30` not `Fixes #30`** so the issue stays open.

Refs #30

## ⚠️ Operational note — unsigned commit
Same signing-server issue as PR #46. The single commit on this branch (`c7975c8`) is unsigned. Squash-merge will rewrite the commit; verify the merge commit on `main` is signed by GitHub.

## Test plan
- [x] `go vet ./...` silent
- [x] `go test ./auth/... -run TestRefreshToken -v` green
- [x] `go test ./...` full suite green
- [x] `go build -o tutor-mcp .` builds

https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbSAYP5ePeUNyCzPF3M97)_