### PR TITLE
chore(pfa): drop unused PFA columns and writer paths

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -85,6 +85,15 @@ func Migrate(db *sql.DB) error {
 		// captured at write time").
 		`ALTER TABLE interactions ADD COLUMN bkt_slip REAL`,
 		`ALTER TABLE interactions ADD COLUMN bkt_guess REAL`,
+		// Issue #55: PFA persisted state was written but never consumed —
+		// engine/alert.go recomputes PFA in-memory from the interactions
+		// list each call. Drop the dead columns. Forward-only: there is
+		// no "down" migration. The errors are swallowed by the loop's
+		// `_, _ = db.Exec(m)` so re-running on a DB where the columns
+		// are already gone is a no-op (idempotent). DROP COLUMN requires
+		// SQLite >= 3.35; modernc.org/sqlite v1.47 ships above that.
+		`ALTER TABLE concept_states DROP COLUMN pfa_successes`,
+		`ALTER TABLE concept_states DROP COLUMN pfa_failures`,
 	}
 	for _, m := range alterMigrations {
 		_, _ = db.Exec(m) // ignore "duplicate column" errors

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -95,6 +95,109 @@ func TestMigrate_Idempotent(t *testing.T) {
 	}
 }
 
+// TestMigrate_DropsPFAColumns is the regression guard for issue #55.
+// Two scenarios are exercised in the same test so that the assertion
+// holds regardless of whether a deployed DB started fresh (post-#55) or
+// upgraded from a pre-#55 schema that still had the columns:
+//
+//  1. Fresh DB: schema.sql no longer declares pfa_successes / pfa_failures.
+//     After Migrate(), table_info(concept_states) must not list them.
+//  2. Upgrade DB: the columns are inserted manually before Migrate(),
+//     simulating a pre-#55 database. Migrate() must drop them via the
+//     incremental ALTER TABLE ... DROP COLUMN entries (idempotent).
+//
+// If either column reappears in either scenario the test fails — that
+// catches accidental re-introduction in schema.sql and accidental
+// removal of the DROP COLUMN migration entries.
+func TestMigrate_DropsPFAColumns(t *testing.T) {
+	pfaCols := []string{"pfa_successes", "pfa_failures"}
+
+	hasColumn := func(t *testing.T, db *sql.DB, table, col string) bool {
+		t.Helper()
+		rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+		if err != nil {
+			t.Fatalf("PRAGMA table_info(%s): %v", table, err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				cid     int
+				name    string
+				ctype   string
+				notnull int
+				dflt    sql.NullString
+				pk      int
+			)
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+				t.Fatalf("scan table_info row: %v", err)
+			}
+			if name == col {
+				return true
+			}
+		}
+		return rows.Err() == nil && false
+	}
+
+	// Scenario 1: fresh DB.
+	t.Run("fresh", func(t *testing.T) {
+		dsn := fmt.Sprintf("file:migrate_pfa_fresh_%d?mode=memory&cache=shared", testDBCounter+10100)
+		testDBCounter++
+		db, err := sql.Open("sqlite", dsn)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		t.Cleanup(func() { db.Close() })
+		if err := Migrate(db); err != nil {
+			t.Fatalf("Migrate: %v", err)
+		}
+		for _, col := range pfaCols {
+			if hasColumn(t, db, "concept_states", col) {
+				t.Errorf("concept_states.%s must not exist in fresh schema", col)
+			}
+		}
+	})
+
+	// Scenario 2: pre-#55 DB upgraded.
+	t.Run("upgrade_from_pre_55", func(t *testing.T) {
+		dsn := fmt.Sprintf("file:migrate_pfa_upgrade_%d?mode=memory&cache=shared", testDBCounter+10200)
+		testDBCounter++
+		db, err := sql.Open("sqlite", dsn)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		t.Cleanup(func() { db.Close() })
+
+		// First migration brings the schema up to current.
+		if err := Migrate(db); err != nil {
+			t.Fatalf("first Migrate: %v", err)
+		}
+		// Re-introduce the legacy columns to simulate a pre-#55 DB.
+		for _, col := range pfaCols {
+			if _, err := db.Exec(fmt.Sprintf(
+				"ALTER TABLE concept_states ADD COLUMN %s REAL DEFAULT 0.0", col,
+			)); err != nil {
+				t.Fatalf("seed legacy column %s: %v", col, err)
+			}
+			if !hasColumn(t, db, "concept_states", col) {
+				t.Fatalf("seed column %s should exist", col)
+			}
+		}
+		// Second migration must drop them again — idempotent.
+		if err := Migrate(db); err != nil {
+			t.Fatalf("second Migrate: %v", err)
+		}
+		for _, col := range pfaCols {
+			if hasColumn(t, db, "concept_states", col) {
+				t.Errorf("concept_states.%s should have been dropped by Migrate", col)
+			}
+		}
+		// Third migration must remain a no-op (no panic, no error).
+		if err := Migrate(db); err != nil {
+			t.Fatalf("third Migrate (idempotent): %v", err)
+		}
+	})
+}
+
 // TestOpenDB_Memory exercises the OpenDB helper. OpenDB appends `?_pragma=...`
 // to the path before opening, so we use a file-backed temp DB to keep the DSN
 // shape simple.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -51,8 +51,6 @@ CREATE TABLE IF NOT EXISTS concept_states (
     p_slip         REAL DEFAULT 0.1,
     p_guess        REAL DEFAULT 0.2,
     theta          REAL DEFAULT 0.0,
