### PR TITLE
fix(tools): enforce activity_type and error_type enums in record_interaction

### DIFF
--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -16,11 +16,11 @@ import (
 
 type RecordInteractionParams struct {
 	Concept             string  `json:"concept" jsonschema:"Le concept concerné"`
-	ActivityType        string  `json:"activity_type" jsonschema:"Type d'activité (RECALL_EXERCISE, NEW_CONCEPT, etc.)"`
+	ActivityType        string  `json:"activity_type" jsonschema:"Type d'activité — DOIT être l'une des valeurs canoniques: RECALL_EXERCISE, NEW_CONCEPT, MASTERY_CHALLENGE, DEBUGGING_CASE, REST, SETUP_DOMAIN, PRACTICE, DEBUG_MISCONCEPTION, FEYNMAN_PROMPT, TRANSFER_PROBE, CLOSE_SESSION"`
 	Success             bool    `json:"success" jsonschema:"L'exercice a été réussi"`
 	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"Temps de réponse en secondes"`
 	Confidence          float64 `json:"confidence" jsonschema:"Confiance estimée entre 0 et 1"`
-	ErrorType           string  `json:"error_type,omitempty" jsonschema:"Type d'erreur si échec: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP (optionnel)"`
+	ErrorType           string  `json:"error_type,omitempty" jsonschema:"Type d'erreur si échec — laisser vide ou utiliser exactement: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP"`
 	Notes               string  `json:"notes" jsonschema:"Notes optionnelles sur l'interaction"`
 	DomainID            string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
 	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"Nombre d'indices demandés pendant l'échange (optionnel, défaut 0)"`
@@ -66,6 +66,24 @@ func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 		}
 		for _, f := range stringFields {
 			if err := validateString(f.name, f.value, f.max); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+		}
+
+		// Enum whitelist for activity_type and error_type (issue #88).
+		// Without these guards the LLM has to guess from the prose schema
+		// description ("RECALL_EXERCISE, NEW_CONCEPT, etc."), and typos
+		// like "RECALL" leak into the audit row, escape downstream filters,
+		// and silently degrade the BKT slip-by-error-type heuristic plus
+		// alert.go's errorTypeCounts aggregation.
+		if err := validateEnum("activity_type", params.ActivityType, allowedActivityTypes); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+		// error_type is optional — empty string passes through unchecked.
+		if params.ErrorType != "" {
+			if err := validateEnum("error_type", params.ErrorType, allowedErrorTypes); err != nil {
 				r, _ := errorResult(err.Error())
 				return r, nil, nil
 			}

--- a/tools/interaction_test.go
+++ b/tools/interaction_test.go
@@ -445,6 +445,100 @@ func TestRecordInteraction_AuditRowCarriesHeuristicSlipGuess_Success(t *testing.
 	}
 }
 
+// Issue #88: activity_type must be constrained to a known enum so the LLM
+// stops guessing values from prose like "RECALL_EXERCISE, NEW_CONCEPT, etc.".
+// A free-form value like "GARBAGE" must be rejected with a clear error
+// listing the accepted values.
+func TestRecordInteraction_RejectsUnknownActivityType(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "GARBAGE",
+		"success":               true,
+		"response_time_seconds": 5.0,
+		"confidence":            0.8,
+		"notes":                 "",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for activity_type=GARBAGE, got %q", resultText(res))
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "activity_type") {
+		t.Fatalf("expected error to mention 'activity_type', got %q", msg)
+	}
+	if !strings.Contains(msg, "must be one of") {
+		t.Fatalf("expected error to list accepted values via 'must be one of', got %q", msg)
+	}
+	// Spot-check a few canonical values are mentioned.
+	if !strings.Contains(msg, "RECALL_EXERCISE") || !strings.Contains(msg, "NEW_CONCEPT") {
+		t.Fatalf("expected error to list canonical activity types, got %q", msg)
+	}
+
+	// And nothing should have been persisted.
+	recents, _ := store.GetRecentInteractionsByLearner("L_owner", 5)
+	if len(recents) != 0 {
+		t.Fatalf("expected no interactions persisted on bad activity_type, got %d", len(recents))
+	}
+}
+
+// Issue #88: error_type is also a free-form string today and must be
+// constrained to the BKT heuristic's vocabulary (SYNTAX_ERROR, LOGIC_ERROR,
+// KNOWLEDGE_GAP). The empty value remains allowed (omitted).
+func TestRecordInteraction_RejectsUnknownErrorType(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               false,
+		"response_time_seconds": 10.0,
+		"confidence":            0.4,
+		"error_type":            "GARBAGE",
+		"notes":                 "",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for error_type=GARBAGE, got %q", resultText(res))
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "error_type") {
+		t.Fatalf("expected error to mention 'error_type', got %q", msg)
+	}
+	if !strings.Contains(msg, "must be one of") {
+		t.Fatalf("expected error to list accepted values via 'must be one of', got %q", msg)
+	}
+	if !strings.Contains(msg, "SYNTAX_ERROR") || !strings.Contains(msg, "KNOWLEDGE_GAP") {
+		t.Fatalf("expected error to list canonical error types, got %q", msg)
+	}
+
+	// And nothing should have been persisted.
+	recents, _ := store.GetRecentInteractionsByLearner("L_owner", 5)
+	if len(recents) != 0 {
+		t.Fatalf("expected no interactions persisted on bad error_type, got %d", len(recents))
+	}
+}
+
+// Issue #88: error_type is optional — empty string must be allowed (omitted).
+func TestRecordInteraction_AllowsEmptyErrorType(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+
+	res := callTool(t, deps, registerRecordInteraction, "L_owner", "record_interaction", map[string]any{
+		"concept":               "a",
+		"activity_type":         "RECALL_EXERCISE",
+		"success":               false,
+		"response_time_seconds": 10.0,
+		"confidence":            0.4,
+		"error_type":            "", // explicitly empty — must pass
+		"notes":                 "",
+	})
+	if res.IsError {
+		t.Fatalf("expected empty error_type to pass, got %q", resultText(res))
+	}
+}
+
 func TestComputeCognitiveSignals(t *testing.T) {
 	// Less than 3 interactions → no signals.
 	fatigue, frust := computeCognitiveSignals([]*models.Interaction{

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -6,6 +6,7 @@ package tools
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"tutor-mcp/models"
 )
@@ -115,4 +116,48 @@ func validateString(field, value string, max int) error {
 		return fmt.Errorf("%s exceeds max length: got %d bytes, max %d", field, len(value), max)
 	}
 	return nil
+}
+
+// validateEnum rejects values that are not in the allowed set. The error
+// names the field, the offending value, and the full accepted vocabulary
+// so the calling LLM can self-correct without a round-trip to the docs.
+// Used for record_interaction.activity_type and error_type (issue #88) where
+// a free-form string forces the LLM to guess from prose hints in the schema
+// description, leading to silent persistence of typos like "RECALL" instead
+// of "RECALL_EXERCISE" — those rows then escape downstream filters that key
+// off the canonical vocabulary.
+func validateEnum(field, value string, allowed []string) error {
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s must be one of: %s (got %q)", field, strings.Join(allowed, ", "), value)
+}
+
+// allowedActivityTypes is the canonical set persisted in interactions.activity_type
+// and consumed by engine/* (motivation, metacognition, action_selector). Sourced
+// from models.ActivityType constants — keep in sync if a new ActivityType is added.
+var allowedActivityTypes = []string{
+	string(models.ActivityRecall),           // RECALL_EXERCISE
+	string(models.ActivityNewConcept),       // NEW_CONCEPT
+	string(models.ActivityMasteryChallenge), // MASTERY_CHALLENGE
+	string(models.ActivityDebuggingCase),    // DEBUGGING_CASE
+	string(models.ActivityRest),             // REST
+	string(models.ActivitySetupDomain),      // SETUP_DOMAIN
+	string(models.ActivityPractice),         // PRACTICE
+	string(models.ActivityDebugMisconception),
+	string(models.ActivityFeynmanPrompt),  // FEYNMAN_PROMPT
+	string(models.ActivityTransferProbe),  // TRANSFER_PROBE
+	string(models.ActivityCloseSession),   // CLOSE_SESSION
+}
+
+// allowedErrorTypes is the vocabulary the BKT heuristic
+// (algorithms.BKTUpdateHeuristicSlipByErrorType) branches on. Anything else
+// is silently treated as standard BKT, so accepting arbitrary labels causes
+// audit-trail noise and breaks alert.go's errorTypeCounts aggregation.
+var allowedErrorTypes = []string{
+	"SYNTAX_ERROR",
+	"LOGIC_ERROR",
+	"KNOWLEDGE_GAP",
 }


### PR DESCRIPTION
Fixes #88

## Rationale

`record_interaction.activity_type` and `error_type` were free-form `string` parameters whose only contract lived in a prose schema description ("RECALL_EXERCISE, NEW_CONCEPT, etc."). The LLM had to guess from that prose, and typos like `"RECALL"` silently leaked into the audit row, escaped downstream filters, degraded the BKT slip-by-error-type heuristic, and broke `alert.go`'s `errorTypeCounts` aggregation. This PR introduces a `validateEnum` helper plus canonical vocabularies (sourced from `models.ActivityType` constants for activity_type, and from the BKT heuristic's branch labels for error_type) and wires them into the handler after auth/length checks. Empty `error_type` still passes (the field remains optional, governed by `omitempty`).

## Accepted enum values

- `activity_type` (required): `RECALL_EXERCISE`, `NEW_CONCEPT`, `MASTERY_CHALLENGE`, `DEBUGGING_CASE`, `REST`, `SETUP_DOMAIN`, `PRACTICE`, `DEBUG_MISCONCEPTION`, `FEYNMAN_PROMPT`, `TRANSFER_PROBE`, `CLOSE_SESSION`
- `error_type` (optional, empty allowed): `SYNTAX_ERROR`, `LOGIC_ERROR`, `KNOWLEDGE_GAP`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `TestRecordInteraction_RejectsUnknownActivityType` rejects `"GARBAGE"` with `must be one of: ...`
- [x] `TestRecordInteraction_RejectsUnknownErrorType` rejects `"GARBAGE"` (with `success=false`)
- [x] `TestRecordInteraction_AllowsEmptyErrorType` keeps the optional-empty path working
- [x] `go test ./...` all packages green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_