### PR TITLE
fix(interaction): snapshot inputs before BKT/FSRS/IRT chain to fix non-commutative read

### DIFF
--- a/tools/interaction_apply.go
+++ b/tools/interaction_apply.go
@@ -36,6 +36,16 @@ type interactionInput struct {
 // cognitive state (BKT, FSRS, IRT, PFA) for the concept.  Returns the
 // resulting ConceptState (post-update) and an error if any persistence
 // step failed.
+//
+// The BKT → FSRS → IRT → PFA update chain is *non-commutative* on
+// `cs.Difficulty` (and in spirit on `cs.Reps` / `cs.Stability` /
+// `cs.PMastery`): IRT consumes the FSRS difficulty to compute the θ
+// step, but FSRS itself rewrites that field. Reading `cs.*` directly
+// after running each step would silently mix prior- and post-update
+// values across the chain (issue #53). To keep the chain
+// order-independent we snapshot the read-only prior values at the top,
+// run all four updates against the snapshot, and write the merged
+// result back to `cs` exactly once at the end.
 func applyInteraction(
 	deps *Deps,
 	learnerID string,
@@ -47,6 +57,31 @@ func applyInteraction(
 	if err != nil {
 		cs = models.NewConceptState(learnerID, input.Concept)
 	}
+
+	// ── Snapshot read-only prior state ──────────────────────────────
+	// All downstream algorithm steps read from this snapshot, never
+	// from `cs` directly, to keep the BKT → FSRS → IRT → PFA chain
+	// commutative. See doc comment above and issue #53.
+	priorPMastery := cs.PMastery
+	priorPLearn := cs.PLearn
+	priorPForget := cs.PForget
+	priorPSlip := cs.PSlip
+	priorPGuess := cs.PGuess
+	priorStability := cs.Stability
+	priorDifficulty := cs.Difficulty
+	priorElapsedDays := cs.ElapsedDays
+	priorScheduledDays := cs.ScheduledDays
+	priorReps := cs.Reps
+	priorLapses := cs.Lapses
+	priorCardState := cs.CardState
+	priorTheta := cs.Theta
+	priorPFASuccesses := cs.PFASuccesses
+	priorPFAFailures := cs.PFAFailures
+	var priorLastReview time.Time
+	if cs.LastReview != nil {
+		priorLastReview = *cs.LastReview
+	}
+	priorNextReview := cs.NextReview
 
 	// Build and persist the interaction row.
 	interaction := &models.Interaction{
@@ -71,8 +106,8 @@ func applyInteraction(
 		interaction.MisconceptionDetail = input.MisconceptionDetail
 	}
 
-	// Proactive review flag.
-	if cs.NextReview != nil && cs.NextReview.After(now) && cs.CardState != "new" {
+	// Proactive review flag — derived from the prior schedule.
+	if priorNextReview != nil && priorNextReview.After(now) && priorCardState != "new" {
 		interaction.IsProactiveReview = true
 	}
 
@@ -80,18 +115,17 @@ func applyInteraction(
 		return nil, fmt.Errorf("applyInteraction: create interaction: %w", err)
 	}
 
-	// BKT update — error-type-aware.
+	// ── BKT update — error-type-aware. Reads from prior snapshot. ──
 	bktState := algorithms.BKTState{
-		PMastery: cs.PMastery,
-		PLearn:   cs.PLearn,
-		PForget:  cs.PForget,
-		PSlip:    cs.PSlip,
-		PGuess:   cs.PGuess,
+		PMastery: priorPMastery,
+		PLearn:   priorPLearn,
+		PForget:  priorPForget,
+		PSlip:    priorPSlip,
+		PGuess:   priorPGuess,
 	}
 	bktState = algorithms.BKTUpdateWithErrorType(bktState, input.Success, input.ErrorType)
-	cs.PMastery = bktState.PMastery
 
-	// FSRS ReviewCard.
+	// ── FSRS update — reads from prior snapshot. ───────────────────
 	rating := algorithms.Good
 	if !input.Success {
 		rating = algorithms.Again
@@ -101,21 +135,36 @@ func applyInteraction(
 		rating = algorithms.Hard
 	}
 
-	var lastReview time.Time
-	if cs.LastReview != nil {
-		lastReview = *cs.LastReview
-	}
 	fsrsCard := algorithms.FSRSCard{
-		Stability:     cs.Stability,
-		Difficulty:    cs.Difficulty,
-		ElapsedDays:   cs.ElapsedDays,
-		ScheduledDays: cs.ScheduledDays,
-		Reps:          cs.Reps,
-		Lapses:        cs.Lapses,
-		State:         algorithms.CardState(cs.CardState),
-		LastReview:    lastReview,
+		Stability:     priorStability,
+		Difficulty:    priorDifficulty,
+		ElapsedDays:   priorElapsedDays,
+		ScheduledDays: priorScheduledDays,
+		Reps:          priorReps,
+		Lapses:        priorLapses,
+		State:         algorithms.CardState(priorCardState),
+		LastReview:    priorLastReview,
 	}
 	fsrsCard = algorithms.ReviewCard(fsrsCard, rating, now)
+
+	// ── IRT update — reads PRIOR difficulty from the snapshot, not
+	// the FSRS-rewritten value. This is the issue #53 fix: previously
+	// IRT consumed `cs.Difficulty` after FSRS had overwritten it. ──
+	item := algorithms.IRTItem{
+		Difficulty:     algorithms.FSRSDifficultyToIRT(priorDifficulty),
+		Discrimination: 1.0,
+	}
+	newTheta := algorithms.IRTUpdateTheta(priorTheta, []algorithms.IRTItem{item}, []bool{input.Success})
+
+	// ── PFA update — reads from prior snapshot. ────────────────────
+	pfaState := algorithms.PFAState{
+		Successes: priorPFASuccesses,
+		Failures:  priorPFAFailures,
+	}
+	pfaState = algorithms.PFAUpdate(pfaState, input.Success)
+
+	// ── Single write-back of the merged result. ────────────────────
+	cs.PMastery = bktState.PMastery
 	cs.Stability = fsrsCard.Stability
 	cs.Difficulty = fsrsCard.Difficulty
 	cs.ElapsedDays = fsrsCard.ElapsedDays
@@ -126,20 +175,7 @@ func applyInteraction(
 	cs.LastReview = &now
 	nextReview := now.Add(time.Duration(fsrsCard.ScheduledDays) * 24 * time.Hour)
 	cs.NextReview = &nextReview
-
-	// IRT UpdateTheta.
-	item := algorithms.IRTItem{
-		Difficulty:     algorithms.FSRSDifficultyToIRT(cs.Difficulty),
-		Discrimination: 1.0,
-	}
-	cs.Theta = algorithms.IRTUpdateTheta(cs.Theta, []algorithms.IRTItem{item}, []bool{input.Success})
-
-	// PFA Update.
-	pfaState := algorithms.PFAState{
-		Successes: cs.PFASuccesses,
-		Failures:  cs.PFAFailures,
-	}
-	pfaState = algorithms.PFAUpdate(pfaState, input.Success)
+	cs.Theta = newTheta
 	cs.PFASuccesses = pfaState.Successes
 	cs.PFAFailures = pfaState.Failures
 

--- a/tools/interaction_test.go
+++ b/tools/interaction_test.go
@@ -4,9 +4,12 @@
 package tools
 
 import (
+	"math"
 	"strings"
 	"testing"
+	"time"
 
+	"tutor-mcp/algorithms"
 	"tutor-mcp/models"
 )
 
@@ -373,5 +376,110 @@ func TestComputeCognitiveSignals(t *testing.T) {
 	fatigue3, _ := computeCognitiveSignals(long)
 	if fatigue3 == "none" {
 		t.Fatalf("expected fatigue signal, got %q", fatigue3)
+	}
+}
+
+// Issue #53: applyInteraction's BKT → FSRS → IRT chain must be commutative
+// in the sense that the IRT step reads the *prior* (pre-FSRS) Difficulty,
+// not the value FSRS just overwrote. The non-commutative read is on
+// cs.Difficulty: FSRS rewrites it, then IRT consumes it via
+// FSRSDifficultyToIRT to compute the θ update. Reading post-FSRS difficulty
+// silently shifts θ along the difficulty curve, biasing the learner's IRT
+// estimate by the size of the difficulty step. Snapshot the read-only
+// inputs at the top, run the three updates against the snapshot, write
+// once at the end.
+func TestApplyInteraction_IRTReadsPreFSRSDifficulty(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	// Seed a concept state in the Review FSRS state with a non-default
+	// Difficulty and Reps. Difficulty=9.0 sits at the high end of the
+	// FSRS [1,10] range; on an Again rating FSRS's nextDifficulty pulls
+	// it sharply down (toward ~6.9), so post-FSRS difficulty differs
+	// from pre-FSRS by ~2 difficulty points. With a failure response
+	// IRT pushes θ negative, and the two starting difficulties produce
+	// distinguishable θ values inside the [-4, 4] clamp window.
+	now := time.Now().UTC()
+	last := now.Add(-48 * time.Hour)
+	seed := &models.ConceptState{
+		LearnerID:     "L_owner",
+		Concept:       "a",
+		Stability:     5.0,
+		Difficulty:    9.0,
+		ElapsedDays:   2,
+		ScheduledDays: 5,
+		Reps:          5,
+		Lapses:        0,
+		CardState:     "review",
+		LastReview:    &last,
+		PMastery:      0.4,
+		PLearn:        0.15,
+		PForget:       0.05,
+		PSlip:         0.1,
+		PGuess:        0.2,
+		// θ seed is non-zero and close to the pre-FSRS IRT difficulty so
+		// the Newton iterations in IRTUpdateTheta land *inside* the
+		// [-4, 4] clamp window, leaving room to distinguish the pre-FSRS
+		// vs post-FSRS difficulty cases.
+		Theta: 2.0,
+	}
+	if err := store.UpsertConceptState(seed); err != nil {
+		t.Fatalf("seed concept state: %v", err)
+	}
+
+	// Compute the expected θ update by running IRT against the *pre-FSRS*
+	// difficulty (9.0). success=false maps to FSRS rating Again.
+	expectedItem := algorithms.IRTItem{
+		Difficulty:     algorithms.FSRSDifficultyToIRT(9.0),
+		Discrimination: 1.0,
+	}
+	expectedTheta := algorithms.IRTUpdateTheta(seed.Theta, []algorithms.IRTItem{expectedItem}, []bool{false})
+
+	// And the *post-FSRS* difficulty θ — what today's buggy code computes.
+	// We capture this so the assertion can also confirm the two values are
+	// in fact distinguishable on this scenario (otherwise the test is
+	// vacuous).
+	postFSRSDiff := algorithms.ReviewCard(algorithms.FSRSCard{
+		Stability:     5.0,
+		Difficulty:    9.0,
+		ElapsedDays:   2,
+		ScheduledDays: 5,
+		Reps:          5,
+		Lapses:        0,
+		State:         algorithms.Review,
+		LastReview:    last,
+	}, algorithms.Again, now).Difficulty
+	buggyItem := algorithms.IRTItem{
+		Difficulty:     algorithms.FSRSDifficultyToIRT(postFSRSDiff),
+		Discrimination: 1.0,
+	}
+	buggyTheta := algorithms.IRTUpdateTheta(seed.Theta, []algorithms.IRTItem{buggyItem}, []bool{false})
+	if math.Abs(expectedTheta-buggyTheta) < 1e-6 {
+		t.Fatalf("test setup is vacuous: pre/post FSRS thetas are identical (%v)", expectedTheta)
+	}
+
+	cs, err := applyInteraction(deps, "L_owner", interactionInput{
+		Concept:             "a",
+		ActivityType:        "RECALL_EXERCISE",
+		Success:             false, // → FSRS rating Again
+		ResponseTimeSeconds: 10,
+		Confidence:          0.4,
+	}, now)
+	if err != nil {
+		t.Fatalf("applyInteraction: %v", err)
+	}
+
+	if math.Abs(cs.Theta-expectedTheta) > 1e-9 {
+		t.Fatalf("IRT consumed post-FSRS difficulty: got θ=%v, want θ=%v (post-FSRS-buggy θ=%v)",
+			cs.Theta, expectedTheta, buggyTheta)
+	}
+
+	// Sanity: FSRS *did* rewrite Difficulty and Reps, so the read-then-
+	// update concern is real on this path.
+	if cs.Difficulty == 9.0 {
+		t.Fatalf("FSRS did not rewrite Difficulty as expected (still 9.0)")
+	}
+	if cs.Reps != 6 {
+		t.Fatalf("FSRS did not increment Reps as expected: got %d, want 6", cs.Reps)
 	}
 }


### PR DESCRIPTION
Fixes #53

References #8 (item: record_interaction non-commutative update order)

## Summary

The `record_interaction` BKT → FSRS → IRT chain in `tools/interaction_apply.go` was non-commutative on `cs.Difficulty`: FSRS overwrites it, then IRT was reading the rewritten value via `FSRSDifficultyToIRT`, silently shifting the learner's θ along the difficulty curve.

**Non-commutative read identified**: IRT (old line 132) read `cs.Difficulty` to feed `FSRSDifficultyToIRT`, but FSRS at old lines 119–125 had already overwritten `Stability`, `Difficulty`, `ElapsedDays`, `ScheduledDays`, `Reps`, `Lapses`, `CardState`. The proactive-review check sat before FSRS so it was correct; PFA reads its own `cs.PFA*` fields which FSRS doesn't touch.

**Snapshot strategy**: capture all read-only prior fields (`PMastery`, `PLearn`, `PForget`, `PSlip`, `PGuess`, `Stability`, `Difficulty`, `ElapsedDays`, `ScheduledDays`, `Reps`, `Lapses`, `CardState`, `Theta`, `PFASuccesses`, `PFAFailures`, `LastReview`, `NextReview`) at the top of `applyInteraction`. BKT, FSRS, IRT and PFA all read from the snapshot. Results land in fresh local variables (`bktState`, `fsrsCard`, `newTheta`, `pfaState`), with a single write-back block at the end.

## Regression test

`TestApplyInteraction_IRTReadsPreFSRSDifficulty` seeds `Difficulty=9.0, Reps=5, CardState="review", Theta=2.0`, calls `applyInteraction` with `Success=false` (FSRS rating Again, which yanks Difficulty from 9.0 down to ~6.89), and asserts `cs.Theta` matches `FSRSDifficultyToIRT(9.0)`'s update — i.e. the pre-FSRS difficulty. Also asserts the buggy θ (post-FSRS difficulty) is distinguishable so the test is not vacuous. Verified to FAIL on unfixed code (`θ=-4` vs `θ=-3.9069`) and PASS on fixed code.

## Notes

- PR #74 (BKT rename) also touches `tools/interaction_apply.go`. Independent branches from `staging`; reviewer handles merge.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green
- [x] New `TestApplyInteraction_IRTReadsPreFSRSDifficulty` fails pre-fix, passes post-fix
- [x] No pre-existing test had to change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_