### PR TITLE
fix(engine): filter selectMaintenance candidates by active domain graph

### DIFF
--- a/engine/concept_selector.go
+++ b/engine/concept_selector.go
@@ -80,7 +80,7 @@ func SelectConcept(
 	case models.PhaseInstruction:
 		return selectInstruction(states, graph, goalRelevance), nil
 	case models.PhaseMaintenance:
-		return selectMaintenance(states, goalRelevance), nil
+		return selectMaintenance(states, graph, goalRelevance), nil
 	case models.PhaseDiagnostic:
 		return selectDiagnostic(states), nil
 	default:
@@ -239,14 +239,36 @@ func selectInstruction(
 // CardState=="new" get urgency=0 — they are mastered by BKT but
 // have no FSRS history yet.
 //
+// Candidates are restricted to concepts present in the active
+// domain's graph (issue #93). `states` is loaded per learner
+// (cross-domain), so without this filter a concept mastered in
+// another domain could be returned as a MAINTENANCE candidate for
+// the active domain — particularly when goal_relevance is nil and
+// urgency alone drives selection. An empty graph.Concepts disables
+// the filter (preserves existing call sites that pass
+// models.KnowledgeSpace{} in unit tests).
+//
 // v2 note: the dervative form "elapsed_days/stability" would be more
 // sensitive near the decay knee; revisit if eval shows MAINTENANCE
 // missing fast-forgetting concepts.
 func selectMaintenance(
 	states []*models.ConceptState,
+	graph models.KnowledgeSpace,
 	goalRelevance map[string]float64,
 ) Selection {
 	bktThreshold := algorithms.MasteryBKT()
+
+	// Build the active-domain concept set from graph.Concepts. An
+	// empty set is treated as "no filter" so existing unit tests
+	// that pass models.KnowledgeSpace{} keep working; the
+	// orchestrator always passes a non-empty filtered graph.
+	var domainSet map[string]bool
+	if len(graph.Concepts) > 0 {
+		domainSet = make(map[string]bool, len(graph.Concepts))
+		for _, c := range graph.Concepts {
+			domainSet[c] = true
+		}
+	}
 
 	// Collect mastered concepts; sort alphabetically for deterministic
 	// tie-break.
@@ -259,6 +281,11 @@ func selectMaintenance(
 			continue
 		}
 		if cs.PMastery < bktThreshold {
+			continue
+		}
+		if domainSet != nil && !domainSet[cs.Concept] {
+			// Concept mastered in a different domain — not eligible
+			// for the active domain's MAINTENANCE pool (#93).
 			continue
 		}
 		mastered = append(mastered, cs)

--- a/engine/concept_selector_test.go
+++ b/engine/concept_selector_test.go
@@ -350,6 +350,63 @@ func TestSelectConcept_Maintenance_TieBreakAlphabetical(t *testing.T) {
 	}
 }
 
+// Issue #93: selectMaintenance must restrict candidates to concepts present
+// in the active domain's graph. ConceptState rows are loaded per learner
+// (cross-domain in storage), so a concept mastered in another domain (e.g.
+// "x" in D1) must NOT surface as a MAINTENANCE candidate when the active
+// domain is D2 (concepts {a, b}). With goal_relevance=nil this regression
+// would silently pick "x" because urgency alone treats all mastered
+// states equally.
+func TestSelectConcept_Maintenance_FiltersByActiveDomainGraph_Issue93(t *testing.T) {
+	// "x" belongs to a different domain (D1). It is mastered AND highly
+	// urgent (low stability, high elapsed) so without the domain filter it
+	// would dominate the active-domain selection.
+	csX := reviewedCS("x", 0.95)
+	csX.Stability = 1
+	csX.ElapsedDays = 100 // very high urgency
+
+	// "a" is the only legitimate candidate (present in active D2 graph).
+	csA := reviewedCS("a", 0.95)
+	csA.Stability = 30
+	csA.ElapsedDays = 1 // modest urgency
+
+	// "b" is in the active domain but not yet mastered.
+	csB := reviewedCS("b", 0.30)
+
+	activeGraph := graphFlat("a", "b") // active domain = D2
+	sel, err := SelectConcept(models.PhaseMaintenance,
+		[]*models.ConceptState{csX, csA, csB}, activeGraph, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sel.NoFringe {
+		t.Fatalf("expected a maintenance pick from active domain, got NoFringe")
+	}
+	if sel.Concept == "x" {
+		t.Fatalf("issue #93 regressed: cross-domain concept %q selected; expected only active-domain concepts", sel.Concept)
+	}
+	if sel.Concept != "a" {
+		t.Fatalf("expected 'a' (only mastered active-domain concept), got %q", sel.Concept)
+	}
+}
+
+// Issue #93: when every mastered concept belongs to another domain, the
+// active domain has nothing to maintain → NoFringe (not a wrong pick).
+func TestSelectConcept_Maintenance_AllMasteredFromOtherDomain_NoFringe_Issue93(t *testing.T) {
+	csX := reviewedCS("x", 0.95)       // D1
+	csY := reviewedCS("y", 0.95)       // D1
+	activeGraph := graphFlat("a", "b") // D2
+
+	sel, err := SelectConcept(models.PhaseMaintenance,
+		[]*models.ConceptState{csX, csY}, activeGraph, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sel.NoFringe {
+		t.Fatalf("expected NoFringe when no mastered concept is in active domain, got %+v", sel)
+	}
+}
+
 // ─── DIAGNOSTIC ────────────────────────────────────────────────────────────
 
 func TestSelectConcept_Diagnostic_PicksMaxInfoGain(t *testing.T) {


### PR DESCRIPTION
Fixes #93

## Rationale

`selectMaintenance` previously consumed the learner-wide `ConceptState` slice without checking domain membership. `ConceptState` rows are stored per learner (cross-domain), so a concept mastered in another domain could surface as a MAINTENANCE candidate for the active domain — particularly when `goal_relevance` is `nil` and urgency alone drives selection. The fix builds a `domainSet` from the active `graph.Concepts` and skips mastered states whose concept is absent. An empty `graph.Concepts` is treated as "no filter" to preserve existing unit-test call sites that pass `models.KnowledgeSpace{}`; the orchestrator always supplies a non-empty graph for the active domain.

## Test plan
- [x] New regression test `TestSelectConcept_Maintenance_FiltersByActiveDomainGraph_Issue93`: verified it FAILS on staging (cross-domain "x" selected) and PASSES with the fix (only "a" eligible).
- [x] New regression test `TestSelectConcept_Maintenance_AllMasteredFromOtherDomain_NoFringe_Issue93`: confirms `NoFringe` when every mastered concept belongs to another domain.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [x] Pre-existing MAINTENANCE tests still pass (empty `KnowledgeSpace{}` disables the filter as documented).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_