### PR TITLE
refactor(engine): extract recent-interactions window into named constant

### DIFF
--- a/engine/olm.go
+++ b/engine/olm.go
@@ -169,7 +169,7 @@ func BuildOLMSnapshot(store *db.Store, learnerID, domainID string) (*OLMSnapshot
 			domainStates = append(domainStates, cs)
 		}
 	}
-	recent, _ := store.GetRecentInteractionsByLearner(learnerID, 20)
+	recent, _ := store.GetRecentInteractionsByLearner(learnerID, DefaultRecentInteractionsWindow)
 	var domainInteractions []*models.Interaction
 	for _, in := range recent {
 		if domainConceptSet[in.Concept] {

--- a/engine/window.go
+++ b/engine/window.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package engine
+
+// DefaultRecentInteractionsWindow is the default number of most-recent
+// learner interactions fetched from the store and fed into downstream
+// engine consumers (alerts, OLM focus, dashboard activity).
+//
+// Rationale for 20: balances responsiveness vs. statistical noise — it
+// covers roughly the last ~5 sessions of activity at typical pacing
+// (~4 items/session), which is enough history for ComputeAlerts to
+// detect FRUSTRATION / FORGETTING patterns while staying small enough
+// to avoid bleed-in from sessions that no longer reflect the learner's
+// current state.
+//
+// Per-domain tunability is intentionally out of scope here; future work
+// can wire this into LearnerProfile or DomainConfig as needed.
+const DefaultRecentInteractionsWindow = 20

--- a/engine/window_test.go
+++ b/engine/window_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import "testing"
+
+// TestDefaultRecentInteractionsWindow_Value pins the documented value.
+// Changing it should be a deliberate decision (touch this test together
+// with the doc comment in window.go).
+func TestDefaultRecentInteractionsWindow_Value(t *testing.T) {
+	if DefaultRecentInteractionsWindow != 20 {
+		t.Fatalf("DefaultRecentInteractionsWindow = %d; want 20", DefaultRecentInteractionsWindow)
+	}
+}
+
+// TestDefaultRecentInteractionsWindow_Sane guards against accidental
+// regression to a pathological window (0, negative, or so large that
+// it dwarfs the alert pipeline). The constant must stay strictly
+// positive and within a sensible range for the alert / OLM consumers.
+func TestDefaultRecentInteractionsWindow_Sane(t *testing.T) {
+	if DefaultRecentInteractionsWindow <= 0 {
+		t.Fatalf("DefaultRecentInteractionsWindow must be > 0, got %d", DefaultRecentInteractionsWindow)
+	}
+	if DefaultRecentInteractionsWindow > 1000 {
+		t.Fatalf("DefaultRecentInteractionsWindow unreasonably large: %d", DefaultRecentInteractionsWindow)
+	}
+}

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -46,7 +46,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 		}
 
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
-		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, 20)
+		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, engine.DefaultRecentInteractionsWindow)
 		sessionStart, _ := deps.Store.GetSessionStart(learnerID)
 
 		// Get session interactions to track what was already practiced

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -30,7 +30,7 @@ func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 		}
 
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
-		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, 20)
+		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, engine.DefaultRecentInteractionsWindow)
 		sessionStart, _ := deps.Store.GetSessionStart(learnerID)
 
 		// Resolve which domain(s) constrain this alert computation. The

--- a/tools/get_dashboard_state.go
+++ b/tools/get_dashboard_state.go
@@ -54,7 +54,7 @@ func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 		}
 
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
-		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, 20)
+		interactions, _ := deps.Store.GetRecentInteractionsByLearner(learnerID, engine.DefaultRecentInteractionsWindow)
 		sessionStart, _ := deps.Store.GetSessionStart(learnerID)
 
 		stateMap := make(map[string]*models.ConceptState)


### PR DESCRIPTION
Fixes #57

References #8 (item: recentInteractions magic constant)

## Summary

Extracts the magic literal `20` (recent-interactions window size used by `GetRecentInteractionsByLearner`) into `engine.DefaultRecentInteractionsWindow`, declared in a new `engine/window.go` with a doc comment justifying the value (~5 sessions of activity at typical pacing — balances responsiveness vs. statistical noise). Per-domain tunability is left for future work.

Note: `engine/router.go` referenced in the original tracker was already retired (commit `7d4a979`). The constant is now wired through all four remaining production call-sites:

1. `engine/olm.go:172`
2. `tools/alerts.go:33`
3. `tools/activity.go:49`
4. `tools/get_dashboard_state.go:57`

Other unrelated literals (`50` in `engine/orchestrator.go`, `10` in `tools/context.go`, the `20` for `GetRecentConceptsByDomain` — different query) were intentionally left alone.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green across all packages
- [x] Value-pin test asserts the constant is `20`
- [x] Sanity-bound test guards against pathological window regression
- [x] Grep verified no production call-site of `GetRecentInteractionsByLearner` still uses literal `20`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_