### PR TITLE
feat(alert): explicit FORGETTING vs MASTERY_READY arbitration on critical retention

### DIFF
--- a/engine/alert.go
+++ b/engine/alert.go
@@ -16,6 +16,15 @@ import (
 func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.Interaction, sessionStart time.Time) []models.Alert {
 	var alerts []models.Alert
 
+	// criticalForgetting tracks concepts where FORGETTING fired at UrgencyCritical
+	// (retention < 0.30). These concepts skip MASTERY_READY emission below — the
+	// two alerts would otherwise be contradictory in the same get_pending_alerts
+	// response (sub-issue #54). FORGETTING at UrgencyWarning (0.30 ≤ retention <
+	// 0.40) is NOT a contradiction and both alerts are kept. Threshold rationale:
+	// the cutoff matches the existing UrgencyCritical band defined a few lines
+	// below, so retuning means changing both together.
+	criticalForgetting := make(map[string]bool)
+
 	for _, cs := range states {
 		if cs.CardState == "new" {
 			continue
@@ -31,6 +40,7 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 			urgency := models.UrgencyWarning
 			if retention < 0.30 {
 				urgency = models.UrgencyCritical
+				criticalForgetting[cs.Concept] = true
 			}
 			hoursLeft := 0.0
 			if retention > 0.30 {
@@ -47,7 +57,13 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 		}
 
 		// MASTERY_READY: BKT >= 0.85
-		if cs.PMastery >= algorithms.MasteryBKT() {
+		// Arbitration (sub-issue #54): if FORGETTING already fired at
+		// UrgencyCritical for this concept, suppress MASTERY_READY to avoid
+		// emitting contradictory nudges on the same tick. The action selector
+		// already prioritizes FORGETTING over mastery brackets in
+		// engine/action_selector.go; this mirrors that precedence at the alert
+		// layer so get_pending_alerts callers see a coherent recommendation.
+		if cs.PMastery >= algorithms.MasteryBKT() && !criticalForgetting[cs.Concept] {
 			alerts = append(alerts, models.Alert{
 				Type:              models.AlertMasteryReady,
 				Concept:           cs.Concept,

--- a/engine/alert_test.go
+++ b/engine/alert_test.go
@@ -30,7 +30,10 @@ func TestComputeAlertsForgetting(t *testing.T) {
 }
 
 func TestComputeAlertsMasteryReady(t *testing.T) {
-	states := []*models.ConceptState{{Concept: "basics", PMastery: 0.90, CardState: "review"}}
+	// Stability=1.0, ElapsedDays=1 → retention ≈ 0.90 (well above 0.40), so the
+	// FORGETTING/MASTERY_READY arbitration introduced for sub-issue #54 does not
+	// suppress MASTERY_READY here.
+	states := []*models.ConceptState{{Concept: "basics", PMastery: 0.90, Stability: 1.0, ElapsedDays: 1, CardState: "review"}}
 	alerts := ComputeAlerts(states, nil, time.Time{})
 	found := false
 	for _, a := range alerts {
@@ -40,6 +43,113 @@ func TestComputeAlertsMasteryReady(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected MASTERY_READY for basics")
+	}
+}
+
+// TestComputeAlertsMasteryForgettingArbitration covers the four corners of the
+// (PMastery × retention) matrix to verify the alert-level arbitration rule:
+// FORGETTING at UrgencyCritical (retention < 0.30) suppresses MASTERY_READY for
+// the same concept. FORGETTING at UrgencyWarning (0.30 ≤ retention < 0.40) does
+// NOT suppress — the learner is in a nuanced "almost mastered, slightly stale"
+// state that warrants both nudges.
+//
+// Threshold rationale: retention < 0.30 corresponds to the existing
+// UrgencyCritical band defined in ComputeAlerts (engine/alert.go). Retuning the
+// suppression cutoff means changing both that constant and the comment in
+// ComputeAlerts together.
+func TestComputeAlertsMasteryForgettingArbitration(t *testing.T) {
+	// Retention closed-form: (1 + (19/81)*elapsed/stability)^(-0.5)
+	//   elapsed=1,  stability=1.0  → retention ≈ 0.900 (>= 0.40)
+	//   elapsed=5,  stability=0.2  → retention ≈ 0.382 (in [0.30, 0.40))
+	//   elapsed=5,  stability=0.1  → retention ≈ 0.280 (< 0.30)
+	masteryHigh := 0.90 // >= MasteryBKT() (0.85)
+	masteryLow := 0.50  // <  MasteryBKT()
+
+	cases := []struct {
+		name             string
+		pMastery         float64
+		stability        float64
+		elapsedDays      int
+		wantForgetting   bool
+		wantForgettingUrgency models.AlertUrgency
+		wantMasteryReady bool
+	}{
+		{
+			name:             "high mastery + high retention → only MASTERY_READY",
+			pMastery:         masteryHigh,
+			stability:        1.0,
+			elapsedDays:      1,
+			wantForgetting:   false,
+			wantMasteryReady: true,
+		},
+		{
+			name:                  "high mastery + warning retention → both alerts kept",
+			pMastery:              masteryHigh,
+			stability:             0.2,
+			elapsedDays:           5,
+			wantForgetting:        true,
+			wantForgettingUrgency: models.UrgencyWarning,
+			wantMasteryReady:      true,
+		},
+		{
+			name:                  "high mastery + critical retention → only FORGETTING (arbitration)",
+			pMastery:              masteryHigh,
+			stability:             0.1,
+			elapsedDays:           5,
+			wantForgetting:        true,
+			wantForgettingUrgency: models.UrgencyCritical,
+			wantMasteryReady:      false,
+		},
+		{
+			name:                  "low mastery + critical retention → only FORGETTING",
+			pMastery:              masteryLow,
+			stability:             0.1,
+			elapsedDays:           5,
+			wantForgetting:        true,
+			wantForgettingUrgency: models.UrgencyCritical,
+			wantMasteryReady:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			states := []*models.ConceptState{
+				{
+					Concept:     "arbitration_concept",
+					Stability:   tc.stability,
+					ElapsedDays: tc.elapsedDays,
+					PMastery:    tc.pMastery,
+					CardState:   "review",
+				},
+			}
+			alerts := ComputeAlerts(states, nil, time.Time{})
+
+			gotForgetting := false
+			gotForgettingUrgency := models.AlertUrgency("")
+			gotMasteryReady := false
+			for _, a := range alerts {
+				if a.Concept != "arbitration_concept" {
+					continue
+				}
+				switch a.Type {
+				case models.AlertForgetting:
+					gotForgetting = true
+					gotForgettingUrgency = a.Urgency
+				case models.AlertMasteryReady:
+					gotMasteryReady = true
+				}
+			}
+
+			if gotForgetting != tc.wantForgetting {
+				t.Errorf("FORGETTING presence: got %v, want %v", gotForgetting, tc.wantForgetting)
+			}
+			if tc.wantForgetting && gotForgettingUrgency != tc.wantForgettingUrgency {
+				t.Errorf("FORGETTING urgency: got %s, want %s", gotForgettingUrgency, tc.wantForgettingUrgency)
+			}
+			if gotMasteryReady != tc.wantMasteryReady {
+				t.Errorf("MASTERY_READY presence: got %v, want %v", gotMasteryReady, tc.wantMasteryReady)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #54

References #8 (item: MASTERY_READY vs FORGETTING arbitration)

## Summary

Adds explicit alert-level arbitration between `AlertForgetting` and `AlertMasteryReady` in `engine/alert.go` `ComputeAlerts`. Previously both could be appended for the same concept on the same tick, producing contradictory nudges in `get_pending_alerts`.

New rule: when FORGETTING fires at `UrgencyCritical` (retention < 0.30), MASTERY_READY is suppressed for that concept. When FORGETTING is only at `UrgencyWarning` (retention 0.30–0.40), both alerts are retained — that "almost-mastered, slightly stale" state is not contradictory.

**Scope narrowed** from the original issue's mention of `engine/router.go` (retired in commit `7d4a979` / PR #16). Action-level arbitration was already handled in `engine/action_selector.go`'s precedence cascade; this PR covers the alert layer only.

The threshold choice (`retention < 0.30 ≡ UrgencyCritical`) matches the existing band defined in the same function and is documented for future retuning.

## Four-corner table

| PMastery | Retention band | Expected alerts |
|---|---|---|
| ≥ 0.85 | ≥ 0.40 | Only MASTERY_READY |
| ≥ 0.85 | 0.30–0.40 | Both FORGETTING (warning) and MASTERY_READY |
| ≥ 0.85 | < 0.30 | Only FORGETTING (critical) — arbitration rule |
| < 0.85 | < 0.30 | Only FORGETTING (critical) |

## Test plan

- [x] `go build ./...` clean, `go vet ./...` clean
- [x] `go test ./... -count=1` green
- [x] `TestComputeAlertsMasteryForgettingArbitration` covers all four corners
- [x] `TestComputeAlertsMasteryReady` tightened (previously relied on `Stability=0` which silently triggered FORGETTING; arbitration now correctly suppresses MASTERY_READY in that pathological state)
- [x] `TestComputeAlertsForgetting` unchanged (warning band intact)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_