### PR TITLE
chore(models): remove unused ActivityInterleaving type

### DIFF
--- a/docs/goap-recon.md
+++ b/docs/goap-recon.md
@@ -315,11 +315,14 @@ follow-up?
 
 ### 6.9 `INTERLEAVING` is declared but never emitted
 
-The current router never produces `ActivityInterleaving`. A planner
-that thinks in sequences could naturally use it ("alternate concept A
-and concept B over 3 steps to combat illusion of competence"). Free
-expressivity gain — but also a risk of inflating action count beyond
-the 8–12 budget the brief asks for.
+**Resolved (sub-issue #64):** `ActivityInterleaving` was removed from
+`models/domain.go` because no production path ever emitted it. A
+future planner that thinks in sequences could naturally re-introduce
+it ("alternate concept A and concept B over 3 steps to combat
+illusion of competence") — free expressivity gain, but also a risk
+of inflating action count beyond the 8–12 budget the brief asks for.
+Re-introducing it must come with a Rohrer-2012-style emitter, not
+just a constant.
 
 ### 6.10 `learning_negotiation` returns a **single tradeoff per factor**, not a plan diff
 

--- a/models/domain.go
+++ b/models/domain.go
@@ -48,7 +48,6 @@ type ActivityType string
 const (
 	ActivityRecall           ActivityType = "RECALL_EXERCISE"
 	ActivityNewConcept       ActivityType = "NEW_CONCEPT"
-	ActivityInterleaving     ActivityType = "INTERLEAVING"
 	ActivityMasteryChallenge ActivityType = "MASTERY_CHALLENGE"
 	ActivityDebuggingCase    ActivityType = "DEBUGGING_CASE"
 	ActivityRest             ActivityType = "REST"

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -5,6 +5,9 @@
 package models
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"sort"
 	"testing"
 )
@@ -180,5 +183,52 @@ func TestUncoveredConcepts_MalformedJSONTreatsAllAsUncovered(t *testing.T) {
 	got := d.UncoveredConcepts()
 	if len(got) != 1 || got[0] != "A" {
 		t.Errorf("malformed JSON: want [A], got %v", got)
+	}
+}
+
+// ─── ActivityType public surface ───────────────────────────────────────────
+
+// TestActivityType_NoInterleaving is a regression guard for sub-issue #64.
+//
+// `ActivityInterleaving` ("INTERLEAVING") was declared in models/domain.go
+// but never emitted by any production code path (router, action selector).
+// It was removed as dead code rather than implementing Rohrer-style
+// interleaving (out of scope). This test parses the package source and
+// asserts that no constant of type ActivityType equals the literal
+// "INTERLEAVING" — failing if the dead type is ever re-introduced.
+func TestActivityType_NoInterleaving(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "domain.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse domain.go: %v", err)
+	}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range vs.Names {
+				if name.Name == "ActivityInterleaving" {
+					t.Fatalf("models.ActivityInterleaving must not be " +
+						"declared (sub-issue #64: removed as unused " +
+						"dead code; no production path emits it)")
+				}
+			}
+			for _, val := range vs.Values {
+				bl, ok := val.(*ast.BasicLit)
+				if !ok || bl.Kind != token.STRING {
+					continue
+				}
+				if bl.Value == `"INTERLEAVING"` {
+					t.Fatalf(`ActivityType literal "INTERLEAVING" must not ` +
+						`be declared (sub-issue #64)`)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes #64

References #8 (item: remove ActivityInterleaving)

## Summary

`ActivityInterleaving` ("INTERLEAVING") was declared in `models/domain.go` but never produced by any production path. `grep -rn ActivityInterleaving` returned only the declaration site and a single design-doc note (`docs/goap-recon.md` §6.9). Per the EASY fork in #64, this PR removes the dead constant rather than implementing Rohrer-2012 interleaving (out of scope).

Scope of deletion: 1 line in `models/domain.go`. No DB column, no JSON marshal site, no test fixture, no prompt string referenced it. Docs §6.9 updated from "smell" to "Resolved" with a forward note that any re-introduction must ship with an emitter, not just a constant.

Added regression guard `TestActivityType_NoInterleaving` in `models/domain_test.go` that parses `domain.go` via `go/ast` and fails if either the identifier `ActivityInterleaving` or the string literal `"INTERLEAVING"` is re-introduced. Test was written first (failed pre-removal, passes post-removal).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` green across all packages
- [x] `TestActivityType_NoInterleaving` regression guard fails on pre-removal source, passes on post-removal source
- [x] No new `go.mod` deps (uses stdlib `go/ast`, `go/parser`, `go/token`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_