-    pfa_successes  REAL DEFAULT 0.0,
-    pfa_failures   REAL DEFAULT 0.0,
     updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(learner_id, concept)
 );

--- a/db/store.go
+++ b/db/store.go
@@ -537,12 +537,12 @@ func (s *Store) InsertConceptStateIfNotExists(cs *models.ConceptState) error {
 		`INSERT OR IGNORE INTO concept_states
 		    (learner_id, concept, stability, difficulty, elapsed_days, scheduled_days,
 		     reps, lapses, card_state, last_review, next_review, p_mastery, p_learn, p_forget,
-		     p_slip, p_guess, theta, pfa_successes, pfa_failures, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		     p_slip, p_guess, theta, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		cs.LearnerID, cs.Concept, cs.Stability, cs.Difficulty, cs.ElapsedDays, cs.ScheduledDays,
 		cs.Reps, cs.Lapses, cs.CardState, cs.LastReview, cs.NextReview,
 		cs.PMastery, cs.PLearn, cs.PForget, cs.PSlip, cs.PGuess,
-		cs.Theta, cs.PFASuccesses, cs.PFAFailures, cs.UpdatedAt,
+		cs.Theta, cs.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("insert concept state if not exists: %w", err)
@@ -558,7 +558,7 @@ func (s *Store) GetConceptState(learnerID, concept string) (*models.ConceptState
 	err := s.db.QueryRow(
 		`SELECT id, learner_id, concept, stability, difficulty, elapsed_days, scheduled_days,
 		        reps, lapses, card_state, last_review, next_review, p_mastery, p_learn, p_forget,
-		        p_slip, p_guess, theta, pfa_successes, pfa_failures, updated_at
+		        p_slip, p_guess, theta, updated_at
 		 FROM concept_states WHERE learner_id = ? AND concept = ?`,
 		learnerID, concept,
 	).Scan(
@@ -566,7 +566,7 @@ func (s *Store) GetConceptState(learnerID, concept string) (*models.ConceptState
 		&cs.ElapsedDays, &cs.ScheduledDays, &cs.Reps, &cs.Lapses, &cs.CardState,
 		&lastReview, &nextReview,
 		&cs.PMastery, &cs.PLearn, &cs.PForget, &cs.PSlip, &cs.PGuess,
-		&cs.Theta, &cs.PFASuccesses, &cs.PFAFailures, &cs.UpdatedAt,
+		&cs.Theta, &cs.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get concept state: %w", err)
@@ -586,8 +586,8 @@ func (s *Store) UpsertConceptState(cs *models.ConceptState) error {
 		`INSERT INTO concept_states
 		    (learner_id, concept, stability, difficulty, elapsed_days, scheduled_days,
 		     reps, lapses, card_state, last_review, next_review, p_mastery, p_learn, p_forget,
-		     p_slip, p_guess, theta, pfa_successes, pfa_failures, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		     p_slip, p_guess, theta, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(learner_id, concept) DO UPDATE SET
 		    stability      = excluded.stability,
 		    difficulty     = excluded.difficulty,
@@ -604,13 +604,11 @@ func (s *Store) UpsertConceptState(cs *models.ConceptState) error {
 		    p_slip         = excluded.p_slip,
 		    p_guess        = excluded.p_guess,
 		    theta          = excluded.theta,
-		    pfa_successes  = excluded.pfa_successes,
-		    pfa_failures   = excluded.pfa_failures,
 		    updated_at     = excluded.updated_at`,
 		cs.LearnerID, cs.Concept, cs.Stability, cs.Difficulty, cs.ElapsedDays, cs.ScheduledDays,
 		cs.Reps, cs.Lapses, cs.CardState, cs.LastReview, cs.NextReview,
 		cs.PMastery, cs.PLearn, cs.PForget, cs.PSlip, cs.PGuess,
-		cs.Theta, cs.PFASuccesses, cs.PFAFailures, cs.UpdatedAt,
+		cs.Theta, cs.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert concept state: %w", err)
@@ -622,7 +620,7 @@ func (s *Store) GetConceptStatesByLearner(learnerID string) ([]*models.ConceptSt
 	rows, err := s.db.Query(
 		`SELECT id, learner_id, concept, stability, difficulty, elapsed_days, scheduled_days,
 		        reps, lapses, card_state, last_review, next_review, p_mastery, p_learn, p_forget,
-		        p_slip, p_guess, theta, pfa_successes, pfa_failures, updated_at
+		        p_slip, p_guess, theta, updated_at
 		 FROM concept_states WHERE learner_id = ?`,
 		learnerID,
 	)
@@ -640,7 +638,7 @@ func (s *Store) GetConceptStatesByLearner(learnerID string) ([]*models.ConceptSt
 			&cs.ElapsedDays, &cs.ScheduledDays, &cs.Reps, &cs.Lapses, &cs.CardState,
 			&lastReview, &nextReview,
 			&cs.PMastery, &cs.PLearn, &cs.PForget, &cs.PSlip, &cs.PGuess,
-			&cs.Theta, &cs.PFASuccesses, &cs.PFAFailures, &cs.UpdatedAt,
+			&cs.Theta, &cs.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan concept state row: %w", err)
 		}

--- a/db/store_extra_test.go
+++ b/db/store_extra_test.go
@@ -840,8 +840,8 @@ func TestGetConceptsDueForReview_ExcludesArchivedDomain(t *testing.T) {
 	// Concept states: BOTH due, BOTH non-new.
 	for _, c := range []string{"active_c", "archived_c"} {
 		if _, err := store.db.Exec(
-			`INSERT INTO concept_states (learner_id, concept, p_mastery, stability, difficulty, elapsed_days, scheduled_days, reps, lapses, card_state, last_review, next_review, p_learn, p_forget, p_slip, p_guess, theta, pfa_successes, pfa_failures)
-			 VALUES (?, ?, 0.5, 5, 5, 1, 1, 1, 0, 'review', ?, ?, 0.15, 0.1, 0.1, 0.2, 0, 0, 0)`,
+			`INSERT INTO concept_states (learner_id, concept, p_mastery, stability, difficulty, elapsed_days, scheduled_days, reps, lapses, card_state, last_review, next_review, p_learn, p_forget, p_slip, p_guess, theta)
+			 VALUES (?, ?, 0.5, 5, 5, 1, 1, 1, 0, 'review', ?, ?, 0.15, 0.1, 0.1, 0.2, 0)`,
 			"L2", c, past, past,
 		); err != nil {
 			t.Fatal(err)

--- a/models/learner.go
+++ b/models/learner.go
@@ -36,8 +36,6 @@ type ConceptState struct {
 	PSlip         float64
 	PGuess        float64
 	Theta         float64
-	PFASuccesses  float64
-	PFAFailures   float64
 	UpdatedAt     time.Time
 }
 

--- a/tools/interaction_apply.go
+++ b/tools/interaction_apply.go
@@ -13,7 +13,7 @@ import (
 )
 
 // interactionInput carries the minimal fields needed to persist an
-// interaction and drive the BKT/FSRS/IRT/PFA update chain.  Fields not
+// interaction and drive the BKT/FSRS/IRT update chain.  Fields not
 // relevant to a given call site (e.g. HintsRequested for submit_answer)
 // should be left at their zero values.
 type interactionInput struct {
@@ -33,19 +33,24 @@ type interactionInput struct {
 }
 
 // applyInteraction persists the interaction and updates the learner's
-// cognitive state (BKT, FSRS, IRT, PFA) for the concept.  Returns the
+// cognitive state (BKT, FSRS, IRT) for the concept.  Returns the
 // resulting ConceptState (post-update) and an error if any persistence
 // step failed.
 //
-// The BKT → FSRS → IRT → PFA update chain is *non-commutative* on
+// The BKT → FSRS → IRT update chain is *non-commutative* on
 // `cs.Difficulty` (and in spirit on `cs.Reps` / `cs.Stability` /
 // `cs.PMastery`): IRT consumes the FSRS difficulty to compute the θ
 // step, but FSRS itself rewrites that field. Reading `cs.*` directly
 // after running each step would silently mix prior- and post-update
 // values across the chain (issue #53). To keep the chain
 // order-independent we snapshot the read-only prior values at the top,
-// run all four updates against the snapshot, and write the merged
+// run all three updates against the snapshot, and write the merged
 // result back to `cs` exactly once at the end.
+//
+// Note: PFA is intentionally NOT persisted on the concept state. The
+// PLATEAU alert in engine/alert.go recomputes a fresh PFAState from the
+// recent-interactions list on each call, so storing rolling counts
+// per-concept added schema weight without any reader (issue #55).
 func applyInteraction(
 	deps *Deps,
 	learnerID string,
@@ -60,7 +65,7 @@ func applyInteraction(
 
 	// ── Snapshot read-only prior state ──────────────────────────────
 	// All downstream algorithm steps read from this snapshot, never
-	// from `cs` directly, to keep the BKT → FSRS → IRT → PFA chain
+	// from `cs` directly, to keep the BKT → FSRS → IRT chain
 	// commutative. See doc comment above and issue #53.
 	priorPMastery := cs.PMastery
 	priorPLearn := cs.PLearn
@@ -75,8 +80,6 @@ func applyInteraction(
 	priorLapses := cs.Lapses
 	priorCardState := cs.CardState
 	priorTheta := cs.Theta
-	priorPFASuccesses := cs.PFASuccesses
-	priorPFAFailures := cs.PFAFailures
 	var priorLastReview time.Time
 	if cs.LastReview != nil {
 		priorLastReview = *cs.LastReview
@@ -163,13 +166,6 @@ func applyInteraction(
 	}
 	newTheta := algorithms.IRTUpdateTheta(priorTheta, []algorithms.IRTItem{item}, []bool{input.Success})
 
-	// ── PFA update — reads from prior snapshot. ────────────────────
-	pfaState := algorithms.PFAState{
-		Successes: priorPFASuccesses,
-		Failures:  priorPFAFailures,
-	}
-	pfaState = algorithms.PFAUpdate(pfaState, input.Success)
-
 	// ── Single write-back of the merged result. ────────────────────
 	cs.PMastery = bktState.PMastery
 	cs.Stability = fsrsCard.Stability
@@ -183,8 +179,6 @@ func applyInteraction(
 	nextReview := now.Add(time.Duration(fsrsCard.ScheduledDays) * 24 * time.Hour)
 	cs.NextReview = &nextReview
 	cs.Theta = newTheta
-	cs.PFASuccesses = pfaState.Successes
-	cs.PFAFailures = pfaState.Failures
 
 	// Persist updated concept state.
 	if err := deps.Store.UpsertConceptState(cs); err != nil {

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -51,7 +51,7 @@ OUTILS DISPONIBLES :
 - get_learner_context(domain_id?) : contexte de session, liste des domaines, progress_narrative
 - get_pending_alerts(domain_id?) : alertes critiques
 - get_next_activity(domain_id?) : prochaine activité optimale + miroir métacognitif + tutor_mode + motivation_brief
-- record_interaction(concept, success, confidence, error_type?, hints_requested?, self_initiated?, calibration_id?, domain_id?) : enregistre + met à jour BKT/FSRS/IRT/PFA
+- record_interaction(concept, success, confidence, error_type?, hints_requested?, self_initiated?, calibration_id?, domain_id?) : enregistre + met à jour BKT/FSRS/IRT
 - record_affect(session_id, energy?, confidence?, satisfaction?, perceived_difficulty?, next_session_intent?) : check-in émotionnel début/fin de session
 - record_session_close(domain_id?, implementation_intention?) : clôture la session, retourne recap_brief (wins, struggles, prompt_for_implementation_intent)
 - queue_webhook_message(kind, scheduled_for, content, expires_at?, priority?) : mettre en queue un nudge que le scheduler postera sur le webhook Discord (daily_motivation | daily_recap | reactivation | reminder)


### PR DESCRIPTION
Fixes #55

References #8 (item: PFA persisted state never consumed)

## Summary

PFA persisted state on `concept_states` (`pfa_successes`, `pfa_failures`) was written by `tools/interaction_apply.go` on every interaction but no selector / dashboard / alert path ever read it back. `engine/alert.go`'s PLATEAU detector recomputes a fresh `PFAState` from the recent-interactions list on each call, so the columns were schema dead-weight.

**Conservative fork**: dropped the columns and the writer. Kept `algorithms/pfa.go` because `engine/alert.go` still consumes the pure functions (`PFAState`, `PFAUpdate`, `PFAProbability`, `PFADetectPlateau`) for in-memory plateau detection — leaves the file ready for the #48 fidelity work without relying on dead persistence.

Migration is forward-only via two appended `ALTER TABLE concept_states DROP COLUMN` entries (modernc.org/sqlite v1.47 ships SQLite > 3.35, so `DROP COLUMN` is supported). The existing migration loop pattern keeps it idempotent.

## Columns dropped

- `concept_states.pfa_successes`
- `concept_states.pfa_failures`

## Files touched

- `db/schema.sql` — DDL
- `db/migrations.go` — forward-only DROP COLUMN entries
- `db/migrations_test.go` — `TestMigrate_DropsPFAColumns`
- `db/store.go` — INSERT/UPDATE/SELECT/Scan paths
- `db/store_extra_test.go` — fixture seed
- `models/learner.go` — `ConceptState.PFASuccesses`, `ConceptState.PFAFailures` removed
- `tools/interaction_apply.go` — PFA read/update/write block removed
- `tools/prompt.go` — `record_interaction` doc no longer claims PFA update

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green
- [x] `TestMigrate_DropsPFAColumns/fresh` — fresh DB has no PFA columns
- [x] `TestMigrate_DropsPFAColumns/upgrade_from_pre_55` — seeds legacy columns then re-runs Migrate; confirms drop + idempotency on third Migrate call
- [x] `TestMigrate_Idempotent` still passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_