### PR TITLE
feat(db): track schema_migrations with checksum drift detection

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
-// GitHub: https://github.com/ArnaudGuiovanna
+// GitHub: https://github.com/ArnaudGuiovanna/tutor-mcp
 // SPDX-License-Identifier: MIT
 
 package db
@@ -26,131 +26,99 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-func Migrate(db *sql.DB) error {
-	_, err := db.Exec(schemaSQL)
-	if err != nil {
-		return fmt.Errorf("migrate: %w", err)
-	}
-	// Incremental migrations for existing databases (ALTER TABLE is idempotent-safe)
-	alterMigrations := []string{
-		`ALTER TABLE learners ADD COLUMN profile_json TEXT DEFAULT '{}'`,
-		`ALTER TABLE interactions ADD COLUMN error_type TEXT DEFAULT ''`,
-		`ALTER TABLE interactions ADD COLUMN hints_requested INTEGER DEFAULT 0`,
-		`ALTER TABLE interactions ADD COLUMN self_initiated INTEGER DEFAULT 0`,
-		`ALTER TABLE interactions ADD COLUMN calibration_id TEXT DEFAULT ''`,
-		`ALTER TABLE interactions ADD COLUMN is_proactive_review INTEGER DEFAULT 0`,
-		`ALTER TABLE domains ADD COLUMN personal_goal TEXT DEFAULT ''`,
-		`ALTER TABLE domains ADD COLUMN archived INTEGER DEFAULT 0`,
-		`ALTER TABLE interactions ADD COLUMN misconception_type TEXT`,
-		`ALTER TABLE interactions ADD COLUMN misconception_detail TEXT`,
-		`ALTER TABLE domains ADD COLUMN value_framings_json TEXT DEFAULT ''`,
-		`ALTER TABLE domains ADD COLUMN last_value_axis TEXT DEFAULT ''`,
-		`ALTER TABLE oauth_codes ADD COLUMN client_id TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE oauth_clients ADD COLUMN client_secret_hash TEXT DEFAULT ''`,
-		`ALTER TABLE domains ADD COLUMN pinned_concept TEXT DEFAULT ''`,
-		// [1] GoalDecomposer — graph version + goal relevance vector storage.
-		// graph_version starts at 1 for existing rows so the next add_concepts
-		// makes IsGoalRelevanceStale() true vs goal_relevance_version=0.
-		`ALTER TABLE domains ADD COLUMN graph_version INTEGER NOT NULL DEFAULT 1`,
-		`ALTER TABLE domains ADD COLUMN goal_relevance_json TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE domains ADD COLUMN goal_relevance_version INTEGER NOT NULL DEFAULT 0`,
-		// [2] PhaseController — FSM state per domain. NULL on existing
-		// rows means "pre-pipeline domain, treat as PhaseInstruction"
-		// (backward-compat per OQ-2.1.b). New domains are initialised
-		// to DIAGNOSTIC explicitly by tools/domain.go init_domain.
-		`ALTER TABLE domains ADD COLUMN phase TEXT`,
-		`ALTER TABLE domains ADD COLUMN phase_changed_at TIMESTAMP`,
-		`ALTER TABLE domains ADD COLUMN phase_entry_entropy REAL`,
-		// Historical chat_mode_enabled column: added then dropped after the
-		// iframe surface was retired. Both statements stay in the ALTER list
-		// so a fresh DB is reconciled with one that already saw the column.
-		// DROP COLUMN requires SQLite >= 3.35 (modernc.org/sqlite ships above).
-		`ALTER TABLE learners ADD COLUMN chat_mode_enabled INTEGER NOT NULL DEFAULT 0`,
-		`ALTER TABLE learners DROP COLUMN chat_mode_enabled`,
-		// Issue #24: persist domain_id on interaction rows so two domains
-		// sharing a concept name can be told apart in audits and downstream
-		// analytics. Nullable: pre-existing rows stay NULL (origin unknown).
-		`ALTER TABLE interactions ADD COLUMN domain_id TEXT`,
-		// Issue #30 part 2: bind refresh_token rows to the issuing client
-		// so a stolen token cannot be redeemed by a different (e.g. self-
-		// registered confidential) client. Nullable: pre-existing rows
-		// stay NULL and bypass the binding check (compat with v0.2 tokens
-		// that were issued before the migration).
-		`ALTER TABLE refresh_tokens ADD COLUMN client_id TEXT`,
-		// Issue #51: log the slip/guess values that the non-canonical
-		// error-type-aware heuristic (algorithms.BKTUpdateHeuristicSlipByErrorType)
-		// actually fed into the BKT update on each interaction so the
-		// run can be replayed deterministically. Nullable: pre-existing
-		// rows have no record (NULL means "unknown / heuristic not
-		// captured at write time").
-		`ALTER TABLE interactions ADD COLUMN bkt_slip REAL`,
-		`ALTER TABLE interactions ADD COLUMN bkt_guess REAL`,
-		// Issue #55: PFA persisted state was written but never consumed —
-		// engine/alert.go recomputes PFA in-memory from the interactions
-		// list each call. Drop the dead columns. Forward-only: there is
-		// no "down" migration. The errors are swallowed by the loop's
-		// `_, _ = db.Exec(m)` so re-running on a DB where the columns
-		// are already gone is a no-op (idempotent). DROP COLUMN requires
-		// SQLite >= 3.35; modernc.org/sqlite v1.47 ships above that.
-		`ALTER TABLE concept_states DROP COLUMN pfa_successes`,
-		`ALTER TABLE concept_states DROP COLUMN pfa_failures`,
-	}
-	for _, m := range alterMigrations {
-		_, _ = db.Exec(m) // ignore "duplicate column" errors
-	}
+// alterMigrations are historical incremental schema changes. Each statement is
+// recorded as its own migration in schema_migrations so future drift can be
+// detected on a per-statement basis. Errors during Exec are tolerated (see
+// migration.IgnoreExecErrors) because legacy databases will already have most
+// of these columns from the previous "best-effort ALTER" loop.
+var alterMigrations = []string{
+	`ALTER TABLE learners ADD COLUMN profile_json TEXT DEFAULT '{}'`,
+	`ALTER TABLE interactions ADD COLUMN error_type TEXT DEFAULT ''`,
+	`ALTER TABLE interactions ADD COLUMN hints_requested INTEGER DEFAULT 0`,
+	`ALTER TABLE interactions ADD COLUMN self_initiated INTEGER DEFAULT 0`,
+	`ALTER TABLE interactions ADD COLUMN calibration_id TEXT DEFAULT ''`,
+	`ALTER TABLE interactions ADD COLUMN is_proactive_review INTEGER DEFAULT 0`,
+	`ALTER TABLE domains ADD COLUMN personal_goal TEXT DEFAULT ''`,
+	`ALTER TABLE domains ADD COLUMN archived INTEGER DEFAULT 0`,
+	`ALTER TABLE interactions ADD COLUMN misconception_type TEXT`,
+	`ALTER TABLE interactions ADD COLUMN misconception_detail TEXT`,
+	`ALTER TABLE domains ADD COLUMN value_framings_json TEXT DEFAULT ''`,
+	`ALTER TABLE domains ADD COLUMN last_value_axis TEXT DEFAULT ''`,
+	`ALTER TABLE oauth_codes ADD COLUMN client_id TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE oauth_clients ADD COLUMN client_secret_hash TEXT DEFAULT ''`,
+	`ALTER TABLE domains ADD COLUMN pinned_concept TEXT DEFAULT ''`,
+	// [1] GoalDecomposer — graph version + goal relevance vector storage.
+	// graph_version starts at 1 for existing rows so the next add_concepts
+	// makes IsGoalRelevanceStale() true vs goal_relevance_version=0.
+	`ALTER TABLE domains ADD COLUMN graph_version INTEGER NOT NULL DEFAULT 1`,
+	`ALTER TABLE domains ADD COLUMN goal_relevance_json TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE domains ADD COLUMN goal_relevance_version INTEGER NOT NULL DEFAULT 0`,
+	// [2] PhaseController — FSM state per domain. NULL on existing
+	// rows means "pre-pipeline domain, treat as PhaseInstruction"
+	// (backward-compat per OQ-2.1.b). New domains are initialised
+	// to DIAGNOSTIC explicitly by tools/domain.go init_domain.
+	`ALTER TABLE domains ADD COLUMN phase TEXT`,
+	`ALTER TABLE domains ADD COLUMN phase_changed_at TIMESTAMP`,
+	`ALTER TABLE domains ADD COLUMN phase_entry_entropy REAL`,
+	// Historical chat_mode_enabled column: added then dropped after the
+	// iframe surface was retired. Both statements stay in the ALTER list
+	// so a fresh DB is reconciled with one that already saw the column.
+	// DROP COLUMN requires SQLite >= 3.35 (modernc.org/sqlite ships above).
+	`ALTER TABLE learners ADD COLUMN chat_mode_enabled INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE learners DROP COLUMN chat_mode_enabled`,
+	// Issue #24: persist domain_id on interaction rows so two domains
+	// sharing a concept name can be told apart in audits and downstream
+	// analytics. Nullable: pre-existing rows stay NULL (origin unknown).
+	`ALTER TABLE interactions ADD COLUMN domain_id TEXT`,
+	// Issue #30 part 2: bind refresh_token rows to the issuing client
+	// so a stolen token cannot be redeemed by a different (e.g. self-
+	// registered confidential) client. Nullable: pre-existing rows
+	// stay NULL and bypass the binding check (compat with v0.2 tokens
+	// that were issued before the migration).
+	`ALTER TABLE refresh_tokens ADD COLUMN client_id TEXT`,
+	// Issue #51: log the slip/guess values that the non-canonical
+	// error-type-aware heuristic (algorithms.BKTUpdateHeuristicSlipByErrorType)
+	// actually fed into the BKT update on each interaction so the
+	// run can be replayed deterministically. Nullable: pre-existing
+	// rows have no record (NULL means "unknown / heuristic not
+	// captured at write time").
+	`ALTER TABLE interactions ADD COLUMN bkt_slip REAL`,
+	`ALTER TABLE interactions ADD COLUMN bkt_guess REAL`,
+	// Issue #55: PFA persisted state was written but never consumed —
+	// engine/alert.go recomputes PFA in-memory from the interactions
+	// list each call. Drop the dead columns. Forward-only: there is
+	// no "down" migration. DROP COLUMN requires SQLite >= 3.35;
+	// modernc.org/sqlite v1.47 ships above that.
+	`ALTER TABLE concept_states DROP COLUMN pfa_successes`,
+	`ALTER TABLE concept_states DROP COLUMN pfa_failures`,
+}
 
-	// Data migration: BKT.PLearn default lowered from 0.30 to 0.15 after
-	// the synthetic-learner harness investigation showed BKT systematically
-	// over-estimates mastery by +0.27 with PLearn=0.30 (see
-	// eval/PLEARN_FINDINGS.md). Idempotent: matches no rows after the
-	// first run on this database.
-	if _, err := db.Exec(`UPDATE concept_states SET p_learn = 0.15 WHERE p_learn = 0.3`); err != nil {
-		return fmt.Errorf("data migration plearn: %w", err)
-	}
-
-	// Issue #61: scrub the legacy `level`, `background`, `learning_style`
-	// keys out of profile_json. These were write-only fields on
-	// update_learner_profile with no production reader (no consumer in
-	// motivation, concept selection, alerts, dashboard). Forward-only —
-	// the tool no longer accepts them so re-introduction is impossible
-	// without code changes. json_remove is idempotent: a second run on a
-	// scrubbed row is a no-op (the keys are already absent).
-	if _, err := db.Exec(
-		`UPDATE learners
-		 SET profile_json = json_remove(profile_json, '$.level', '$.background', '$.learning_style')
-		 WHERE profile_json IS NOT NULL
-		   AND profile_json != ''
-		   AND (json_extract(profile_json, '$.level') IS NOT NULL
-		     OR json_extract(profile_json, '$.background') IS NOT NULL
-		     OR json_extract(profile_json, '$.learning_style') IS NOT NULL)`,
-	); err != nil {
-		return fmt.Errorf("data migration drop learner profile fields: %w", err)
-	}
-
-	// Idempotent table + index creation for existing databases
-	idempotentMigrations := []string{
-		`CREATE TABLE IF NOT EXISTS oauth_codes (
-			code           TEXT PRIMARY KEY,
-			learner_id     TEXT NOT NULL REFERENCES learners(id),
-			code_challenge TEXT NOT NULL,
-			client_id      TEXT NOT NULL DEFAULT '',
-			expires_at     DATETIME NOT NULL,
-			created_at     DATETIME DEFAULT CURRENT_TIMESTAMP
-		)`,
-		`CREATE TABLE IF NOT EXISTS oauth_clients (
-			client_id          TEXT PRIMARY KEY,
-			client_name        TEXT DEFAULT '',
-			redirect_uris      TEXT DEFAULT '[]',
-			client_secret_hash TEXT DEFAULT '',
-			created_at         DATETIME DEFAULT CURRENT_TIMESTAMP
-		)`,
-		`CREATE INDEX IF NOT EXISTS idx_concept_states_learner ON concept_states(learner_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_concept_states_review ON concept_states(learner_id, next_review)`,
-		`CREATE INDEX IF NOT EXISTS idx_interactions_learner_created ON interactions(learner_id, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_interactions_learner_concept ON interactions(learner_id, concept, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_scheduled_alerts_learner_type ON scheduled_alerts(learner_id, alert_type, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_codes(expires_at)`,
-		`CREATE TABLE IF NOT EXISTS affect_states (
+// idempotentMigrations are CREATE TABLE/INDEX IF NOT EXISTS statements that
+// were historically rerun on every startup. They are now versioned individually
+// so a body change is caught as drift rather than silently re-executed.
+var idempotentMigrations = []string{
+	`CREATE TABLE IF NOT EXISTS oauth_codes (
+				code           TEXT PRIMARY KEY,
+				learner_id     TEXT NOT NULL REFERENCES learners(id),
+				code_challenge TEXT NOT NULL,
+				client_id      TEXT NOT NULL DEFAULT '',
+				expires_at     DATETIME NOT NULL,
+				created_at     DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`,
+	`CREATE TABLE IF NOT EXISTS oauth_clients (
+				client_id          TEXT PRIMARY KEY,
+				client_name        TEXT DEFAULT '',
+				redirect_uris      TEXT DEFAULT '[]',
+				client_secret_hash TEXT DEFAULT '',
+				created_at         DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`,
+	`CREATE INDEX IF NOT EXISTS idx_concept_states_learner ON concept_states(learner_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_concept_states_review ON concept_states(learner_id, next_review)`,
+	`CREATE INDEX IF NOT EXISTS idx_interactions_learner_created ON interactions(learner_id, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_interactions_learner_concept ON interactions(learner_id, concept, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_scheduled_alerts_learner_type ON scheduled_alerts(learner_id, alert_type, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_codes(expires_at)`,
+	`CREATE TABLE IF NOT EXISTS affect_states (
     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
     learner_id           TEXT NOT NULL REFERENCES learners(id),
     session_id           TEXT NOT NULL,
@@ -163,7 +131,7 @@ func Migrate(db *sql.DB) error {
     created_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(learner_id, session_id)
 )`,
-		`CREATE TABLE IF NOT EXISTS calibration_records (
+	`CREATE TABLE IF NOT EXISTS calibration_records (
     prediction_id TEXT PRIMARY KEY,
     learner_id    TEXT NOT NULL REFERENCES learners(id),
     concept_id    TEXT NOT NULL,
@@ -172,7 +140,7 @@ func Migrate(db *sql.DB) error {
     delta         REAL,
     created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
 )`,
-		`CREATE TABLE IF NOT EXISTS transfer_records (
+	`CREATE TABLE IF NOT EXISTS transfer_records (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     learner_id   TEXT NOT NULL REFERENCES learners(id),
     concept_id   TEXT NOT NULL,
@@ -181,12 +149,12 @@ func Migrate(db *sql.DB) error {
     session_id   TEXT DEFAULT '',
     created_at   DATETIME DEFAULT CURRENT_TIMESTAMP
 )`,
-		`CREATE INDEX IF NOT EXISTS idx_affect_states_learner ON affect_states(learner_id, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_calibration_records_learner ON calibration_records(learner_id, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_transfer_records_learner_concept ON transfer_records(learner_id, concept_id, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_interactions_self_initiated ON interactions(learner_id, self_initiated, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_interactions_misconception ON interactions(learner_id, concept, misconception_type)`,
-		`CREATE TABLE IF NOT EXISTS implementation_intentions (
+	`CREATE INDEX IF NOT EXISTS idx_affect_states_learner ON affect_states(learner_id, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_calibration_records_learner ON calibration_records(learner_id, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_transfer_records_learner_concept ON transfer_records(learner_id, concept_id, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_interactions_self_initiated ON interactions(learner_id, self_initiated, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_interactions_misconception ON interactions(learner_id, concept, misconception_type)`,
+	`CREATE TABLE IF NOT EXISTS implementation_intentions (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     learner_id     TEXT    NOT NULL REFERENCES learners(id),
     domain_id      TEXT    NOT NULL,
@@ -196,7 +164,7 @@ func Migrate(db *sql.DB) error {
     created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     scheduled_for  DATETIME
 )`,
-		`CREATE TABLE IF NOT EXISTS webhook_message_queue (
+	`CREATE TABLE IF NOT EXISTS webhook_message_queue (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     learner_id     TEXT    NOT NULL REFERENCES learners(id),
     kind           TEXT    NOT NULL,
@@ -208,12 +176,33 @@ func Migrate(db *sql.DB) error {
     created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     sent_at        DATETIME
 )`,
-		`CREATE INDEX IF NOT EXISTS idx_impl_intent_learner ON implementation_intentions(learner_id, created_at)`,
-		`CREATE INDEX IF NOT EXISTS idx_wmq_dispatch ON webhook_message_queue(learner_id, kind, status, scheduled_for)`,
+	`CREATE INDEX IF NOT EXISTS idx_impl_intent_learner ON implementation_intentions(learner_id, created_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_wmq_dispatch ON webhook_message_queue(learner_id, kind, status, scheduled_for)`,
+}
+
+// Migrate brings the database schema up to the version expected by this build.
+//
+// On first run it creates the schema_migrations bookkeeping table, then walks
+// the ordered list returned by buildMigrations() applying any rows that are
+// not yet recorded. On subsequent runs it verifies every previously applied
+// migration's stored SHA-256 checksum still matches the in-source body, and
+// returns an error containing "checksum mismatch" if a body has drifted —
+// rollback is intentionally out of scope, drift requires manual operator
+// intervention.
+//
+// The first invocation against a pre-existing database (one created before the
+// schema_migrations table existed) re-executes every migration body. Each
+// statement is either idempotent (CREATE TABLE/INDEX IF NOT EXISTS, the data
+// UPDATEs) or is marked IgnoreExecErrors so a "duplicate column" from an ALTER
+// that already ran does not abort startup; only the final INSERT into
+// schema_migrations is required to succeed.
+func Migrate(db *sql.DB) error {
+	if err := ensureSchemaMigrationsTable(db); err != nil {
+		return fmt.Errorf("migrate: %w", err)
 	}
-	for _, m := range idempotentMigrations {
-		if _, err := db.Exec(m); err != nil {
-			return fmt.Errorf("idempotent migration: %w", err)
+	for _, m := range buildMigrations() {
+		if err := applyMigration(db, m); err != nil {
+			return fmt.Errorf("migrate: %w", err)
 		}
 	}
 	return nil

--- a/db/migrations_checksum.go
+++ b/db/migrations_checksum.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna/tutor-mcp
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// migration is a single versioned schema change. Body is the SQL executed when
+// the migration is first applied; Checksum is computed from Body and persisted
+// in schema_migrations to detect drift on subsequent startups.
+//
+// IgnoreExecErrors is set for ALTER-style migrations whose statements may
+// already have been applied to a pre-existing database (e.g. "duplicate column"
+// from sqlite). For those, errors during Exec are intentionally swallowed so
+// the migration can still be recorded as applied.
+type migration struct {
+	Version          string
+	Body             string
+	IgnoreExecErrors bool
+}
+
+// checksum returns the lowercase hex SHA-256 of the migration body. Whitespace
+// is preserved deliberately so editing a body — even cosmetically — surfaces as
+// a checksum mismatch on the next startup. Operators who knowingly want to
+// rewrite history must update the row in schema_migrations themselves.
+func (m migration) checksum() string {
+	sum := sha256.Sum256([]byte(m.Body))
+	return hex.EncodeToString(sum[:])
+}
+
+// ensureSchemaMigrationsTable creates the bookkeeping table used by Migrate to
+// track which migrations have been applied and the checksum they were applied
+// with. Called unconditionally before any other migration runs.
+func ensureSchemaMigrationsTable(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+    version    TEXT PRIMARY KEY,
+    checksum   TEXT NOT NULL,
+    applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`)
+	if err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+	return nil
+}
+
+// applyMigration executes one migration if it has not been applied yet, or
+// verifies its stored checksum if it has. A mismatch returns an error
+// containing "checksum mismatch" so callers (and tests) can detect drift.
+func applyMigration(db *sql.DB, m migration) error {
+	var storedChecksum string
+	row := db.QueryRow(`SELECT checksum FROM schema_migrations WHERE version = ?`, m.Version)
+	switch err := row.Scan(&storedChecksum); err {
+	case nil:
+		if storedChecksum != m.checksum() {
+			return fmt.Errorf(
+				"schema_migrations: checksum mismatch for version %q: stored=%s current=%s "+
+					"(migration body changed since it was applied; manual intervention required)",
+				m.Version, storedChecksum, m.checksum(),
+			)
+		}
+		return nil
+	case sql.ErrNoRows:
+		// fall through to apply
+	default:
+		return fmt.Errorf("schema_migrations: read version %q: %w", m.Version, err)
+	}
+
+	if _, err := db.Exec(m.Body); err != nil {
+		if !m.IgnoreExecErrors {
+			return fmt.Errorf("apply migration %q: %w", m.Version, err)
+		}
+		// IgnoreExecErrors covers ALTERs already applied on legacy DBs
+		// ("duplicate column name", "no such column" on DROP COLUMN, etc.).
+		// We still record the checksum so subsequent runs are pure no-ops.
+		_ = err
+	}
+	if _, err := db.Exec(
+		`INSERT INTO schema_migrations (version, checksum) VALUES (?, ?)`,
+		m.Version, m.checksum(),
+	); err != nil {
+		return fmt.Errorf("record migration %q: %w", m.Version, err)
+	}
+	return nil
+}
+
+// buildMigrations assembles the ordered migration list from the embedded
+// schema.sql, the historical ALTER list, the BKT data migration, and the
+// idempotent CREATE TABLE/INDEX list. The order here is the canonical apply
+// order; appending new entries is safe, reordering is not.
+func buildMigrations() []migration {
+	out := make([]migration, 0, 2+len(alterMigrations)+1+len(idempotentMigrations))
+	out = append(out, migration{
+		Version: "0001_base_schema",
+		Body:    schemaSQL,
+	})
+	for i, body := range alterMigrations {
+		out = append(out, migration{
+			Version: fmt.Sprintf("0002_alter_%03d_%s", i+1, alterShortName(body)),
+			Body:    body,
+			// ALTERs may already be present on legacy DBs that ran the old
+			// "ignore errors" migrator. Swallow per-statement errors so the
+			// row still gets recorded.
+			IgnoreExecErrors: true,
+		})
+	}
+	out = append(out, migration{
+		Version: "0003_data_plearn_default_0_15",
+		Body:    `UPDATE concept_states SET p_learn = 0.15 WHERE p_learn = 0.3`,
+	})
+	// Issue #61: scrub the legacy `level`, `background`, `learning_style`
+	// keys out of profile_json. The tool no longer accepts them so the
+	// re-introduction surface is closed; json_remove is idempotent.
+	out = append(out, migration{
+		Version: "0003_data_drop_legacy_learner_profile_fields",
+		Body: `UPDATE learners
+		 SET profile_json = json_remove(profile_json, '$.level', '$.background', '$.learning_style')
+		 WHERE profile_json IS NOT NULL
+		   AND profile_json != ''
+		   AND (json_extract(profile_json, '$.level') IS NOT NULL
+		     OR json_extract(profile_json, '$.background') IS NOT NULL
+		     OR json_extract(profile_json, '$.learning_style') IS NOT NULL)`,
+	})
+	for i, body := range idempotentMigrations {
+		out = append(out, migration{
+			Version: fmt.Sprintf("0004_idempotent_%03d_%s", i+1, alterShortName(body)),
+			Body:    body,
+		})
+	}
+	return out
+}
+
+// alterShortName extracts a short, stable token from a SQL statement to make
+// the version key human-readable. It is purely cosmetic — the checksum, not the
+// version string, is what guards integrity.
+func alterShortName(sql string) string {
+	// Take the first significant identifier-ish run of characters.
+	const maxLen = 40
+	var b strings.Builder
+	prevSpace := true
+	for _, r := range sql {
+		switch {
+		case r == '\n' || r == '\t':
+			if !prevSpace {
+				b.WriteByte('_')
+				prevSpace = true
+			}
+		case r == ' ':
+			if !prevSpace {
+				b.WriteByte('_')
+				prevSpace = true
+			}
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_':
+			b.WriteRune(r)
+			prevSpace = false
+		default:
+			if !prevSpace {
+				b.WriteByte('_')
+				prevSpace = true
+			}
+		}
+		if b.Len() >= maxLen {
+			break
+		}
+	}
+	s := strings.Trim(b.String(), "_")
+	if s == "" {
+		return "stmt"
+	}
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	return strings.ToLower(s)
+}

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -158,6 +159,12 @@ func TestMigrate_DropsPFAColumns(t *testing.T) {
 	})
 
 	// Scenario 2: pre-#55 DB upgraded.
+	//
+	// Under the schema_migrations + checksum system the DROP COLUMN
+	// migrations run exactly once per database, recorded by version.
+	// To simulate a real pre-#55 DB we apply the base schema directly
+	// and seed the legacy columns BEFORE Migrate runs — that mirrors
+	// the upgrade path a deployed v0.2 DB would actually take.
 	t.Run("upgrade_from_pre_55", func(t *testing.T) {
 		dsn := fmt.Sprintf("file:migrate_pfa_upgrade_%d?mode=memory&cache=shared", testDBCounter+10200)
 		testDBCounter++
@@ -167,11 +174,13 @@ func TestMigrate_DropsPFAColumns(t *testing.T) {
 		}
 		t.Cleanup(func() { db.Close() })
 
-		// First migration brings the schema up to current.
-		if err := Migrate(db); err != nil {
-			t.Fatalf("first Migrate: %v", err)
+		// Apply the embedded base schema directly. CREATE TABLE IF NOT
+		// EXISTS keeps it compatible with Migrate's own bookkeeping run
+		// later in the test.
+		if _, err := db.Exec(schemaSQL); err != nil {
+			t.Fatalf("apply base schema: %v", err)
 		}
-		// Re-introduce the legacy columns to simulate a pre-#55 DB.
+		// Seed the legacy columns to simulate a pre-#55 DB.
 		for _, col := range pfaCols {
 			if _, err := db.Exec(fmt.Sprintf(
 				"ALTER TABLE concept_states ADD COLUMN %s REAL DEFAULT 0.0", col,
@@ -182,18 +191,19 @@ func TestMigrate_DropsPFAColumns(t *testing.T) {
 				t.Fatalf("seed column %s should exist", col)
 			}
 		}
-		// Second migration must drop them again — idempotent.
+		// Migrate must drop them as part of the versioned ALTER list.
 		if err := Migrate(db); err != nil {
-			t.Fatalf("second Migrate: %v", err)
+			t.Fatalf("Migrate: %v", err)
 		}
 		for _, col := range pfaCols {
 			if hasColumn(t, db, "concept_states", col) {
 				t.Errorf("concept_states.%s should have been dropped by Migrate", col)
 			}
 		}
-		// Third migration must remain a no-op (no panic, no error).
+		// Subsequent Migrate calls must remain no-ops (checksums match,
+		// no migration body is re-executed).
 		if err := Migrate(db); err != nil {
-			t.Fatalf("third Migrate (idempotent): %v", err)
+			t.Fatalf("second Migrate (idempotent): %v", err)
 		}
 	})
 }
@@ -217,13 +227,14 @@ func TestMigrate_DropsLegacyLearnerProfileFields(t *testing.T) {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	// Run an initial migration so the learners table (and profile_json
-	// column) exists, then seed legacy rows BEFORE the second migration
-	// runs the data scrub. The migration is idempotent so the seed runs
-	// after a no-op second call would also work — but seeding between
-	// two Migrate() calls makes the assertion order obvious.
-	if err := Migrate(db); err != nil {
-		t.Fatalf("first Migrate: %v", err)
+	// Apply the embedded base schema directly (CREATE TABLE IF NOT EXISTS
+	// so it stays compatible with the schema_migrations bookkeeping in
+	// Migrate). Seeding legacy rows BEFORE Migrate is what we need to test
+	// here — the data-scrub migration is now versioned and runs exactly
+	// once, on the first Migrate it sees, so the seed must precede it
+	// (the same shape any deployed pre-#61 DB had at upgrade time).
+	if _, err := db.Exec(schemaSQL); err != nil {
+		t.Fatalf("apply base schema: %v", err)
 	}
 	seed := []struct {
 		id      string
@@ -254,7 +265,7 @@ func TestMigrate_DropsLegacyLearnerProfileFields(t *testing.T) {
 	}
 
 	if err := Migrate(db); err != nil {
-		t.Fatalf("second Migrate (must scrub legacy keys): %v", err)
+		t.Fatalf("Migrate (must scrub legacy keys): %v", err)
 	}
 
 	// Each dropped key must be absent (json_extract returns NULL) on
@@ -339,5 +350,155 @@ func TestOpenDB_BadPath(t *testing.T) {
 	_, err := OpenDB("/proc/0/forbidden-not-a-real-sqlite-file")
 	if err == nil {
 		t.Fatal("expected error for unreachable path")
+	}
+}
+
+// openMigrateTestDB returns a fresh in-memory sqlite handle scoped to the
+// current test. Sub-issue #65 tests need to inspect the schema_migrations
+// table directly, so they bypass the higher-level Store helper.
+func openMigrateTestDB(t *testing.T, suffix string) *sql.DB {
+	t.Helper()
+	testDBCounter++
+	dsn := fmt.Sprintf("file:memdb_%s_%s_%d?mode=memory&cache=shared", t.Name(), suffix, testDBCounter)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// TestMigrate_RecordsSchemaMigrationsRows guards the bookkeeping contract:
+// after Migrate() succeeds on a fresh database the schema_migrations table
+// must exist and contain one row per migration in buildMigrations(), each
+// with a non-empty checksum that matches the in-source body. This is the
+// "fresh DB" arm of sub-issue #65.
+func TestMigrate_RecordsSchemaMigrationsRows(t *testing.T) {
+	db := openMigrateTestDB(t, "fresh")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// schema_migrations must exist as a table.
+	var name string
+	if err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'`,
+	).Scan(&name); err != nil {
+		t.Fatalf("schema_migrations table missing: %v", err)
+	}
+
+	// Row count == migration count.
+	expected := buildMigrations()
+	var rowCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&rowCount); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rowCount != len(expected) {
+		t.Fatalf("schema_migrations row count = %d, want %d", rowCount, len(expected))
+	}
+
+	// Every migration is recorded with the correct, non-empty checksum.
+	for _, m := range expected {
+		var (
+			storedChecksum string
+			appliedAt      sql.NullTime
+		)
+		err := db.QueryRow(
+			`SELECT checksum, applied_at FROM schema_migrations WHERE version = ?`, m.Version,
+		).Scan(&storedChecksum, &appliedAt)
+		if err != nil {
+			t.Fatalf("missing row for version %q: %v", m.Version, err)
+		}
+		if storedChecksum == "" {
+			t.Errorf("version %q: checksum is empty", m.Version)
+		}
+		if storedChecksum != m.checksum() {
+			t.Errorf("version %q: stored checksum %q != current %q",
+				m.Version, storedChecksum, m.checksum())
+		}
+		if !appliedAt.Valid {
+			t.Errorf("version %q: applied_at is NULL", m.Version)
+		}
+	}
+}
+
+// TestMigrate_ReRunIsNoOp asserts that running Migrate twice does not insert
+// duplicate schema_migrations rows and does not change applied_at — proving
+// the second pass took the "checksum already matches, skip" branch rather
+// than re-executing every body.
+func TestMigrate_ReRunIsNoOp(t *testing.T) {
+	db := openMigrateTestDB(t, "rerun")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+
+	// Snapshot rows after the first pass.
+	type row struct {
+		version   string
+		checksum  string
+		appliedAt string
+	}
+	snap := func() []row {
+		rows, err := db.Query(`SELECT version, checksum, applied_at FROM schema_migrations ORDER BY version`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		defer rows.Close()
+		var out []row
+		for rows.Next() {
+			var r row
+			if err := rows.Scan(&r.version, &r.checksum, &r.appliedAt); err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			out = append(out, r)
+		}
+		return out
+	}
+
+	before := snap()
+	if err := Migrate(db); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	after := snap()
+
+	if len(before) != len(after) {
+		t.Fatalf("row count changed: before=%d after=%d", len(before), len(after))
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("row %d drifted on re-run: before=%+v after=%+v", i, before[i], after[i])
+		}
+	}
+}
+
+// TestMigrate_DetectsChecksumDrift simulates an operator (or a corrupted
+// replica) editing a migration body after it was applied. The next call to
+// Migrate must refuse to start and surface a "checksum mismatch" error so
+// the drift is visible rather than silently accepted.
+func TestMigrate_DetectsChecksumDrift(t *testing.T) {
+	db := openMigrateTestDB(t, "drift")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+
+	// Pick the base schema migration and corrupt its stored checksum to
+	// simulate the source body having changed since it was applied.
+	const tampered = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	res, err := db.Exec(
+		`UPDATE schema_migrations SET checksum = ? WHERE version = '0001_base_schema'`, tampered,
+	)
+	if err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	if n, _ := res.RowsAffected(); n != 1 {
+		t.Fatalf("expected to tamper 1 row, got %d", n)
+	}
+
+	err = Migrate(db)
+	if err == nil {
+		t.Fatal("expected checksum-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error %q does not contain 'checksum mismatch'", err.Error())
 	}
 }


### PR DESCRIPTION
Fixes #65

References #8 (item: schema_migrations checksum)

## Summary

Adds a minimal `schema_migrations` bookkeeping table and refactors `db/migrations.go` to apply migrations through a versioned, checksum-aware loop.

```sql
CREATE TABLE schema_migrations (
    version    TEXT PRIMARY KEY,
    checksum   TEXT NOT NULL,
    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);
```

- Each migration's body is hashed with stdlib `crypto/sha256` (lowercase hex SHA-256) and recorded on first apply.
- On every subsequent startup, stored checksums are compared against in-source bodies; a mismatch returns:
  `schema_migrations: checksum mismatch for version "<X>": stored=... current=... (migration body changed since it was applied; manual intervention required)`
- Base `schema.sql`, each historical `ALTER`, the BKT data migration, and each idempotent `CREATE TABLE/INDEX IF NOT EXISTS` are now individually versioned.

Pre-existing databases stay compatible: ALTER migrations carry an `IgnoreExecErrors` flag so legacy "duplicate column" errors don't abort startup, and CREATEs remain `IF NOT EXISTS`.

**Rollback is intentionally out of scope** — drift requires manual operator action.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` green
- [x] `TestMigrate_RecordsSchemaMigrationsRows` — fresh DB writes one row per migration with non-empty checksum matching source
- [x] `TestMigrate_ReRunIsNoOp` — second `Migrate` leaves rows (and `applied_at`) unchanged
- [x] `TestMigrate_DetectsChecksumDrift` — tampering with a stored checksum surfaces `"checksum mismatch"`
- [x] Pre-existing `TestMigrate_Idempotent` still passes (back-compat with legacy ALTER swallowing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_