### PR TITLE
chore(motivation): remove cosmetic recontextualize tutor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,7 @@ The system adapts its communication register based on affect state:
 |------|---------|
 | `normal` | Default |
 | `scaffolding` | Learner reports high anxiety (confidence = 1) |
-| `lighter` | Learner reports fatigue (energy = 1) or frustration (2 negative sessions) |
-| `recontextualize` | High energy but low satisfaction (boredom detected) |
+| `lighter` | Learner reports fatigue (energy = 1), frustration, or boredom (negative affect with low satisfaction) |
 
 ## Authentication
 

--- a/engine/metacognition.go
+++ b/engine/metacognition.go
@@ -286,12 +286,11 @@ func ComputeTutorMode(affect *models.AffectState, alerts []models.Alert) string 
 		}
 	}
 
-	// Affect negative: bored (high energy + low satisfaction) → recontextualize
-	if hasAffectNegative && affect.Energy >= 3 && affect.Satisfaction <= 2 {
-		return "recontextualize"
-	}
-
-	// Affect negative: frustration → lighter
+	// Affect negative (frustration or boredom): low satisfaction → lighter.
+	// (The previously distinct "recontextualize" branch for high-energy boredom
+	// was removed in #60: it was purely cosmetic — the only side effect was
+	// appending a label to Activity.Rationale, with no different prompt,
+	// selector input, or persistence. Both sub-cases now map to "lighter".)
 	if hasAffectNegative && affect.Satisfaction <= 2 {
 		return "lighter"
 	}

--- a/engine/metacognition_test.go
+++ b/engine/metacognition_test.go
@@ -197,7 +197,7 @@ func TestComputeTutorMode(t *testing.T) {
 		{"scaffolding — anxious", &models.AffectState{SubjectConfidence: 1}, nil, "scaffolding"},
 		{"lighter — fatigued", &models.AffectState{Energy: 1, SubjectConfidence: 3}, nil, "lighter"},
 		{"lighter — affect negative frustration", &models.AffectState{Energy: 2, Satisfaction: 1}, []models.Alert{{Type: models.AlertAffectNegative}}, "lighter"},
-		{"recontextualize — bored", &models.AffectState{Energy: 4, Satisfaction: 1}, []models.Alert{{Type: models.AlertAffectNegative}}, "recontextualize"},
+		{"lighter — affect negative bored (was recontextualize)", &models.AffectState{Energy: 4, Satisfaction: 1}, []models.Alert{{Type: models.AlertAffectNegative}}, "lighter"},
 		{"normal — happy", &models.AffectState{Energy: 3, SubjectConfidence: 3, Satisfaction: 3}, nil, "normal"},
 	}
 
@@ -208,6 +208,43 @@ func TestComputeTutorMode(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestComputeTutorMode_NeverReturnsRecontextualize is a regression guard for
+// issue #60: the cosmetic "recontextualize" mode was removed because it had no
+// behavioural effect (it only appended a label suffix to Activity.Rationale).
+// This sweep exercises the full input space ComputeTutorMode reads and asserts
+// the removed mode is never produced.
+func TestComputeTutorMode_NeverReturnsRecontextualize(t *testing.T) {
+	alertSets := [][]models.Alert{
+		nil,
+		{{Type: models.AlertAffectNegative}},
+		{{Type: models.AlertCalibrationDiverging}},
+		{{Type: models.AlertAffectNegative}, {Type: models.AlertCalibrationDiverging}},
+	}
+	// AffectState fields used by ComputeTutorMode are Energy, Satisfaction,
+	// SubjectConfidence — sweep their full 0..5 range.
+	for _, alerts := range alertSets {
+		for energy := 0; energy <= 5; energy++ {
+			for sat := 0; sat <= 5; sat++ {
+				for conf := 0; conf <= 5; conf++ {
+					affect := &models.AffectState{
+						Energy:            energy,
+						Satisfaction:      sat,
+						SubjectConfidence: conf,
+					}
+					got := ComputeTutorMode(affect, alerts)
+					if got == "recontextualize" {
+						t.Errorf("ComputeTutorMode returned removed mode %q for affect=%+v alerts=%v", got, affect, alerts)
+					}
+				}
+			}
+		}
+	}
+	// Nil-affect path.
+	if got := ComputeTutorMode(nil, nil); got == "recontextualize" {
+		t.Errorf("ComputeTutorMode(nil, nil) returned removed mode %q", got)
 	}
 }
 

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -155,8 +155,6 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			}
 		case "scaffolding":
 			activity.DifficultyTarget *= 0.75
-		case "recontextualize":
-			activity.Rationale += " · recontextualisation demandée"
 		}
 
 		// Apply calibration bias adjustment

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -85,7 +85,7 @@ REGLES ABSOLUES — à chaque réponse, dans cet ordre :
    → Appelle get_pending_alerts(domain_id)
    → Si alert critique : agis dessus en priorité
    → Sinon : appelle get_next_activity(domain_id) — contient miroir + tutor_mode
-   → Si tutor_mode != normal : adapte ton registre (scaffolding/lighter/recontextualize)
+   → Si tutor_mode != normal : adapte ton registre (scaffolding/lighter)
    → Si metacognitive_mirror est présent : transmets le message tel quel, sans reformuler
    → Appelle calibration_check(concept_id, predicted_mastery) avant l'exercice
      (demande à l'apprenant d'estimer sa maîtrise 1-5)


### PR DESCRIPTION
Fixes #60

References #8 (item: recontextualize cosmetic tutor mode)

## Summary

Removes the `recontextualize` tutor mode from the metacognition selector and the `get_next_activity` handler. `grep -rn "recontextualize\|Recontextualize\|RECONTEXTUALIZE"` confirmed the mode had no behavioural effect — only echoed as a label, with the handler-side action being a single Rationale string suffix (cosmetic, no different prompt, no selector input, no DB column, no schema persistence).

The boredom case (`AlertAffectNegative` + `Energy >= 3` + `Satisfaction <= 2`) now collapses naturally into the existing `lighter` branch, which already covers `Satisfaction <= 2` with `AlertAffectNegative`.

## Sites removed (5)

1. `engine/metacognition.go:289-292` — selector branch returning `"recontextualize"`
2. `engine/metacognition_test.go:200` — bored-case row now expects `"lighter"`
3. `tools/activity.go:158-159` — cosmetic `case "recontextualize"` Rationale suffix
4. `tools/prompt.go:88` — `(scaffolding/lighter/recontextualize)` listing
5. `README.md:231` — tutor-mode table row

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green
- [x] `TestComputeTutorMode_NeverReturnsRecontextualize` regression sweep over the full input space (Energy/Satisfaction/SubjectConfidence 0..5 × four alert combos); failed pre-removal, passes post-removal
- [x] `TestComputeTutorMode` bored-case row updated
- [x] No DB schema changes; no new `go.mod` deps

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_