### PR TITLE
test(prompt): assert system prompt covers registered tools

### DIFF
--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -70,6 +70,10 @@ OUTILS DISPONIBLES :
 - add_concepts(domain_id?, concepts, prerequisites) : ajoute des concepts
 - update_learner_profile(device?, background?, learning_style?, objective?, language?, level?, calibration_bias?, affect_baseline?, autonomy_score?) : métadonnées persistantes
 - get_misconceptions(domain_id?, concept?) : liste les misconceptions détectées par concept
+- get_olm_snapshot(domain_id?, scope?) : snapshot transparent de l'état d'apprentissage (mastery distrib, focus, signaux métacognitifs, progression goal). scope='session' (défaut) ou 'global'
+- archive_domain(domain_id) : archive un domaine — il disparaît du dashboard et du routing, progression préservée
+- unarchive_domain(domain_id) : réactive un domaine archivé
+- delete_domain(domain_id, confirm) : supprime définitivement un domaine (concept_states et interactions préservés). confirm=true requis
 
 REGLES ABSOLUES — à chaque réponse, dans cet ordre :
 

--- a/tools/prompt_test.go
+++ b/tools/prompt_test.go
@@ -5,6 +5,8 @@ package tools
 
 import (
 	"context"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -40,5 +42,125 @@ func TestRegisterPrompt_ReturnsSystemPrompt(t *testing.T) {
 	}
 	if !strings.Contains(msg.Text, "tutor MCP") {
 		t.Fatalf("expected systemPrompt body to mention 'tutor MCP'")
+	}
+}
+
+// promptToolBulletRE matches the canonical "OUTILS DISPONIBLES" /
+// "OUTILS GOAL-AWARE" entries — a hyphen, a space, a snake_case identifier,
+// and an opening parenthesis. This is the strictest lexically-anchored token
+// the prompt uses to declare a tool surface and avoids false positives on
+// prose that incidentally mentions a tool by name.
+var promptToolBulletRE = regexp.MustCompile(`(?m)^- ([a-z_][a-z0-9_]*)\(`)
+
+// extractDocumentedTools pulls the set of tool names declared in the prompt
+// header bullet lists. Free-prose mentions inside the rules section are
+// intentionally ignored: the bullet list is the contract, the rules are
+// commentary.
+func extractDocumentedTools(prompt string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range promptToolBulletRE.FindAllStringSubmatch(prompt, -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
+// extractRegisteredTools wires up RegisterTools against an in-memory MCP
+// server, lists the registered tools and returns their canonical names. This
+// mirrors TestRegisterTools_Smoke and ensures the consistency check uses the
+// same source of truth as production startup.
+func extractRegisteredTools(t *testing.T) map[string]bool {
+	t.Helper()
+	_, deps := setupToolsTest(t)
+	ctx := context.Background()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	RegisterTools(server, deps)
+
+	st, ct := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatal(err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "0"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	res, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	out := map[string]bool{}
+	for _, tool := range res.Tools {
+		out[tool.Name] = true
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestSystemPrompt_ToolRegistryConsistency asserts that the system prompt
+// bullet list and the runtime tool registry stay in lockstep. Drift in
+// either direction (registered-but-undocumented, documented-but-unregistered)
+// fails the test with a sorted, human-readable list.
+//
+// Both surfaces are exercised under the same feature-flag configuration:
+// REGULATION_GOAL is forced "on" so the goal-aware tools (set_goal_relevance,
+// get_goal_relevance) and their corresponding prompt appendix are both
+// active and must agree.
+func TestSystemPrompt_ToolRegistryConsistency(t *testing.T) {
+	// Force a deterministic flag config for the comparison. The action /
+	// concept / gate / fade appendices are documentation-only (they don't
+	// register new tools), so toggling them does not affect this test —
+	// we leave them at their package defaults.
+	t.Setenv("REGULATION_GOAL", "on")
+
+	registered := extractRegisteredTools(t)
+	prompt := buildSystemPrompt()
+	documented := extractDocumentedTools(prompt)
+
+	if len(registered) == 0 {
+		t.Fatalf("no registered tools discovered — RegisterTools wiring is broken")
+	}
+	if len(documented) == 0 {
+		t.Fatalf("no documented tools parsed from prompt — bullet format may have changed (regex %q)", promptToolBulletRE.String())
+	}
+
+	var registeredButUndocumented []string
+	for name := range registered {
+		if !documented[name] {
+			registeredButUndocumented = append(registeredButUndocumented, name)
+		}
+	}
+	sort.Strings(registeredButUndocumented)
+
+	var documentedButUnregistered []string
+	for name := range documented {
+		if !registered[name] {
+			documentedButUnregistered = append(documentedButUnregistered, name)
+		}
+	}
+	sort.Strings(documentedButUnregistered)
+
+	if len(registeredButUndocumented) > 0 || len(documentedButUnregistered) > 0 {
+		t.Fatalf(
+			"system prompt vs tool registry drift detected\n"+
+				"  registered-but-undocumented (%d): %s\n"+
+				"  documented-but-unregistered (%d): %s\n"+
+				"  full registered set: %s\n"+
+				"  full documented set: %s",
+			len(registeredButUndocumented), strings.Join(registeredButUndocumented, ", "),
+			len(documentedButUnregistered), strings.Join(documentedButUnregistered, ", "),
+			strings.Join(sortedKeys(registered), ", "),
+			strings.Join(sortedKeys(documented), ", "),
+		)
 	}
 }


### PR DESCRIPTION
Fixes #63

References #8 (item: system prompt vs tool registry consistency)

## Summary

New test `TestSystemPrompt_ToolRegistryConsistency` in `tools/prompt_test.go` that wires `RegisterTools` against an in-memory MCP server (matching the existing smoke-test path) to obtain the canonical registered tool set, parses tool tokens out of the prompt's `OUTILS DISPONIBLES` / `OUTILS GOAL-AWARE` bullets via a strict regex (`^- name(...`), and asserts bidirectional coverage. On failure it emits a sorted, human-readable diff naming the drift items.

The test runs with `REGULATION_GOAL=on` so the goal-aware tools and their prompt appendix are both active and must agree.

## Drift fixed

Four registered-but-undocumented tools were surfaced and added to `OUTILS DISPONIBLES` with descriptions derived from each `Tool.Description`:

- `get_olm_snapshot`
- `archive_domain`
- `unarchive_domain`
- `delete_domain`

No documented-but-unregistered drift was found.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green across all packages
- [x] `go test ./tools/ -run TestSystemPrompt_ToolRegistryConsistency -v` passes
- [x] Test reads canonical registry; failure mode is a sorted diff
- [x] No new `go.mod` deps; no `t.Skip`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_