### PR TITLE
refactor(bkt): rename heuristic + log slip/guess to audit trail

### DIFF
--- a/algorithms/bkt.go
+++ b/algorithms/bkt.go
@@ -55,13 +55,25 @@ func BKTUpdate(state BKTState, correct bool) BKTState {
 	return result
 }
 
-// BKTUpdateWithErrorType adjusts BKT parameters based on error type before updating.
+// BKTUpdateHeuristicSlipByErrorType adjusts BKT slip/guess parameters based on
+// the error type before applying a standard BKT update. NOTE: this is a
+// PROJECT-SPECIFIC HEURISTIC, not part of canonical BKT (Corbett & Anderson
+// 1995, "Knowledge Tracing: Modeling the Acquisition of Procedural
+// Knowledge"). The literature treats slip and guess as fixed per-skill
+// parameters; ramping them per-observation by an externally-supplied error
+// label has no source in the BKT corpus and is a heuristic introduced here.
+// The function is named to keep the deviation explicit at every call-site.
+//
 // SYNTAX_ERROR: careless mistake — higher slip, less penalizing to mastery.
 // KNOWLEDGE_GAP: genuine lack of understanding — lower guess, more penalizing.
-// LOGIC_ERROR or empty: standard BKT update.
-func BKTUpdateWithErrorType(state BKTState, correct bool, errorType string) BKTState {
+// LOGIC_ERROR or empty: standard BKT update (no heuristic ramp).
+//
+// The returned (slipUsed, guessUsed) values are the parameters the heuristic
+// fed into BKTUpdate for this observation; callers should log them to the
+// interaction audit trail so the run can be replayed deterministically.
+func BKTUpdateHeuristicSlipByErrorType(state BKTState, correct bool, errorType string) (next BKTState, slipUsed, guessUsed float64) {
 	if correct || errorType == "" {
-		return BKTUpdate(state, correct)
+		return BKTUpdate(state, correct), state.PSlip, state.PGuess
 	}
 
 	adjusted := state
@@ -76,7 +88,7 @@ func BKTUpdateWithErrorType(state BKTState, correct bool, errorType string) BKTS
 	}
 	// LOGIC_ERROR uses standard parameters
 
-	return BKTUpdate(adjusted, correct)
+	return BKTUpdate(adjusted, correct), adjusted.PSlip, adjusted.PGuess
 }
 
 func BKTIsMastered(state BKTState) bool {

--- a/algorithms/bkt_test.go
+++ b/algorithms/bkt_test.go
@@ -46,7 +46,7 @@ func TestBKTUpdateClampsToOne(t *testing.T) {
 	}
 }
 
