### PR TITLE
fix(tools): validate learner_concept in learning_negotiation

### DIFF
--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -54,6 +54,20 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// Issue #92: when the learner proposes a concept, validate it is part
+		// of the active domain before any plan construction. Without this
+		// guard the orchestrator silently builds an "accepted" plan around a
+		// hallucinated concept (no prereqs to break, no states to consult)
+		// and returns counts_as_self_initiated=true. Mirror the record_
+		// interaction / transfer_challenge guard pattern. LearnerConcept is
+		// optional (system_plan-only path), so only validate when non-empty.
+		if params.LearnerConcept != "" {
+			if err := validateConceptInDomain(domain, params.LearnerConcept); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+		}
+
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
 
 		domainConcepts := make(map[string]bool)

--- a/tools/negotiation_test.go
+++ b/tools/negotiation_test.go
@@ -4,6 +4,7 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"tutor-mcp/models"
@@ -50,6 +51,30 @@ func TestLearningNegotiation_SystemPlanOnly(t *testing.T) {
 	}
 	if _, ok := out["learner_proposal"]; ok {
 		t.Fatalf("learner_proposal should not be present, got %v", out["learner_proposal"])
+	}
+}
+
+// TestLearningNegotiation_UnknownConceptRejected guards issue #92: a learner
+// (or hallucinating LLM) can pass a concept name that does not exist in the
+// active domain's Graph.Concepts. Without the validateConceptInDomain guard
+// the negotiation tool silently builds a plan around the non-existent concept
+// and returns accepted=true even though no prereqs exist. Mirror the
+// record_interaction / transfer_challenge guard pattern.
+func TestLearningNegotiation_UnknownConceptRejected(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // domain has {a, b}
+
+	res := callTool(t, deps, registerLearningNegotiation, "L_owner", "learning_negotiation", map[string]any{
+		"session_id":      "s1",
+		"learner_concept": "ghost",
+		"domain_id":       d.ID,
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown concept, got %q", resultText(res))
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "ghost") || !strings.Contains(msg, "not part of domain") {
+		t.Fatalf("expected error mentioning unknown concept and domain, got %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #92.

`learning_negotiation` did not validate `learner_concept` against the active domain's `Graph.Concepts`. A learner (or hallucinating LLM) could pass a concept name that did not exist in the domain; the tool happily built an "accepted" plan around the non-existent concept (no prereqs to fail, no states to consult) and returned `counts_as_self_initiated=true`. This mirrors the same guard already used by `record_interaction` (tools/interaction.go) and `transfer_challenge` (tools/transfer.go) by calling `validateConceptInDomain` on the learner-supplied concept after domain resolution and before any plan construction. `LearnerConcept` is optional (system-plan-only path), so the validator is only invoked when non-empty.

## Test plan

- [x] New regression test `TestLearningNegotiation_UnknownConceptRejected` fails on `staging` (returns `accepted=true` for `"ghost"`) and passes with the fix.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./tools/` -> `ok  tutor-mcp/tools  2.451s` (existing negotiation tests still pass: NoAuth, NoDomain, SystemPlanOnly, LearnerProposalAccepted).

https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_