### PR TITLE
feat(metacognition): wire ComputeMetacognitiveAlerts into tools and scheduler

### DIFF
--- a/db/metacognition.go
+++ b/db/metacognition.go
@@ -202,6 +202,32 @@ func (s *Store) GetTransferScores(learnerID, conceptID string) ([]*models.Transf
 	return records, rows.Err()
 }
 
+// GetTransferRecordsByLearner returns every transfer probe record for the
+// learner across all concepts. Used by the metacognitive alert pipeline to
+// detect TRANSFER_BLOCKED (mastered concepts whose context-transfer scores
+// remain below 0.50 on 2+ contexts). Newest-first.
+func (s *Store) GetTransferRecordsByLearner(learnerID string) ([]*models.TransferRecord, error) {
+	rows, err := s.db.Query(
+		`SELECT id, learner_id, concept_id, context_type, score, session_id, created_at
+		 FROM transfer_records WHERE learner_id = ?
+		 ORDER BY created_at DESC`,
+		learnerID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get transfer records by learner: %w", err)
+	}
+	defer rows.Close()
+	var records []*models.TransferRecord
+	for rows.Next() {
+		r := &models.TransferRecord{}
+		if err := rows.Scan(&r.ID, &r.LearnerID, &r.ConceptID, &r.ContextType, &r.Score, &r.SessionID, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan transfer record: %w", err)
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
 // ─── Autonomy Queries ───────────────────────────────────────────────────────
 
 func (s *Store) GetHintStatsForMastered(learnerID string, threshold float64) (hints int, total int, err error) {

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -82,9 +82,16 @@ func (s *Scheduler) Start() error {
 	if _, err := s.cron.AddFunc("0 * * * *", s.cleanupExpiredData); err != nil {
 		return fmt.Errorf("add cleanup job: %w", err)
 	}
+	// Metacognitive alerts: every 30 minutes. Each alert kind is fired at
+	// most once per learner per UTC day via WasAlertSentToday so the cron
+	// cadence only controls *latency* (worst case 30 min between the state
+	// being met and the webhook firing), not frequency-of-spam.
+	if _, err := s.cron.AddFunc("*/30 * * * *", s.dispatchMetacognitiveAlerts); err != nil {
+		return fmt.Errorf("add metacognitive alerts job: %w", err)
+	}
 
 	s.cron.Start()
-	s.logger.Info("scheduler started", "jobs", "olm(13h), motivation(8h), recap(21h), cleanup(1h)")
+	s.logger.Info("scheduler started", "jobs", "olm(13h), motivation(8h), recap(21h), cleanup(1h), metacog(30m)")
 	return nil
 }
 

--- a/engine/scheduler_jobs_test.go
+++ b/engine/scheduler_jobs_test.go
@@ -96,9 +96,10 @@ func TestStart_RegistersJobsAndStops(t *testing.T) {
 	if err := s.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	// Ensure cron entries were added (4 jobs: olm, motivation, recap, cleanup).
-	if got := len(s.cron.Entries()); got != 4 {
-		t.Errorf("registered jobs = %d, want 4", got)
+	// Ensure cron entries were added (5 jobs: olm, motivation, recap,
+	// cleanup, metacog).
+	if got := len(s.cron.Entries()); got != 5 {
+		t.Errorf("registered jobs = %d, want 5", got)
 	}
 	s.Stop() // must not panic, must complete promptly
 }

--- a/engine/scheduler_metacog.go
+++ b/engine/scheduler_metacog.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// GitHub: https://github.com/ArnaudGuiovanna
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"time"
+
+	"tutor-mcp/models"
+)
+
+// metacogKindToWebhookKind maps an AlertType to the webhook_message_queue
+// `kind` slot under which the dispatch enqueues a nudge. Each kind is
+// dispatched independently — a learner with both AFFECT_NEGATIVE and
+// CALIBRATION_DIVERGING firing on the same tick will get two webhook
+// rows, deduped per-day via scheduled_alerts (WasAlertSentToday).
+func metacogKindToWebhookKind(t models.AlertType) string {
+	switch t {
+	case models.AlertDependencyIncreasing:
+		return "metacog_dependency"
+	case models.AlertCalibrationDiverging:
+		return "metacog_calibration"
+	case models.AlertAffectNegative:
+		return "metacog_affect"
+	case models.AlertTransferBlocked:
+		return "metacog_transfer"
+	}
+	return ""
+}
+
+// metacogFallbackContent returns the sober Go-side fallback nudge body for
+// each metacognitive alert kind. The content is intentionally short and
+// non-prescriptive — it tells the learner *what surfaced* and points to
+// the corresponding tool, leaving the conversational handling to Claude
+// when the learner returns.
+func metacogFallbackContent(a models.Alert) string {
+	switch a.Type {
+	case models.AlertDependencyIncreasing:
+		return "Ton score d'autonomie a baisse sur les 3 dernieres sessions. " +
+			"Quand tu reprends, on peut en parler — appelle get_metacognitive_mirror."
+	case models.AlertCalibrationDiverging:
+		return "Ta calibration s'est ecartee de la realite (" + a.RecommendedAction + "). " +
+			"Une courte session de calibration peut aider — calibration_check."
+	case models.AlertAffectNegative:
+		return "Deux sessions consecutives ont ete dures. " +
+			"On peut adapter le tutor_mode quand tu reviens."
+	case models.AlertTransferBlocked:
+		concept := a.Concept
+		if concept == "" {
+			concept = "un concept maitrise"
+		}
+		return "Le transfert sur \"" + concept + "\" reste faible malgre la maitrise. " +
+			"Un Feynman challenge debloquerait probablement la situation."
+	}
+	return "Une nouvelle observation metacognitive est disponible."
+}
+
+// dispatchMetacognitiveAlerts iterates over every active learner, computes
+// metacognitive alerts (DEPENDENCY / CALIBRATION / AFFECT / TRANSFER) from
+// their current state, and pushes a webhook for each newly-firing alert
+// kind. Per-learner per-day dedup is enforced by dispatchQueued via
+// scheduled_alerts (WasAlertSentToday + CreateScheduledAlert) — the cron
+// cadence only affects detection latency, not delivery frequency.
+//
+// Two-stage flow on each tick:
+//
+//  1. Compute alerts → enqueue one webhook_message_queue row per *kind*
+//     that just went hot (kind = metacog_dependency / metacog_calibration
+//     / metacog_affect / metacog_transfer). Skip kinds already fired today
+//     (WasAlertSentToday) so we don't enqueue stale duplicates.
+//  2. Drain each enqueued kind via dispatchQueued, which posts the embed
+//     and stamps scheduled_alerts so the next tick deduplicates.
+//
+// TRANSFER_BLOCKED is per-concept in the alert payload but is collapsed to
+// a single per-day kind here — one nudge per day is the product contract,
+// and the embed mentions the most-recent concept that fired.
+func (s *Scheduler) dispatchMetacognitiveAlerts() {
+	if s.store == nil {
+		return
+	}
+	learners, err := s.store.GetActiveLearners()
+	if err != nil {
+		s.logger.Error("scheduler: metacog get learners", "err", err)
+		return
+	}
+	now := time.Now().UTC()
+
+	// Track which kinds were enqueued this tick so we know what to drain.
+	enqueuedKinds := make(map[string]bool)
+
+	for _, learner := range learners {
+		if learner.WebhookURL == "" {
+			continue
+		}
+		avail, _ := s.store.GetAvailability(learner.ID)
+		if avail != nil && avail.DoNotDisturb {
+			continue
+		}
+
+		// Gather inputs. Errors on any one source are tolerated — the
+		// missing input simply skips its branch in
+		// ComputeMetacognitiveAlerts (no alert is better than panicking
+		// the cron tick on a single learner with corrupt rows).
+		states, _ := s.store.GetConceptStatesByLearner(learner.ID)
+		interactions, _ := s.store.GetRecentInteractionsByLearner(learner.ID, 20)
+		affects, _ := s.store.GetRecentAffectStates(learner.ID, 10)
+		var autonomyScores []float64
+		for _, a := range affects {
+			autonomyScores = append(autonomyScores, a.AutonomyScore)
+		}
+		calibBias, _ := s.store.GetCalibrationBias(learner.ID, 20)
+		transfers, _ := s.store.GetTransferRecordsByLearner(learner.ID)
+
+		alerts := ComputeMetacognitiveAlerts(
+			autonomyScores,
+			calibBias,
+			affects,
+			interactions,
+			WithTransferData(states, transfers),
+		)
+
+		// Collapse per-concept alerts down to one row per kind. Keep the
+		// first alert seen for each kind (deterministic enough — alerts
+		// from ComputeMetacognitiveAlerts are produced in a fixed order).
+		seenKind := make(map[string]bool)
+		for _, a := range alerts {
+			kind := metacogKindToWebhookKind(a.Type)
+			if kind == "" || seenKind[kind] {
+				continue
+			}
+			seenKind[kind] = true
+
+			// kind is the dedup tag too — dispatchQueued stamps
+			// scheduled_alerts(alert_type=kind) on success, so a re-tick
+			// today will WasAlertSentToday-skip before re-enqueueing.
+			alreadySent, _ := s.store.WasAlertSentToday(learner.ID, kind)
+			if alreadySent {
+				continue
+			}
+
+			content := metacogFallbackContent(a)
+			if _, err := s.store.EnqueueWebhookMessage(
+				learner.ID, kind, content, now, now.Add(2*time.Hour), 5,
+			); err != nil {
+				s.logger.Error("scheduler: metacog enqueue",
+					"err", err, "learner", learner.ID, "kind", kind)
+				continue
+			}
+			enqueuedKinds[kind] = true
+			s.logger.Info("scheduler: metacog enqueued",
+				"learner", learner.ID, "kind", kind, "type", a.Type)
+		}
+	}
+
+	// Drain every kind we enqueued so the webhook actually leaves the
+	// process this tick. dispatchQueued handles the WasAlertSentToday
+	// dedup + CreateScheduledAlert stamping so the next tick is a no-op.
+	for kind := range enqueuedKinds {
+		s.dispatchQueued(kind, kind, nil)
+	}
+}
+

--- a/engine/scheduler_metacog_test.go
+++ b/engine/scheduler_metacog_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"tutor-mcp/models"
+)
+
+// TestDispatchMetacognitiveAlerts_EnqueuesAndPostsAffect is the regression
+// for sub-issue #58: the scheduler tick must (a) compute metacognitive
+// alerts for an active learner, (b) enqueue a webhook_message_queue row,
+// (c) drain the queue and POST to the learner's webhook, and (d) stamp
+// scheduled_alerts so the next tick is a no-op (per-day dedup).
+func TestDispatchMetacognitiveAlerts_EnqueuesAndPostsAffect(t *testing.T) {
+	allowAnyURL(t)
+	withoutBackoff(t)
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	rawDB, store, learnerID := rawTestSetup(t, srv.URL)
+
+	// Two consecutive low-satisfaction affect rows trip AFFECT_NEGATIVE.
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    learnerID,
+		SessionID:    "s1",
+		Satisfaction: 2,
+	}); err != nil {
+		t.Fatalf("upsert affect s1: %v", err)
+	}
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    learnerID,
+		SessionID:    "s2",
+		Satisfaction: 1,
+	}); err != nil {
+		t.Fatalf("upsert affect s2: %v", err)
+	}
+
+	s := schedulerForTest(store)
+	s.dispatchMetacognitiveAlerts()
+
+	// (b) webhook_message_queue row was added under metacog_affect.
+	var queueCount int
+	if err := rawDB.QueryRow(
+		`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+		learnerID, "metacog_affect",
+	).Scan(&queueCount); err != nil {
+		t.Fatalf("count queue: %v", err)
+	}
+	if queueCount != 1 {
+		t.Fatalf("webhook_message_queue rows for metacog_affect = %d, want 1", queueCount)
+	}
+
+	// (c) the webhook fired.
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("webhook hits = %d, want 1", got)
+	}
+
+	// Queue row marked sent.
+	var status string
+	if err := rawDB.QueryRow(
+		`SELECT status FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+		learnerID, "metacog_affect",
+	).Scan(&status); err != nil {
+		t.Fatalf("scan status: %v", err)
+	}
+	if status != "sent" {
+		t.Errorf("queue status = %q, want 'sent'", status)
+	}
+
+	// (d) per-day dedup: a second tick must not re-enqueue.
+	s.dispatchMetacognitiveAlerts()
+	var queueCount2 int
+	if err := rawDB.QueryRow(
+		`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+		learnerID, "metacog_affect",
+	).Scan(&queueCount2); err != nil {
+		t.Fatalf("count queue 2: %v", err)
+	}
+	if queueCount2 != 1 {
+		t.Errorf("second tick must not re-enqueue, queue count = %d, want 1", queueCount2)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("second tick must not re-fire webhook, hits = %d, want 1", got)
+	}
+}
+
+// TestDispatchMetacognitiveAlerts_NoOpWithoutTriggerState ensures the job
+// doesn't enqueue anything for a learner whose state doesn't trip any of
+// the four metacognitive alerts.
+func TestDispatchMetacognitiveAlerts_NoOpWithoutTriggerState(t *testing.T) {
+	allowAnyURL(t)
+	withoutBackoff(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("scheduler must not POST when no metacognitive alert is active")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, store, _ := rawTestSetup(t, srv.URL)
+	s := schedulerForTest(store)
+	s.dispatchMetacognitiveAlerts()
+}
+
+// TestDispatchMetacognitiveAlerts_HandlesMultipleKinds ensures that when
+// several kinds fire on the same tick we enqueue + drain each
+// independently. AFFECT_NEGATIVE (from satisfaction) plus
+// CALIBRATION_DIVERGING (from a high-bias calibration record) is the
+// minimal non-trivial multi-kind setup.
+func TestDispatchMetacognitiveAlerts_HandlesMultipleKinds(t *testing.T) {
+	allowAnyURL(t)
+	withoutBackoff(t)
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	rawDB, store, learnerID := rawTestSetup(t, srv.URL)
+
+	// Trip AFFECT_NEGATIVE.
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    learnerID,
+		SessionID:    "s1",
+		Satisfaction: 2,
+	}); err != nil {
+		t.Fatalf("upsert affect s1: %v", err)
+	}
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    learnerID,
+		SessionID:    "s2",
+		Satisfaction: 1,
+	}); err != nil {
+		t.Fatalf("upsert affect s2: %v", err)
+	}
+
+	// Trip CALIBRATION_DIVERGING by inserting completed calibration records
+	// with a delta well above 1.5.
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		actual := 0.0
+		delta := 2.0
+		if _, err := rawDB.Exec(
+			`INSERT INTO calibration_records (prediction_id, learner_id, concept_id, predicted, actual, delta, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			"p"+string(rune('0'+i)), learnerID, "c", 0.9, actual, delta, now.Add(-time.Duration(i)*time.Minute),
+		); err != nil {
+			t.Fatalf("insert calibration: %v", err)
+		}
+	}
+
+	s := schedulerForTest(store)
+	s.dispatchMetacognitiveAlerts()
+
+	// Both kinds should have queue rows (independent per kind).
+	for _, kind := range []string{"metacog_affect", "metacog_calibration"} {
+		var c int
+		if err := rawDB.QueryRow(
+			`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+			learnerID, kind,
+		).Scan(&c); err != nil {
+			t.Fatalf("count %s: %v", kind, err)
+		}
+		if c != 1 {
+			t.Errorf("queue rows for %s = %d, want 1", kind, c)
+		}
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Errorf("webhook hits = %d, want 2 (one per kind)", got)
+	}
+}
+
+// TestMetacogKindToWebhookKind exercises the kind mapping for each of
+// the four metacognitive alert types.
+func TestMetacogKindToWebhookKind(t *testing.T) {
+	cases := []struct {
+		in   models.AlertType
+		want string
+	}{
+		{models.AlertDependencyIncreasing, "metacog_dependency"},
+		{models.AlertCalibrationDiverging, "metacog_calibration"},
+		{models.AlertAffectNegative, "metacog_affect"},
+		{models.AlertTransferBlocked, "metacog_transfer"},
+		{models.AlertForgetting, ""}, // not a metacog kind → empty string
+	}
+	for _, tc := range cases {
+		if got := metacogKindToWebhookKind(tc.in); got != tc.want {
+			t.Errorf("metacogKindToWebhookKind(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -80,6 +80,29 @@ func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 
 		alerts := engine.ComputeAlerts(states, interactions, sessionStart)
 
+		// Metacognitive alerts (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING,
+		// AFFECT_NEGATIVE, TRANSFER_BLOCKED) are cross-domain learner-level
+		// signals. They are computed alongside the activity-level alerts
+		// above and merged before returning. Errors fetching any single
+		// input are tolerated — the missing input simply skips its branch
+		// inside ComputeMetacognitiveAlerts (defensive: a corrupt affect
+		// row shouldn't block the whole alert payload).
+		affects, _ := deps.Store.GetRecentAffectStates(learnerID, 10)
+		var autonomyScores []float64
+		for _, a := range affects {
+			autonomyScores = append(autonomyScores, a.AutonomyScore)
+		}
+		calibBias, _ := deps.Store.GetCalibrationBias(learnerID, 20)
+		transfers, _ := deps.Store.GetTransferRecordsByLearner(learnerID)
+		metaAlerts := engine.ComputeMetacognitiveAlerts(
+			autonomyScores,
+			calibBias,
+			affects,
+			interactions,
+			engine.WithTransferData(states, transfers),
+		)
+		alerts = mergeMetacognitiveAlerts(alerts, metaAlerts)
+
 		hasCritical := false
 		for _, a := range alerts {
 			if a.Urgency == models.UrgencyCritical {
@@ -98,4 +121,28 @@ func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 		})
 		return r, nil, nil
 	})
+}
+
+// mergeMetacognitiveAlerts appends meta alerts to the activity-level alert
+// list while deduping on (Type, Concept). The Type is the alert kind
+// (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE,
+// TRANSFER_BLOCKED) and Concept disambiguates per-concept TRANSFER_BLOCKED
+// entries (the other three are learner-wide and carry an empty concept).
+// This guards against double-emit if ComputeAlerts ever starts producing
+// the same kinds, and against duplicates if this function is called twice
+// in the same payload assembly.
+func mergeMetacognitiveAlerts(base, extra []models.Alert) []models.Alert {
+	seen := make(map[string]bool, len(base))
+	for _, a := range base {
+		seen[string(a.Type)+"|"+a.Concept] = true
+	}
+	for _, a := range extra {
+		key := string(a.Type) + "|" + a.Concept
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		base = append(base, a)
+	}
+	return base
 }

--- a/tools/alerts_test.go
+++ b/tools/alerts_test.go
@@ -95,6 +95,90 @@ func TestGetPendingAlerts_NoActiveDomain_ReturnsCleanEmpty(t *testing.T) {
 	}
 }
 
+// TestGetPendingAlerts_WiresMetacognitiveAlerts is the regression for sub-issue
+// #58: ComputeMetacognitiveAlerts must be called from the sync get_pending_alerts
+// tool, not just from tests. Seeds the AFFECT_NEGATIVE precondition (two
+// consecutive sessions with Satisfaction <= 2) and asserts the alert surfaces.
+func TestGetPendingAlerts_WiresMetacognitiveAlerts(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	// At least one active domain so the no-domain_id branch doesn't
+	// short-circuit on needs_domain_setup.
+	if _, err := store.CreateDomain("L_owner", "math", "", models.KnowledgeSpace{
+		Concepts: []string{"a"},
+	}); err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+
+	// Two consecutive low-satisfaction affect rows trigger AFFECT_NEGATIVE.
+	now := time.Now().UTC()
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    "L_owner",
+		SessionID:    "s1",
+		Satisfaction: 2,
+	}); err != nil {
+		t.Fatalf("upsert affect s1: %v", err)
+	}
+	// Force a small ordering gap so newest-first ordering is deterministic.
+	_ = now
+	if err := store.UpsertAffectState(&models.AffectState{
+		LearnerID:    "L_owner",
+		SessionID:    "s2",
+		Satisfaction: 1,
+	}); err != nil {
+		t.Fatalf("upsert affect s2: %v", err)
+	}
+
+	res := callTool(t, deps, registerGetPendingAlerts, "L_owner", "get_pending_alerts", map[string]any{})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+	alerts, _ := out["alerts"].([]any)
+	sawAffect := false
+	for _, a := range alerts {
+		m, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["type"] == string(models.AlertAffectNegative) {
+			sawAffect = true
+		}
+	}
+	if !sawAffect {
+		t.Fatalf("expected AFFECT_NEGATIVE metacognitive alert in payload, got %+v", alerts)
+	}
+}
+
+// TestGetPendingAlerts_DedupsMetacognitiveAlerts asserts mergeMetacognitiveAlerts
+// does not double-emit when an activity-level alert and a metacognitive alert
+// share the same (Type, Concept). We synthesize the collision by reaching into
+// the merge helper directly — going through the DB would require an
+// AFFECT_NEGATIVE-equivalent on the activity side, which doesn't exist.
+func TestMergeMetacognitiveAlerts_Dedupes(t *testing.T) {
+	base := []models.Alert{
+		{Type: models.AlertAffectNegative, Concept: ""},
+	}
+	extra := []models.Alert{
+		{Type: models.AlertAffectNegative, Concept: ""},
+		{Type: models.AlertCalibrationDiverging, Concept: ""},
+	}
+	merged := mergeMetacognitiveAlerts(base, extra)
+	if len(merged) != 2 {
+		t.Fatalf("expected dedup to drop the duplicate AFFECT_NEGATIVE, got %d alerts: %+v", len(merged), merged)
+	}
+	// Ensure CALIBRATION_DIVERGING was kept (i.e. dedup is by type+concept,
+	// not a blanket de-overlap).
+	sawCalib := false
+	for _, a := range merged {
+		if a.Type == models.AlertCalibrationDiverging {
+			sawCalib = true
+		}
+	}
+	if !sawCalib {
+		t.Errorf("dedup must not drop unrelated kinds, got %+v", merged)
+	}
+}
+
 // Reproducer for issue #29: when the learner has multiple non-archived
 // domains and no domain_id filter is given, alerts must be computed only
 // over the union of concepts across active domains — orphan concepts


### PR DESCRIPTION
Fixes #58

References #8 (item: ComputeMetacognitiveAlerts dead in production)

## Summary

`ComputeMetacognitiveAlerts` was dead in production — only called by tests. This change wires it into both production paths:

- **Synchronous** — inside `get_pending_alerts` (`tools/alerts.go`), its output is merged with the existing activity-level alerts and deduped by `(Type, Concept)` via a new `mergeMetacognitiveAlerts` helper.
- **Asynchronous** — a new scheduler cron `dispatchMetacognitiveAlerts` (every 30 min), iterates active learners, enqueues one `webhook_message_queue` row per firing alert kind, and drains via the existing `dispatchQueued`.

Per-day dedup is enforced by `WasAlertSentToday` + `scheduled_alerts` so the cron cadence controls detection latency only, not delivery frequency. Per-concept TRANSFER_BLOCKED is collapsed to a single per-day nudge that names the firing concept.

Adds `db.Store.GetTransferRecordsByLearner` (the existing `GetTransferScores` required a concept ID upfront, which the metacog pipeline doesn't have).

## Files

- `db/metacognition.go` — `GetTransferRecordsByLearner`
- `tools/alerts.go` — sync wiring + `mergeMetacognitiveAlerts`
- `tools/alerts_test.go` — sync test + dedup test
- `engine/scheduler.go` — registered new `*/30 * * * *` cron entry
- `engine/scheduler_metacog.go` (new) — `dispatchMetacognitiveAlerts`, `metacogKindToWebhookKind`, fallback content
- `engine/scheduler_metacog_test.go` (new) — DB-backed integration tests
- `engine/scheduler_jobs_test.go` — job count 4 → 5

## Test plan

- [x] `go build ./...` clean, `go vet ./...` clean
- [x] `go test ./... -count=1` green
- [x] `TestGetPendingAlerts_WiresMetacognitiveAlerts` — sync wiring smoke
- [x] `TestMergeMetacognitiveAlerts_Dedupes` — dedup helper
- [x] `TestDispatchMetacognitiveAlerts_EnqueuesAndPostsAffect` — full async flow + per-day dedup
- [x] `TestDispatchMetacognitiveAlerts_NoOpWithoutTriggerState` — no false positives
- [x] `TestDispatchMetacognitiveAlerts_HandlesMultipleKinds` — multi-kind same tick
- [x] `TestMetacogKindToWebhookKind` — kind mapping table
- [x] No new `go.mod` deps; no `t.Skip`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_