### PR TITLE
fix(domain): reject cyclic concept graphs in init_domain

### DIFF
--- a/tools/domain.go
+++ b/tools/domain.go
@@ -84,7 +84,132 @@ func validateConcepts(concepts []string, prereqs map[string][]string) error {
 			}
 		}
 	}
+
+	// Issue #62: the prerequisite graph MUST be a DAG. A cycle would make
+	// algorithms/kst.go ComputeFrontier and the concept_selector loop —
+	// every node in the cycle is `locked` because its prereq chain
+	// transitively depends on itself, and learners can never make
+	// progress. Reject up-front with a descriptive MCP error.
+	if cycle := findPrereqCycle(concepts, prereqs); len(cycle) > 0 {
+		return fmt.Errorf("prerequisite graph contains a cycle: %s", formatCycle(cycle))
+	}
 	return nil
+}
+
+// findPrereqCycle runs an iterative DFS with white/gray/black coloring on
+// the prerequisite graph and, if it finds a back-edge, returns the nodes
+// forming the cycle (in dependency order, with the closing node repeated
+// at the end for clarity). Returns nil if the graph is a DAG.
+//
+// Edge convention: prereqs[c] = [p1, p2] encodes p1 -> c and p2 -> c
+// (a prereq points at the concept it unlocks). We DFS in that direction
+// so a discovered back-edge is reported as `pk -> ... -> pk`.
+func findPrereqCycle(concepts []string, prereqs map[string][]string) []string {
+	const (
+		white = 0 // unvisited
+		gray  = 1 // on the current DFS stack
+		black = 2 // fully explored
+	)
+
+	// Build the forward adjacency list (prereq -> dependent). Only
+	// include nodes that appear in `concepts` to stay aligned with the
+	// universe check above.
+	adj := make(map[string][]string, len(concepts))
+	for dependent, ps := range prereqs {
+		for _, p := range ps {
+			adj[p] = append(adj[p], dependent)
+		}
+	}
+
+	color := make(map[string]int, len(concepts))
+	parent := make(map[string]string, len(concepts))
+
+	// Self-loops are degenerate cycles that DFS reports correctly, but
+	// surfacing them explicitly keeps the error message readable.
+	for dependent, ps := range prereqs {
+		for _, p := range ps {
+			if p == dependent {
+				return []string{dependent, dependent}
+			}
+		}
+	}
+
+	var cycleStart, cycleEnd string
+	var found bool
+
+	// Iterative DFS; each stack frame holds the node and its next-child index.
+	type frame struct {
+		node string
+		idx  int
+	}
+
+	for _, start := range concepts {
+		if color[start] != white {
+			continue
+		}
+		stack := []frame{{node: start, idx: 0}}
+		color[start] = gray
+
+		for len(stack) > 0 && !found {
+			top := &stack[len(stack)-1]
+			children := adj[top.node]
+			if top.idx >= len(children) {
+				color[top.node] = black
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			child := children[top.idx]
+			top.idx++
+
+			switch color[child] {
+			case white:
+				color[child] = gray
+				parent[child] = top.node
+				stack = append(stack, frame{node: child, idx: 0})
+			case gray:
+				// Back-edge: top.node -> child closes a cycle starting at child.
+				cycleStart = child
+				cycleEnd = top.node
+				found = true
+			}
+		}
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	// Reconstruct the cycle by walking parents from cycleEnd back to cycleStart.
+	path := []string{cycleEnd}
+	for n := cycleEnd; n != cycleStart; {
+		p, ok := parent[n]
+		if !ok {
+			break
+		}
+		n = p
+		path = append(path, n)
+	}
+	// Reverse so we list nodes in dependency order, then close the loop.
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	path = append(path, cycleStart)
+	return path
+}
+
+// formatCycle renders a cycle path like "a -> b -> c -> a".
+func formatCycle(cycle []string) string {
+	if len(cycle) == 0 {
+		return ""
+	}
+	out := cycle[0]
+	for _, n := range cycle[1:] {
+		out += " -> " + n
+	}
+	return out
 }
 
 func validateValueFramings(vf *ValueFramingsInput) error {

--- a/tools/domain_test.go
+++ b/tools/domain_test.go
@@ -69,6 +69,131 @@ func TestValidateConcepts(t *testing.T) {
 	}
 }
 
+// TestValidateConcepts_CycleDetection covers issue #62: the prerequisite
+// graph must be a DAG. Without this guard, KST's ComputeFrontier and the
+// concept_selector logic would loop forever on a cyclic graph (a node's
+// prereq chain never reaches a terminal `mastery >= threshold`).
+//
+// Convention: in `prerequisites`, an entry `c -> [p1, p2]` encodes edges
+// p1 -> c and p2 -> c (prereqs unlock c). A cycle in that prereq-DAG means
+// some concept transitively depends on itself.
+func TestValidateConcepts_CycleDetection(t *testing.T) {
+	cases := []struct {
+		name     string
+		concepts []string
+		prereqs  map[string][]string
+		wantErr  string // empty ⇒ expect success
+	}{
+		{
+			name:     "valid DAG (regression guard)",
+			concepts: []string{"a", "b", "c", "d"},
+			prereqs: map[string][]string{
+				"b": {"a"},
+				"c": {"b"},
+				"d": {"c", "a"},
+			},
+			wantErr: "",
+		},
+		{
+			name:     "self-loop A->A",
+			concepts: []string{"a"},
+			prereqs:  map[string][]string{"a": {"a"}},
+			wantErr:  "cycle",
+		},
+		{
+			name:     "2-cycle A->B->A",
+			concepts: []string{"a", "b"},
+			prereqs: map[string][]string{
+				"a": {"b"},
+				"b": {"a"},
+			},
+			wantErr: "cycle",
+		},
+		{
+			name:     "3-cycle A->B->C->A",
+			concepts: []string{"a", "b", "c"},
+			prereqs: map[string][]string{
+				"b": {"a"},
+				"c": {"b"},
+				"a": {"c"},
+			},
+			wantErr: "cycle",
+		},
+		{
+			name:     "disconnected graph with one cycle",
+			concepts: []string{"x", "y", "a", "b", "c"},
+			prereqs: map[string][]string{
+				"y": {"x"},        // clean DAG component
+				"b": {"a"},        // cycle component
+				"c": {"b"},
+				"a": {"c"},
+			},
+			wantErr: "cycle",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConcepts(tc.concepts, tc.prereqs)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error on valid DAG: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestInitDomain_RejectsCyclicGraph covers the integration path: an
+// init_domain MCP call with a cyclic prereq graph must be rejected before
+// any DB write. We assert (a) the call returns an MCP error, (b) the error
+// text mentions "cycle" so the LLM can recover, and (c) no domain row was
+// persisted.
+func TestInitDomain_RejectsCyclicGraph(t *testing.T) {
+	store, deps := setupToolsTest(t)
+
+	res := callTool(t, deps, registerInitDomain, "L_owner", "init_domain", map[string]any{
+		"name":     "math",
+		"concepts": []string{"a", "b", "c"},
+		"prerequisites": map[string][]string{
+			"b": {"a"},
+			"c": {"b"},
+			"a": {"c"}, // closes the cycle
+		},
+	})
+	if !res.IsError {
+		t.Fatalf("expected cycle error, got success: %q", resultText(res))
+	}
+	if !strings.Contains(strings.ToLower(resultText(res)), "cycle") {
+		t.Fatalf("expected error mentioning cycle, got %q", resultText(res))
+	}
+	if d, _ := store.GetDomainByLearner("L_owner"); d != nil {
+		t.Fatalf("domain should not have been persisted on cycle reject, got %+v", d)
+	}
+}
+
+func TestInitDomain_RejectsSelfLoop(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerInitDomain, "L_owner", "init_domain", map[string]any{
+		"name":          "math",
+		"concepts":      []string{"a"},
+		"prerequisites": map[string][]string{"a": {"a"}},
+	})
+	if !res.IsError {
+		t.Fatalf("expected cycle error for self-loop, got success: %q", resultText(res))
+	}
+	if !strings.Contains(strings.ToLower(resultText(res)), "cycle") {
+		t.Fatalf("expected error mentioning cycle, got %q", resultText(res))
+	}
+}
+
 func TestValidateValueFramings(t *testing.T) {
 	if err := validateValueFramings(nil); err != nil {
 		t.Fatalf("nil framings should be ok, got %v", err)


### PR DESCRIPTION
Fixes #62

References #8 (item: init_domain cycle detection)

## Summary

Add iterative DFS-based cycle detection to `validateConcepts` in `tools/domain.go` (white/gray/black coloring) so `init_domain` rejects any cyclic prerequisite graph before issuing a DB write. Previously a cyclic graph would let `algorithms/kst.go` `ComputeFrontier` and the concept selector loop indefinitely, since every node in the cycle stayed permanently locked.

On detection the validator returns a descriptive MCP error of the form `prerequisite graph contains a cycle: a -> b -> c -> a`, naming concrete nodes so the calling LLM can recover. The check sits after the universe + size checks in `validateConcepts`, so it also covers `add_concepts`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green across `tools`, `algorithms`, `auth`, `db`, `engine`, `models`
- [x] `TestValidateConcepts_CycleDetection` table-driven: self-loop, 2-cycle, 3-cycle, disconnected-with-cycle, valid-DAG regression guard
- [x] `TestInitDomain_RejectsCyclicGraph` integration test asserts MCP error path AND no domain persisted (via `store.GetDomainByLearner`)
- [x] `TestInitDomain_RejectsSelfLoop` integration test for the degenerate single-node case

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_