### PR TITLE
fix(tools): reject archived domains in resolveDomain

### DIFF
--- a/tools/manage_domain_test.go
+++ b/tools/manage_domain_test.go
@@ -214,3 +214,59 @@ func TestDeleteDomain_MissingID(t *testing.T) {
 		t.Fatalf("expected validation error")
 	}
 }
+
+// TestResolveDomain_RejectsArchived verifies that resolveDomain refuses an
+// explicit archived domain_id. Regression for #94: without this guard the
+// BKT/FSRS chain silently advances state on a domain the learner has
+// explicitly archived.
+func TestResolveDomain_RejectsArchived(t *testing.T) {
+	store, _ := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math")
+	if err := store.ArchiveDomain(d.ID, "L_owner"); err != nil {
+		t.Fatalf("archive domain: %v", err)
+	}
+
+	got, err := resolveDomain(store, "L_owner", d.ID)
+	if err == nil {
+		t.Fatalf("expected error resolving archived domain, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "archived") && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'archived' or 'not found' error, got %q", err.Error())
+	}
+}
+
+// TestRecordInteraction_RejectsArchivedDomain is the integration-level guard
+// for #94: passing an archived domain_id to record_interaction must fail
+// rather than silently advance state on the archived domain.
+func TestRecordInteraction_RejectsArchivedDomain(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // concepts: ["a","b"]
+	if err := store.ArchiveDomain(d.ID, "L_owner"); err != nil {
+		t.Fatalf("archive domain: %v", err)
+	}
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"domain_id":             d.ID,
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               true,
+		"response_time_seconds": 5.0,
+		"confidence":            0.9,
+		"notes":                 "",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error when targeting archived domain, got %q", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "domain not found") {
+		t.Fatalf("expected 'domain not found' error, got %q", resultText(res))
+	}
+
+	// DB state: no interaction was recorded against the archived domain.
+	recents, err := store.GetRecentInteractionsByLearner("L_owner", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recents) != 0 {
+		t.Fatalf("expected no interaction recorded on archived domain, got %d", len(recents))
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -64,6 +64,13 @@ func filterInteractionsByConcepts(interactions []*models.Interaction, set map[st
 }
 
 // resolveDomain resolves a domain by ID or falls back to the learner's most recent domain.
+//
+// Archived domains are explicitly rejected when resolved by ID: see issue #94.
+// Without this guard, callers like record_interaction would silently advance
+// BKT/FSRS state on a domain the learner has explicitly archived. Archive-
+// specific tools (archive_domain, unarchive_domain, delete_domain) do not go
+// through resolveDomain — they call store.GetDomainByID directly because they
+// legitimately need to operate on archived rows.
 func resolveDomain(store *db.Store, learnerID, domainID string) (*models.Domain, error) {
 	if domainID != "" {
 		d, err := store.GetDomainByID(domainID)
@@ -71,6 +78,9 @@ func resolveDomain(store *db.Store, learnerID, domainID string) (*models.Domain,
 			return nil, err
 		}
 		if d.LearnerID != learnerID {
+			return nil, fmt.Errorf("domain not found")
+		}
+		if d.Archived {
 			return nil, fmt.Errorf("domain not found")
 		}
 		return d, nil


### PR DESCRIPTION
Fixes #94

## Summary
`tools/tools.go:resolveDomain` looked up an explicit `domain_id` via `store.GetDomainByID`, which has no `archived = 0` filter. As a result, any tool routed through `resolveDomain` (most importantly `record_interaction`) silently advanced BKT/FSRS state on a domain the learner had explicitly archived. This patch adds an `Archived` check inside `resolveDomain`, returning the canonical `domain not found` error when the targeted domain is archived. The fallback path (`GetDomainByLearner`) already filters archived rows. The archive-management tools (`archive_domain`, `unarchive_domain`, `delete_domain`) bypass `resolveDomain` and call `store.GetDomainByID` directly, so they continue to operate on archived rows as intended.

## Test plan
- [x] `TestResolveDomain_RejectsArchived` (unit) — archived domain ID returns an error from `resolveDomain`.
- [x] `TestRecordInteraction_RejectsArchivedDomain` (integration) — `record_interaction` with an archived `domain_id` returns `domain not found` and writes no interaction row.
- [x] Both tests fail on `staging` before the fix and pass after.
- [x] `go build ./... && go vet ./... && go test ./...` all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_