### PR TITLE
chore(learner): drop unconsumed level/background/learning_style fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Tutor MCP is **chat-only**. The LLM drives the learning loop in conversation: it
 | `get_dashboard_state` | Full dashboard: progress, retention, autonomy score, calibration bias, affect history |
 | `get_olm_snapshot` | Open Learner Model snapshot: per-concept mastery, retention, last-seen, fringe membership, anti-repeat status |
 | `get_availability_model` | Learner's time windows and session frequency |
-| `update_learner_profile` | Persist learner metadata (device, background, level, calibration bias, autonomy score) |
+| `update_learner_profile` | Persist learner metadata (device, objective, language, calibration bias, affect baseline, autonomy score) |
 
 ### Domain Management
 

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -108,6 +108,25 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("data migration plearn: %w", err)
 	}
 
+	// Issue #61: scrub the legacy `level`, `background`, `learning_style`
+	// keys out of profile_json. These were write-only fields on
+	// update_learner_profile with no production reader (no consumer in
+	// motivation, concept selection, alerts, dashboard). Forward-only —
+	// the tool no longer accepts them so re-introduction is impossible
+	// without code changes. json_remove is idempotent: a second run on a
+	// scrubbed row is a no-op (the keys are already absent).
+	if _, err := db.Exec(
+		`UPDATE learners
+		 SET profile_json = json_remove(profile_json, '$.level', '$.background', '$.learning_style')
+		 WHERE profile_json IS NOT NULL
+		   AND profile_json != ''
+		   AND (json_extract(profile_json, '$.level') IS NOT NULL
+		     OR json_extract(profile_json, '$.background') IS NOT NULL
+		     OR json_extract(profile_json, '$.learning_style') IS NOT NULL)`,
+	); err != nil {
+		return fmt.Errorf("data migration drop learner profile fields: %w", err)
+	}
+
 	// Idempotent table + index creation for existing databases
 	idempotentMigrations := []string{
 		`CREATE TABLE IF NOT EXISTS oauth_codes (

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -198,6 +198,126 @@ func TestMigrate_DropsPFAColumns(t *testing.T) {
 	})
 }
 
+// TestMigrate_DropsLegacyLearnerProfileFields is the issue #61 regression
+// guard. The data migration in db/migrations.go must scrub the `level`,
+// `background` and `learning_style` keys out of pre-existing profile_json
+// blobs because no production component reads them and leaving them in the
+// blob causes an unbounded write-only key surface.
+//
+// We seed two rows that mirror the historical shape (one with all three
+// keys plus an unrelated key that must survive, one with a partial subset),
+// run Migrate, then assert json_extract returns NULL for the dropped keys
+// and the unrelated key is intact.
+func TestMigrate_DropsLegacyLearnerProfileFields(t *testing.T) {
+	dsn := fmt.Sprintf("file:migrate_drop_legacy_%d?mode=memory&cache=shared", testDBCounter+20000)
+	testDBCounter++
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// Run an initial migration so the learners table (and profile_json
+	// column) exists, then seed legacy rows BEFORE the second migration
+	// runs the data scrub. The migration is idempotent so the seed runs
+	// after a no-op second call would also work — but seeding between
+	// two Migrate() calls makes the assertion order obvious.
+	if err := Migrate(db); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	seed := []struct {
+		id      string
+		profile string
+	}{
+		{
+			id: "legacy_full",
+			profile: `{"level":"intermediate","background":"engineer",` +
+				`"learning_style":"visual","language":"fr","device":"laptop"}`,
+		},
+		{
+			id:      "legacy_partial",
+			profile: `{"level":"beginner","autonomy_score":0.6}`,
+		},
+		{
+			id:      "clean",
+			profile: `{"language":"en"}`,
+		},
+	}
+	for _, s := range seed {
+		_, err := db.Exec(
+			`INSERT INTO learners (id, email, password_hash, objective, profile_json) VALUES (?, ?, 'h', 'o', ?)`,
+			s.id, s.id+"@x", s.profile,
+		)
+		if err != nil {
+			t.Fatalf("seed %s: %v", s.id, err)
+		}
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("second Migrate (must scrub legacy keys): %v", err)
+	}
+
+	// Each dropped key must be absent (json_extract returns NULL) on
+	// every row.
+	droppedKeys := []string{"$.level", "$.background", "$.learning_style"}
+	for _, s := range seed {
+		for _, key := range droppedKeys {
+			var v sql.NullString
+			err := db.QueryRow(
+				`SELECT json_extract(profile_json, ?) FROM learners WHERE id = ?`,
+				key, s.id,
+			).Scan(&v)
+			if err != nil {
+				t.Fatalf("query %s %s: %v", s.id, key, err)
+			}
+			if v.Valid {
+				t.Errorf("learner %s: key %s should have been scrubbed, got %q", s.id, key, v.String)
+			}
+		}
+	}
+
+	// Unrelated keys must survive on the rows that originally carried them.
+	preserved := []struct {
+		id   string
+		key  string
+		want string
+	}{
+		{"legacy_full", "$.language", "fr"},
+		{"legacy_full", "$.device", "laptop"},
+		{"clean", "$.language", "en"},
+	}
+	for _, p := range preserved {
+		var v sql.NullString
+		err := db.QueryRow(
+			`SELECT json_extract(profile_json, ?) FROM learners WHERE id = ?`,
+			p.key, p.id,
+		).Scan(&v)
+		if err != nil {
+			t.Fatalf("query %s %s: %v", p.id, p.key, err)
+		}
+		if !v.Valid || v.String != p.want {
+			t.Errorf("learner %s: key %s should equal %q, got valid=%v value=%q", p.id, p.key, p.want, v.Valid, v.String)
+		}
+	}
+
+	// legacy_partial: autonomy_score must survive, level must be gone.
+	var auto sql.NullFloat64
+	if err := db.QueryRow(
+		`SELECT json_extract(profile_json, '$.autonomy_score') FROM learners WHERE id = 'legacy_partial'`,
+	).Scan(&auto); err != nil {
+		t.Fatalf("query autonomy_score: %v", err)
+	}
+	if !auto.Valid || auto.Float64 != 0.6 {
+		t.Errorf("legacy_partial autonomy_score should equal 0.6, got valid=%v value=%v", auto.Valid, auto.Float64)
+	}
+
+	// Idempotence: running Migrate again on already-scrubbed rows is a
+	// no-op (no error, no spurious changes).
+	if err := Migrate(db); err != nil {
+		t.Fatalf("third Migrate (idempotent on scrubbed rows): %v", err)
+	}
+}
+
 // TestOpenDB_Memory exercises the OpenDB helper. OpenDB appends `?_pragma=...`
 // to the path before opening, so we use a file-backed temp DB to keep the DSN
 // shape simple.

--- a/tools/length_validation_test.go
+++ b/tools/length_validation_test.go
@@ -48,10 +48,14 @@ func TestRecordInteraction_RejectsOversizedConcept(t *testing.T) {
 	}
 }
 
-func TestUpdateLearnerProfile_RejectsOversizedBackground(t *testing.T) {
+// TestUpdateLearnerProfile_RejectsOversizedObjective swapped in for the
+// previous oversized-background coverage after issue #61 dropped the
+// `background` / `level` / `learning_style` fields from the tool surface.
+// `objective` shares the same maxNoteLen cap, keeping the boundary covered.
+func TestUpdateLearnerProfile_RejectsOversizedObjective(t *testing.T) {
 	_, deps := setupToolsTest(t)
 	res := callTool(t, deps, registerUpdateLearnerProfile, "L_owner", "update_learner_profile", map[string]any{
-		"background": strings.Repeat("b", maxNoteLen+1),
+		"objective": strings.Repeat("o", maxNoteLen+1),
 	})
 	if !res.IsError {
 		t.Fatalf("expected length-cap rejection, got %q", resultText(res))

--- a/tools/profile.go
+++ b/tools/profile.go
@@ -12,13 +12,17 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// UpdateLearnerProfileParams enumerates the fields the chat-side LLM may push
+// into a learner's persisted profile blob. Issue #61: `level`, `background`
+// and `learning_style` were removed because no downstream component (motivation
+// brief, concept selector, alerts, dashboard) consumes them — they were
+// write-only metadata that bloated the profile_json blob without informing
+// any decision. The forward-only migration in db/migrations.go scrubs the keys
+// out of existing rows so a re-introduction won't silently inherit stale data.
 type UpdateLearnerProfileParams struct {
 	Device          string  `json:"device,omitempty" jsonschema:"Appareil principal (ex: laptop, phone, tablet)"`
-	Background      string  `json:"background,omitempty" jsonschema:"Contexte professionnel ou académique de l'apprenant"`
-	Style           string  `json:"learning_style,omitempty" jsonschema:"Style d'apprentissage préféré (ex: visuel, pratique, théorique)"`
 	Objective       string  `json:"objective,omitempty" jsonschema:"Objectif d'apprentissage mis à jour"`
 	Language        string  `json:"language,omitempty" jsonschema:"Langue préférée pour les exercices"`
-	Level           string  `json:"level,omitempty" jsonschema:"Niveau actuel (débutant, intermédiaire, avancé)"`
 	CalibrationBias float64 `json:"calibration_bias,omitempty" jsonschema:"Biais de calibration (positif=sur-estimé, négatif=sous-estimé)"`
 	AffectBaseline  string  `json:"affect_baseline,omitempty" jsonschema:"Baseline émotionnelle de l'apprenant"`
 	AutonomyScore   float64 `json:"autonomy_score,omitempty" jsonschema:"Score d'autonomie actuel (0-1)"`
@@ -27,7 +31,7 @@ type UpdateLearnerProfileParams struct {
 func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_learner_profile",
-		Description: "Met à jour les métadonnées persistantes de l'apprenant (device, background, style, objectif, niveau). Seuls les champs fournis sont modifiés.",
+		Description: "Met à jour les métadonnées persistantes de l'apprenant (device, objectif, langue, calibration, affect, autonomie). Seuls les champs fournis sont modifiés.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UpdateLearnerProfileParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -52,11 +56,8 @@ func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 			max   int
 		}{
 			{"device", params.Device, maxShortLabelLen},
-			{"background", params.Background, maxNoteLen},
-			{"learning_style", params.Style, maxShortLabelLen},
 			{"objective", params.Objective, maxNoteLen},
 			{"language", params.Language, maxShortLabelLen},
-			{"level", params.Level, maxShortLabelLen},
 			{"affect_baseline", params.AffectBaseline, maxShortLabelLen},
 		}
 		for _, f := range stringFields {
@@ -78,20 +79,8 @@ func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 			profile["device"] = params.Device
 			updated++
 		}
-		if params.Background != "" {
-			profile["background"] = params.Background
-			updated++
-		}
-		if params.Style != "" {
-			profile["learning_style"] = params.Style
-			updated++
-		}
 		if params.Language != "" {
 			profile["language"] = params.Language
-			updated++
-		}
-		if params.Level != "" {
-			profile["level"] = params.Level
 			updated++
 		}
 		if params.CalibrationBias != 0 {
@@ -121,9 +110,9 @@ func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 		}
 
 		r, _ := jsonResult(map[string]interface{}{
-			"updated":       true,
+			"updated":        true,
 			"fields_changed": updated,
-			"profile":       profile,
+			"profile":        profile,
 		})
 		return r, nil, nil
 	})

--- a/tools/profile_test.go
+++ b/tools/profile_test.go
@@ -5,6 +5,8 @@ package tools
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -20,11 +22,8 @@ func TestUpdateLearnerProfile_HappyPath(t *testing.T) {
 	store, deps := setupToolsTest(t)
 	res := callTool(t, deps, registerUpdateLearnerProfile, "L_owner", "update_learner_profile", map[string]any{
 		"device":           "laptop",
-		"background":       "engineer",
-		"learning_style":   "visual",
 		"objective":        "deep math",
 		"language":         "fr",
-		"level":            "intermediate",
 		"calibration_bias": 0.15,
 		"affect_baseline":  "calm",
 		"autonomy_score":   0.6,
@@ -36,8 +35,8 @@ func TestUpdateLearnerProfile_HappyPath(t *testing.T) {
 	if out["updated"] != true {
 		t.Fatalf("expected updated=true, got %v", out)
 	}
-	if out["fields_changed"].(float64) != 9 {
-		t.Fatalf("expected 9 fields_changed, got %v", out["fields_changed"])
+	if out["fields_changed"].(float64) != 6 {
+		t.Fatalf("expected 6 fields_changed, got %v", out["fields_changed"])
 	}
 
 	// DB state: profile is persisted.
@@ -49,7 +48,7 @@ func TestUpdateLearnerProfile_HappyPath(t *testing.T) {
 	if err := json.Unmarshal([]byte(learner.ProfileJSON), &p); err != nil {
 		t.Fatalf("bad profile JSON: %v", err)
 	}
-	if p["device"] != "laptop" || p["learning_style"] != "visual" {
+	if p["device"] != "laptop" || p["language"] != "fr" {
 		t.Fatalf("unexpected profile: %v", p)
 	}
 }
@@ -57,18 +56,18 @@ func TestUpdateLearnerProfile_HappyPath(t *testing.T) {
 func TestUpdateLearnerProfile_PartialUpdatePreservesExisting(t *testing.T) {
 	store, deps := setupToolsTest(t)
 
-	// First call: sets device + level.
+	// First call: sets device + language.
 	res := callTool(t, deps, registerUpdateLearnerProfile, "L_owner", "update_learner_profile", map[string]any{
-		"device": "phone",
-		"level":  "beginner",
+		"device":   "phone",
+		"language": "fr",
 	})
 	if res.IsError {
 		t.Fatalf("first call: %q", resultText(res))
 	}
 
-	// Second call: only updates level — device should be preserved.
+	// Second call: only updates language — device should be preserved.
 	res2 := callTool(t, deps, registerUpdateLearnerProfile, "L_owner", "update_learner_profile", map[string]any{
-		"level": "advanced",
+		"language": "en",
 	})
 	if res2.IsError {
 		t.Fatalf("second call: %q", resultText(res2))
@@ -83,8 +82,8 @@ func TestUpdateLearnerProfile_PartialUpdatePreservesExisting(t *testing.T) {
 	if p["device"] != "phone" {
 		t.Fatalf("device should be preserved, got %v", p["device"])
 	}
-	if p["level"] != "advanced" {
-		t.Fatalf("level should be updated, got %v", p["level"])
+	if p["language"] != "en" {
+		t.Fatalf("language should be updated, got %v", p["language"])
 	}
 }
 
@@ -97,5 +96,55 @@ func TestUpdateLearnerProfile_NoFieldsProvided(t *testing.T) {
 	out := decodeResult(t, res)
 	if out["fields_changed"].(float64) != 0 {
 		t.Fatalf("expected 0 fields_changed, got %v", out["fields_changed"])
+	}
+}
+
+// TestUpdateLearnerProfile_DroppedFieldsRejected is the issue #61 regression
+// guard. The deprecated fields `level`, `background` and `learning_style`
+// were write-only with no consumer (no read site in motivation, concept
+// selection, alerts or dashboard). After their removal from
+// UpdateLearnerProfileParams, the SDK's JSON-Schema input validator rejects
+// posts that include any of them with an `unexpected additional properties`
+// transport error — so a stale client cannot smuggle them back into
+// profile_json.
+//
+// We try each deprecated key in isolation to assert the rejection is
+// per-field, not just a happy-path collision with one specific key.
+func TestUpdateLearnerProfile_DroppedFieldsRejected(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	for _, key := range []string{"level", "background", "learning_style"} {
+		_, err := callToolRaw(t, deps, registerUpdateLearnerProfile, "L_owner", "update_learner_profile", map[string]any{
+			key: "x",
+		})
+		if err == nil {
+			t.Fatalf("posting deprecated key %q should be rejected by JSON-schema validator, got nil error", key)
+		}
+		if !strings.Contains(err.Error(), "additional properties") {
+			t.Errorf("posting deprecated key %q: expected 'additional properties' rejection, got %v", key, err)
+		}
+	}
+}
+
+// TestUpdateLearnerProfile_DroppedKeysAbsentFromInputSchema is a structural
+// guard: even if the SDK relaxes additionalProperties enforcement in the
+// future, the param struct itself must not carry these JSON tags. We
+// reflect over UpdateLearnerProfileParams and assert no field maps to any
+// of the three deprecated JSON keys.
+func TestUpdateLearnerProfile_DroppedKeysAbsentFromInputSchema(t *testing.T) {
+	dropped := map[string]struct{}{
+		"level":          {},
+		"background":     {},
+		"learning_style": {},
+	}
+	rt := reflect.TypeOf(UpdateLearnerProfileParams{})
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("json")
+		// strip ",omitempty" suffix
+		if idx := strings.Index(tag, ","); idx >= 0 {
+			tag = tag[:idx]
+		}
+		if _, bad := dropped[tag]; bad {
+			t.Errorf("UpdateLearnerProfileParams.%s carries deprecated JSON tag %q (issue #61)", rt.Field(i).Name, tag)
+		}
 	}
 }

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -68,7 +68,7 @@ OUTILS DISPONIBLES :
 - get_availability_model() : créneaux et fréquence
 - init_domain(name, concepts, prerequisites, personal_goal?, value_framings?) : crée un domaine (value_framings = 4 axes de gain: financial/employment/intellectual/innovation)
 - add_concepts(domain_id?, concepts, prerequisites) : ajoute des concepts
-- update_learner_profile(device?, background?, learning_style?, objective?, language?, level?, calibration_bias?, affect_baseline?, autonomy_score?) : métadonnées persistantes
+- update_learner_profile(device?, objective?, language?, calibration_bias?, affect_baseline?, autonomy_score?) : métadonnées persistantes
 - get_misconceptions(domain_id?, concept?) : liste les misconceptions détectées par concept
 - get_olm_snapshot(domain_id?, scope?) : snapshot transparent de l'état d'apprentissage (mastery distrib, focus, signaux métacognitifs, progression goal). scope='session' (défaut) ou 'global'
 - archive_domain(domain_id) : archive un domaine — il disparaît du dashboard et du routing, progression préservée


### PR DESCRIPTION
Fixes #61

References #8 (item: update_learner_profile write-only fields)

## Summary

The `update_learner_profile` tool accepted three fields — `level`, `background`, `learning_style` — that no production component ever read. Verified by `grep` across motivation, concept selection, alerts, dashboard, OLM and engine packages. They were write-only metadata bloating the `profile_json` blob. This PR takes the conservative fork from #61 and drops them entirely.

Schema-wise, the fields live as JSON keys inside `learners.profile_json` (not as columns), so the forward-only data migration uses `json_remove` (a no-op on already-scrubbed rows) instead of `ALTER TABLE DROP COLUMN`. Appended as a new entry in `db/migrations.go`; no existing entries modified.

The tool surface change drops the three fields from `UpdateLearnerProfileParams`; the SDK's JSON-Schema validator now rejects posts that include any of them with an `unexpected additional properties` transport error — louder failure mode than a silent ignore.

## No-production-reader confirmation

`grep -rn "ProfileJSON\|profile_json\|\"level\"\|\"background\"\|\"learning_style\"" --include="*.go" .` (excluding tests) shows the only non-test reads come from `tools/profile.go` itself, which loads the blob, merges the same keys back, and re-persists — i.e. the keys are loop-back metadata with no downstream consumer. Unrelated `level`-token hits (`main.go:parseLogLevel`, `tools/activity.go:engine.HintLevel`, comments) were left untouched.

## Test plan

- [x] `go build ./...` clean, `go vet ./...` clean
- [x] `go test ./... -count=1` green
- [x] `db.TestMigrate_DropsLegacyLearnerProfileFields` — seeds full/partial/clean rows; asserts `json_extract` returns `NULL` for dropped keys post-migration; unrelated keys (`language`, `device`, `autonomy_score`) survive; third `Migrate()` call is idempotent
- [x] `tools.TestUpdateLearnerProfile_DroppedFieldsRejected` — posts each deprecated key in isolation; SDK returns `additional properties` rejection
- [x] `tools.TestUpdateLearnerProfile_DroppedKeysAbsentFromInputSchema` — reflection over `UpdateLearnerProfileParams`; survives if SDK relaxes additional-properties enforcement
- [x] Existing `_HappyPath` / `_PartialUpdatePreservesExisting` updated to use surviving fields (`device`, `language`) and recalculated `fields_changed` count
- [x] `_RejectsOversizedObjective` replaces the old `_RejectsOversizedBackground` length-cap test

## Files

- `tools/profile.go`, `tools/profile_test.go`, `tools/length_validation_test.go`, `tools/prompt.go`
- `db/migrations.go`, `db/migrations_test.go`
- `README.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt7vymp2TGE2NtgAbmeYNo)_