-func TestBKTUpdateWithErrorType(t *testing.T) {
+func TestBKTUpdateHeuristicSlipByErrorType(t *testing.T) {
 	base := BKTState{PMastery: 0.5, PLearn: 0.3, PForget: 0.05, PSlip: 0.1, PGuess: 0.2}
 
 	tests := []struct {
@@ -72,7 +72,8 @@ func TestBKTUpdateWithErrorType(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := BKTUpdateWithErrorType(base, tc.correct, tc.errorType).PMastery
+			next, _, _ := BKTUpdateHeuristicSlipByErrorType(base, tc.correct, tc.errorType)
+			got := next.PMastery
 			ref := standard
 			if tc.correct {
 				ref = standardCorrect
@@ -147,14 +148,16 @@ func TestBKTUpdateNoNaNOrInfOnDegenerateInputs(t *testing.T) {
 	}
 }
 
-// TestBKTUpdateWithErrorTypeNoNaNOrInf is the same guard at the
-// BKTUpdateWithErrorType layer — KNOWLEDGE_GAP/SYNTAX_ERROR mutate inputs
-// before delegating, so we want to make sure the guard still holds end-to-end.
-func TestBKTUpdateWithErrorTypeNoNaNOrInf(t *testing.T) {
+// TestBKTUpdateHeuristicSlipByErrorTypeNoNaNOrInf is the same guard at the
+// renamed heuristic layer — KNOWLEDGE_GAP/SYNTAX_ERROR mutate slip/guess
+// inputs before delegating to BKTUpdate, so we want to make sure the guard
+// still holds end-to-end. The function now returns three values; only the
+// state is checked here for finiteness.
+func TestBKTUpdateHeuristicSlipByErrorTypeNoNaNOrInf(t *testing.T) {
 	degenerate := BKTState{PMastery: 0, PLearn: 0.3, PForget: 0.05, PSlip: 0, PGuess: 0}
 	for _, et := range []string{"", "LOGIC_ERROR", "SYNTAX_ERROR", "KNOWLEDGE_GAP", "UNKNOWN"} {
 		t.Run("errorType="+et, func(t *testing.T) {
-			got := BKTUpdateWithErrorType(degenerate, true, et)
+			got, _, _ := BKTUpdateHeuristicSlipByErrorType(degenerate, true, et)
 			if math.IsNaN(got.PMastery) || math.IsInf(got.PMastery, 0) {
 				t.Errorf("PMastery NaN/Inf for errorType=%q: %v", et, got.PMastery)
 			}
@@ -162,17 +165,60 @@ func TestBKTUpdateWithErrorTypeNoNaNOrInf(t *testing.T) {
 	}
 }
 
-func TestBKTUpdateWithErrorTypeClampsParameters(t *testing.T) {
+func TestBKTUpdateHeuristicSlipByErrorTypeClampsParameters(t *testing.T) {
 	// SYNTAX_ERROR: PSlip clamped to <= 0.5 even when input is high.
 	highSlip := BKTState{PMastery: 0.5, PLearn: 0.3, PForget: 0.05, PSlip: 0.45, PGuess: 0.2}
-	got := BKTUpdateWithErrorType(highSlip, false, "SYNTAX_ERROR")
+	got, _, _ := BKTUpdateHeuristicSlipByErrorType(highSlip, false, "SYNTAX_ERROR")
 	if got.PMastery < 0 || got.PMastery > 1 {
 		t.Errorf("PMastery out of bounds: %f", got.PMastery)
 	}
 	// KNOWLEDGE_GAP: PGuess clamped to >= 0.05 even when input is low.
 	lowGuess := BKTState{PMastery: 0.5, PLearn: 0.3, PForget: 0.05, PSlip: 0.1, PGuess: 0.06}
-	got = BKTUpdateWithErrorType(lowGuess, false, "KNOWLEDGE_GAP")
+	got, _, _ = BKTUpdateHeuristicSlipByErrorType(lowGuess, false, "KNOWLEDGE_GAP")
 	if got.PMastery < 0 || got.PMastery > 1 {
 		t.Errorf("PMastery out of bounds: %f", got.PMastery)
 	}
 }
+
+// TestBKTUpdateHeuristicSlipByErrorType_ReturnsSlipGuessUsed verifies the
+// function reports the slip/guess values it actually fed into BKTUpdate so
+// callers can log them to the audit trail (issue #51).
+func TestBKTUpdateHeuristicSlipByErrorType_ReturnsSlipGuessUsed(t *testing.T) {
+	base := BKTState{PMastery: 0.5, PLearn: 0.3, PForget: 0.05, PSlip: 0.1, PGuess: 0.2}
+
+	// Correct answer: the heuristic does not adjust — we should see the
+	// input slip/guess unchanged.
+	_, slip, guess := BKTUpdateHeuristicSlipByErrorType(base, true, "SYNTAX_ERROR")
+	if !approxEqual(slip, base.PSlip, 1e-9) || !approxEqual(guess, base.PGuess, 1e-9) {
+		t.Errorf("correct answer should report base params, got slip=%f guess=%f", slip, guess)
+	}
+
+	// Empty errorType: standard BKT — base params reported.
+	_, slip, guess = BKTUpdateHeuristicSlipByErrorType(base, false, "")
+	if !approxEqual(slip, base.PSlip, 1e-9) || !approxEqual(guess, base.PGuess, 1e-9) {
+		t.Errorf("empty errorType should report base params, got slip=%f guess=%f", slip, guess)
+	}
+
+	// SYNTAX_ERROR: slip ramps up by 0.15 (clamped).
+	_, slip, guess = BKTUpdateHeuristicSlipByErrorType(base, false, "SYNTAX_ERROR")
+	if !approxEqual(slip, 0.25, 1e-9) {
+		t.Errorf("SYNTAX_ERROR should ramp slip to 0.25, got %f", slip)
+	}
+	if !approxEqual(guess, base.PGuess, 1e-9) {
+		t.Errorf("SYNTAX_ERROR should leave guess at base, got %f", guess)
+	}
+
+	// KNOWLEDGE_GAP: guess ramps down by 0.10 (clamped).
+	_, slip, guess = BKTUpdateHeuristicSlipByErrorType(base, false, "KNOWLEDGE_GAP")
+	if !approxEqual(slip, base.PSlip, 1e-9) {
+		t.Errorf("KNOWLEDGE_GAP should leave slip at base, got %f", slip)
+	}
+	if !approxEqual(guess, 0.10, 1e-9) {
+		t.Errorf("KNOWLEDGE_GAP should ramp guess to 0.10, got %f", guess)
+	}
+}
+
+// Compile-time guard: the public symbol exposed to call-sites must be the new
+// "Heuristic" name. If someone reverts the rename this test file refuses to
+// build — that is the point (issue #51).
+var _ = BKTUpdateHeuristicSlipByErrorType

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -77,6 +77,14 @@ func Migrate(db *sql.DB) error {
 		// stay NULL and bypass the binding check (compat with v0.2 tokens
 		// that were issued before the migration).
 		`ALTER TABLE refresh_tokens ADD COLUMN client_id TEXT`,
+		// Issue #51: log the slip/guess values that the non-canonical
+		// error-type-aware heuristic (algorithms.BKTUpdateHeuristicSlipByErrorType)
+		// actually fed into the BKT update on each interaction so the
+		// run can be replayed deterministically. Nullable: pre-existing
+		// rows have no record (NULL means "unknown / heuristic not
+		// captured at write time").
+		`ALTER TABLE interactions ADD COLUMN bkt_slip REAL`,
+		`ALTER TABLE interactions ADD COLUMN bkt_guess REAL`,
 	}
 	for _, m := range alterMigrations {
 		_, _ = db.Exec(m) // ignore "duplicate column" errors

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -73,6 +73,12 @@ CREATE TABLE IF NOT EXISTS interactions (
     is_proactive_review INTEGER DEFAULT 0,
     misconception_type    TEXT,
     misconception_detail  TEXT,
+    -- bkt_slip / bkt_guess: the slip/guess parameters the non-canonical
+    -- error-type-aware heuristic (algorithms.BKTUpdateHeuristicSlipByErrorType)
+    -- fed into the BKT update for this observation. Logged so the run can
+    -- be replayed. Nullable: pre-issue-#51 rows have no record. (#51 / #8)
+    bkt_slip      REAL,
+    bkt_guess     REAL,
     created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/db/store.go
+++ b/db/store.go
@@ -72,6 +72,17 @@ func nullString(s string) any {
 	return s
 }
 
+// nullFloat64 returns nil when the input pointer is nil and the dereferenced
+// value otherwise. Used to write columns that distinguish "absent" from
+// "literal zero" (e.g. interactions.bkt_slip / bkt_guess on pre-issue-#51
+// rows).
+func nullFloat64(p *float64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 func boolToInt(b bool) int {
 	if b {
 		return 1
@@ -646,18 +657,19 @@ func (s *Store) GetConceptStatesByLearner(learnerID string) ([]*models.ConceptSt
 
 // ─── Interactions ─────────────────────────────────────────────────────────────
 
-const interactionCols = `id, learner_id, concept, activity_type, success, response_time, confidence, error_type, notes, hints_requested, self_initiated, calibration_id, is_proactive_review, misconception_type, misconception_detail, domain_id, created_at`
+const interactionCols = `id, learner_id, concept, activity_type, success, response_time, confidence, error_type, notes, hints_requested, self_initiated, calibration_id, is_proactive_review, misconception_type, misconception_detail, domain_id, bkt_slip, bkt_guess, created_at`
 
 func (s *Store) CreateInteraction(i *models.Interaction) error {
 	i.CreatedAt = time.Now().UTC()
 	result, err := s.db.Exec(
-		`INSERT INTO interactions (learner_id, concept, activity_type, success, response_time, confidence, error_type, notes, hints_requested, self_initiated, calibration_id, is_proactive_review, misconception_type, misconception_detail, domain_id, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO interactions (learner_id, concept, activity_type, success, response_time, confidence, error_type, notes, hints_requested, self_initiated, calibration_id, is_proactive_review, misconception_type, misconception_detail, domain_id, bkt_slip, bkt_guess, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		i.LearnerID, i.Concept, i.ActivityType, boolToInt(i.Success),
 		i.ResponseTime, i.Confidence, i.ErrorType, i.Notes,
 		i.HintsRequested, boolToInt(i.SelfInitiated), i.CalibrationID, boolToInt(i.IsProactiveReview),
 		nullString(i.MisconceptionType), nullString(i.MisconceptionDetail),
 		nullString(i.DomainID),
+		nullFloat64(i.BKTSlip), nullFloat64(i.BKTGuess),
 		i.CreatedAt,
 	)
 	if err != nil {
@@ -717,11 +729,13 @@ func scanInteractions(rows *sql.Rows) ([]*models.Interaction, error) {
 		i := &models.Interaction{}
 		var successInt, selfInitInt, proactiveInt int
 		var errorType, calibrationID, misconceptionType, misconceptionDetail, domainID sql.NullString
+		var bktSlip, bktGuess sql.NullFloat64
 		if err := rows.Scan(
 			&i.ID, &i.LearnerID, &i.Concept, &i.ActivityType,
 			&successInt, &i.ResponseTime, &i.Confidence, &errorType, &i.Notes,
 			&i.HintsRequested, &selfInitInt, &calibrationID, &proactiveInt,
 			&misconceptionType, &misconceptionDetail, &domainID,
+			&bktSlip, &bktGuess,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan interaction row: %w", err)
@@ -743,6 +757,14 @@ func scanInteractions(rows *sql.Rows) ([]*models.Interaction, error) {
 		}
 		if domainID.Valid {
 			i.DomainID = domainID.String
+		}
+		if bktSlip.Valid {
+			v := bktSlip.Float64
+			i.BKTSlip = &v
+		}
+		if bktGuess.Valid {
+			v := bktGuess.Float64
+			i.BKTGuess = &v
 		}
 		interactions = append(interactions, i)
 	}

--- a/models/learner.go
+++ b/models/learner.go
@@ -74,6 +74,14 @@ type Interaction struct {
 	MisconceptionType   string
 	MisconceptionDetail string
 	DomainID            string // optional, blank for pre-issue-#24 rows
+	// BKTSlip / BKTGuess capture the slip/guess parameters the project's
+	// non-canonical error-type-aware heuristic
+	// (algorithms.BKTUpdateHeuristicSlipByErrorType) actually fed into the
+	// BKT update for this observation, so the run can be replayed
+	// deterministically. Pointers so a NULL on pre-issue-#51 rows stays
+	// distinguishable from a legitimate zero. See issue #51 / #8.
+	BKTSlip             *float64
+	BKTGuess            *float64
 	CreatedAt           time.Time
 }
 

--- a/tools/interaction_apply.go
+++ b/tools/interaction_apply.go
@@ -83,6 +83,21 @@ func applyInteraction(
 	}
 	priorNextReview := cs.NextReview
 
+	// ── BKT update — non-canonical, project-specific heuristic that
+	// ramps slip/guess by error_type. Computed up front (it only reads
+	// from the prior snapshot) so the (slipUsed, guessUsed) values can
+	// be persisted on the interaction row below for deterministic
+	// replay (issue #51 / #8). The PMastery write-back to `cs` happens
+	// in the merged-result block at the end of the function.
+	bktState := algorithms.BKTState{
+		PMastery: priorPMastery,
+		PLearn:   priorPLearn,
+		PForget:  priorPForget,
+		PSlip:    priorPSlip,
+		PGuess:   priorPGuess,
+	}
+	bktState, slipUsed, guessUsed := algorithms.BKTUpdateHeuristicSlipByErrorType(bktState, input.Success, input.ErrorType)
+
 	// Build and persist the interaction row.
 	interaction := &models.Interaction{
 		LearnerID:      learnerID,
@@ -97,6 +112,8 @@ func applyInteraction(
 		SelfInitiated:  input.SelfInitiated,
 		CalibrationID:  input.CalibrationID,
 		DomainID:       input.DomainID,
+		BKTSlip:        &slipUsed,
+		BKTGuess:       &guessUsed,
 		CreatedAt:      now,
 	}
 
@@ -114,16 +131,6 @@ func applyInteraction(
 	if err := deps.Store.CreateInteraction(interaction); err != nil {
 		return nil, fmt.Errorf("applyInteraction: create interaction: %w", err)
 	}
-
-	// ── BKT update — error-type-aware. Reads from prior snapshot. ──
-	bktState := algorithms.BKTState{
-		PMastery: priorPMastery,
-		PLearn:   priorPLearn,
-		PForget:  priorPForget,
-		PSlip:    priorPSlip,
-		PGuess:   priorPGuess,
-	}
-	bktState = algorithms.BKTUpdateWithErrorType(bktState, input.Success, input.ErrorType)
 
 	// ── FSRS update — reads from prior snapshot. ───────────────────
 	rating := algorithms.Good

--- a/tools/interaction_test.go
+++ b/tools/interaction_test.go
@@ -13,6 +13,11 @@ import (
 	"tutor-mcp/models"
 )
 
+// Compile-time guard: make sure the BKT heuristic is exposed under its new
+// renamed name. If a future refactor reverts the rename this file refuses
+// to build (issue #51).
+var _ = algorithms.BKTUpdateHeuristicSlipByErrorType
+
 func TestRecordInteraction_NoAuth(t *testing.T) {
 	_, deps := setupToolsTest(t)
 	res := callTool(t, deps, registerRecordInteraction, "", "record_interaction", map[string]any{
@@ -334,6 +339,109 @@ func TestRecordInteraction_RejectsOutOfRangeHints(t *testing.T) {
 	}
 	if !strings.Contains(resultText(res), "hints_requested") {
 		t.Fatalf("expected error to mention 'hints_requested', got %q", resultText(res))
+	}
+}
+
+// Issue #51: each interaction must persist the slip/guess values the
+// non-canonical error-type heuristic fed into the BKT update so the run
+// can be replayed deterministically. SYNTAX_ERROR ramps slip up by 0.15;
+// the row's bkt_slip column must reflect that.
+func TestRecordInteraction_AuditRowCarriesHeuristicSlipGuess_SyntaxError(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               false,
+		"response_time_seconds": 8.0,
+		"confidence":            0.4,
+		"error_type":            "SYNTAX_ERROR",
+		"notes":                 "",
+	})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+
+	recents, _ := store.GetRecentInteractionsByLearner("L_owner", 1)
+	if len(recents) != 1 {
+		t.Fatalf("expected 1 interaction, got %d", len(recents))
+	}
+	got := recents[0]
+	if got.BKTSlip == nil || got.BKTGuess == nil {
+		t.Fatalf("expected bkt_slip and bkt_guess to be persisted, got slip=%v guess=%v", got.BKTSlip, got.BKTGuess)
+	}
+	// Default ConceptState has PSlip=0.1; SYNTAX_ERROR ramp is +0.15 → 0.25.
+	if *got.BKTSlip < 0.249 || *got.BKTSlip > 0.251 {
+		t.Errorf("bkt_slip = %f, want ~0.25 (base 0.1 + SYNTAX_ERROR ramp 0.15)", *got.BKTSlip)
+	}
+	// Default ConceptState has PGuess=0.2 — SYNTAX_ERROR doesn't ramp guess.
+	if *got.BKTGuess < 0.199 || *got.BKTGuess > 0.201 {
+		t.Errorf("bkt_guess = %f, want ~0.20 (unchanged by SYNTAX_ERROR)", *got.BKTGuess)
+	}
+}
+
+// Issue #51: KNOWLEDGE_GAP ramps guess down by 0.10 — the audit row must
+// carry the resulting value (0.20 - 0.10 = 0.10).
+func TestRecordInteraction_AuditRowCarriesHeuristicSlipGuess_KnowledgeGap(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               false,
+		"response_time_seconds": 12.0,
+		"confidence":            0.3,
+		"error_type":            "KNOWLEDGE_GAP",
+		"notes":                 "",
+	})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+
+	recents, _ := store.GetRecentInteractionsByLearner("L_owner", 1)
+	if len(recents) != 1 {
+		t.Fatalf("expected 1 interaction, got %d", len(recents))
+	}
+	got := recents[0]
+	if got.BKTSlip == nil || got.BKTGuess == nil {
+		t.Fatalf("expected bkt_slip and bkt_guess to be persisted, got slip=%v guess=%v", got.BKTSlip, got.BKTGuess)
+	}
+	if *got.BKTSlip < 0.099 || *got.BKTSlip > 0.101 {
+		t.Errorf("bkt_slip = %f, want ~0.10 (unchanged by KNOWLEDGE_GAP)", *got.BKTSlip)
+	}
+	if *got.BKTGuess < 0.099 || *got.BKTGuess > 0.101 {
+		t.Errorf("bkt_guess = %f, want ~0.10 (base 0.20 - KNOWLEDGE_GAP ramp 0.10)", *got.BKTGuess)
+	}
+}
+
+// Issue #51: even a successful interaction (no heuristic ramp applied)
+// records the slip/guess values that were in effect, so replay does not
+// have to special-case missing rows.
+func TestRecordInteraction_AuditRowCarriesHeuristicSlipGuess_Success(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               true,
+		"response_time_seconds": 5.0,
+		"confidence":            0.8,
+		"notes":                 "",
+	})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+
+	recents, _ := store.GetRecentInteractionsByLearner("L_owner", 1)
+	if len(recents) != 1 {
+		t.Fatalf("expected 1 interaction, got %d", len(recents))
+	}
+	got := recents[0]
+	if got.BKTSlip == nil || got.BKTGuess == nil {
+		t.Fatalf("expected bkt_slip and bkt_guess to be persisted on successes too, got slip=%v guess=%v", got.BKTSlip, got.BKTGuess)
 	}
 }
 


### PR DESCRIPTION
Fixes #51

References #8 (item: BKTUpdateWithErrorType rename + audit log)

## Summary

The error-type-aware BKT update is a project-specific heuristic, not in the canonical BKT literature (Corbett & Anderson 1995). Renamed `BKTUpdateWithErrorType` → `BKTUpdateHeuristicSlipByErrorType` so the deviation is explicit at every call-site; doc-comment cites the deviation. The function now also returns the `(slipUsed, guessUsed)` it fed into the BKT update so callers can log them.

Took the **columnar** path for the audit trail (the `interactions` table has no JSON-bag column): forward-only migration adds nullable `bkt_slip REAL` and `bkt_guess REAL`. Pre-existing rows stay `NULL`, which is distinguishable from a literal zero via `*float64`.

## Files

- **Algorithm**: `algorithms/bkt.go` — function rename, doc cites Corbett & Anderson 1995 deviation, returns `(slipUsed, guessUsed)`.
- **Tests**: `algorithms/bkt_test.go` — renamed tests + `TestBKTUpdateHeuristicSlipByErrorType_ReturnsSlipGuessUsed` + compile-time guard.
- **Call-site**: `tools/interaction_apply.go:91` — consumes the new return values and writes them onto the interaction row.
- **Audit trail plumbing**: `models/learner.go` (`*float64` fields), `db/schema.sql`, `db/migrations.go` (two idempotent `ALTER TABLE` migrations), `db/store.go` (`interactionCols`, `nullFloat64` helper, `CreateInteraction`/`scanInteractions`).
- **Cross-package compile-time guard**: `tools/interaction_test.go`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green across all 6 packages
- [x] `TestBKTUpdateHeuristicSlipByErrorType*` (3 tests) — rename + slip/guess return semantics
- [x] `TestRecordInteraction_AuditRowCarriesHeuristicSlipGuess_*` (3 tests) — audit row carries heuristic output for SYNTAX_ERROR / KNOWLEDGE_GAP / success paths
- [x] No new `go.mod` deps; no `t.Skip`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_