### PR TITLE
fix(tools): cap unbounded string fields in remaining handlers

### DIFF
--- a/tools/calibration.go
+++ b/tools/calibration.go
@@ -38,6 +38,25 @@ func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// String length caps (issue #82). concept_id is persisted into
+		// calibration_records and echoed into prompt_text; domain_id is
+		// resolved against the learner's domains. Without these guards a
+		// misbehaving caller could push multi-MB strings into either path.
+		stringFields := []struct {
+			name  string
+			value string
+			max   int
+		}{
+			{"concept_id", params.ConceptID, maxShortLabelLen},
+			{"domain_id", params.DomainID, maxShortLabelLen},
+		}
+		for _, f := range stringFields {
+			if err := validateString(f.name, f.value, f.max); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+		}
+
 		// 1-5 Likert self-assessment. Reject NaN/Inf and out-of-range values
 		// rather than silently clamping — clamping a hallucinated 100.0 to
 		// 1.0 would corrupt the calibration record. See issue #25.

--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -35,6 +35,15 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// String length cap (issue #82). concept_id is echoed into the
+		// generated prompt_text via fmt.Sprintf and used to look up state;
+		// without this guard a misbehaving caller could push multi-MB
+		// strings into orchestrator output.
+		if err := validateString("concept_id", params.ConceptID, maxShortLabelLen); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
 		cs, err := deps.Store.GetConceptState(learnerID, params.ConceptID)
 		if err != nil {
 			deps.Logger.Error("feynman_challenge: failed to get concept state", "err", err, "learner", learnerID)

--- a/tools/length_validation_test.go
+++ b/tools/length_validation_test.go
@@ -83,3 +83,183 @@ func TestValidateString_PureBoundary(t *testing.T) {
 		t.Errorf("empty must always pass, got %v", err)
 	}
 }
+
+// Issue #82 reproducers: cycle-2 string length caps for the remaining
+// chat-side tools that take user-controlled free-text fields persisted to
+// SQLite. Each sub-test posts a payload that exceeds the field's cap and
+// expects an errorResult.
+
+func TestRecordSessionClose_RejectsOversizedIntention(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string // key inside implementation_intention
+		value string
+	}{
+		{"trigger", "trigger", strings.Repeat("t", maxNoteLen+1)},
+		{"action", "action", strings.Repeat("a", maxNoteLen+1)},
+		{"scheduled_for", "scheduled_for", strings.Repeat("s", maxShortLabelLen+1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, deps := setupToolsTest(t)
+			_ = makeOwnerDomain(t, store, "L_owner", "math")
+			intention := map[string]any{
+				"trigger": "demain matin",
+				"action":  "fais un exo",
+			}
+			intention[tc.field] = tc.value
+			res := callTool(t, deps, registerRecordSessionClose, "L_owner", "record_session_close", map[string]any{
+				"implementation_intention": intention,
+			})
+			if !res.IsError {
+				t.Fatalf("expected length-cap rejection on %s, got %q", tc.field, resultText(res))
+			}
+		})
+	}
+}
+
+func TestTransferChallenge_RejectsOversizedFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			"concept_id",
+			map[string]any{"concept_id": strings.Repeat("c", maxShortLabelLen+1)},
+		},
+		{
+			"context_type",
+			map[string]any{"concept_id": "a", "context_type": strings.Repeat("x", maxShortLabelLen+1)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, deps := setupToolsTest(t)
+			_ = makeOwnerDomain(t, store, "L_owner", "math")
+			res := callTool(t, deps, registerTransferChallenge, "L_owner", "transfer_challenge", tc.args)
+			if !res.IsError {
+				t.Fatalf("expected length-cap rejection, got %q", resultText(res))
+			}
+		})
+	}
+}
+
+func TestRecordTransferResult_RejectsOversizedFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			"concept_id",
+			map[string]any{
+				"concept_id":   strings.Repeat("c", maxShortLabelLen+1),
+				"context_type": "real_world",
+				"score":        0.5,
+			},
+		},
+		{
+			"context_type",
+			map[string]any{
+				"concept_id":   "a",
+				"context_type": strings.Repeat("x", maxShortLabelLen+1),
+				"score":        0.5,
+			},
+		},
+		{
+			"session_id",
+			map[string]any{
+				"concept_id":   "a",
+				"context_type": "real_world",
+				"session_id":   strings.Repeat("s", maxShortLabelLen+1),
+				"score":        0.5,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, deps := setupToolsTest(t)
+			res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", tc.args)
+			if !res.IsError {
+				t.Fatalf("expected length-cap rejection, got %q", resultText(res))
+			}
+		})
+	}
+}
+
+func TestFeynmanChallenge_RejectsOversizedConceptID(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	_ = makeOwnerDomain(t, store, "L_owner", "math")
+	res := callTool(t, deps, registerFeynmanChallenge, "L_owner", "feynman_challenge", map[string]any{
+		"concept_id": strings.Repeat("c", maxShortLabelLen+1),
+	})
+	if !res.IsError {
+		t.Fatalf("expected length-cap rejection, got %q", resultText(res))
+	}
+}
+
+func TestCalibrationCheck_RejectsOversizedFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			"concept_id",
+			map[string]any{
+				"concept_id":        strings.Repeat("c", maxShortLabelLen+1),
+				"predicted_mastery": 3.0,
+			},
+		},
+		{
+			"domain_id",
+			map[string]any{
+				"concept_id":        "a",
+				"predicted_mastery": 3.0,
+				"domain_id":         strings.Repeat("d", maxShortLabelLen+1),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, deps := setupToolsTest(t)
+			res := callTool(t, deps, registerCalibrationCheck, "L_owner", "calibration_check", tc.args)
+			if !res.IsError {
+				t.Fatalf("expected length-cap rejection, got %q", resultText(res))
+			}
+		})
+	}
+}
+
+func TestLearningNegotiation_RejectsOversizedFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			"session_id",
+			map[string]any{"session_id": strings.Repeat("s", maxShortLabelLen+1)},
+		},
+		{
+			"learner_concept",
+			map[string]any{
+				"session_id":      "sess1",
+				"learner_concept": strings.Repeat("c", maxShortLabelLen+1),
+			},
+		},
+		{
+			"learner_rationale",
+			map[string]any{
+				"session_id":        "sess1",
+				"learner_rationale": strings.Repeat("r", maxNoteLen+1),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, deps := setupToolsTest(t)
+			res := callTool(t, deps, registerLearningNegotiation, "L_owner", "learning_negotiation", tc.args)
+			if !res.IsError {
+				t.Fatalf("expected length-cap rejection, got %q", resultText(res))
+			}
+		})
+	}
+}

--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -42,6 +42,27 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// String length caps (issue #82). All three fields are echoed back
+		// into the JSON response (tradeoffs, accepted_plan.rationale) and
+		// learner_rationale ends up in the orchestrator-bound
+		// acceptedPlan.Rationale string. Without these guards a misbehaving
+		// caller could push multi-MB strings into orchestrator output.
+		stringFields := []struct {
+			name  string
+			value string
+			max   int
+		}{
+			{"session_id", params.SessionID, maxShortLabelLen},
+			{"learner_concept", params.LearnerConcept, maxShortLabelLen},
+			{"learner_rationale", params.LearnerRationale, maxNoteLen},
+		}
+		for _, f := range stringFields {
+			if err := validateString(f.name, f.value, f.max); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+		}
+
 		domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
 		if err != nil || domain == nil {
 			if params.DomainID != "" {

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -53,6 +53,26 @@ func registerRecordSessionClose(server *mcp.Server, deps *Deps) {
 		if params.ImplementationIntention != nil &&
 			params.ImplementationIntention.Trigger != "" &&
 			params.ImplementationIntention.Action != "" {
+			// String length caps (issue #82). Trigger / Action are user-authored
+			// if-then sentences that flow straight into implementation_intentions
+			// rows; without these guards a misbehaving caller could push multi-MB
+			// strings into the table. ScheduledFor is an ISO 8601 stamp — capped
+			// at maxShortLabelLen to bound parser cost.
+			stringFields := []struct {
+				name  string
+				value string
+				max   int
+			}{
+				{"implementation_intention.trigger", params.ImplementationIntention.Trigger, maxNoteLen},
+				{"implementation_intention.action", params.ImplementationIntention.Action, maxNoteLen},
+				{"implementation_intention.scheduled_for", params.ImplementationIntention.ScheduledFor, maxShortLabelLen},
+			}
+			for _, f := range stringFields {
+				if err := validateString(f.name, f.value, f.max); err != nil {
+					r, _ := errorResult(err.Error())
+					return r, nil, nil
+				}
+			}
 			var scheduled time.Time
 			if params.ImplementationIntention.ScheduledFor != "" {
 				if parsed, perr := time.Parse(time.RFC3339, params.ImplementationIntention.ScheduledFor); perr == nil {

--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -37,6 +37,26 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
+		// String length caps (issue #82). concept_id flows into the
+		// transfer_records query / response and context_type ends up in the
+		// persisted row label — without these guards a misbehaving caller
+		// could push multi-MB strings into the read path and bloat downstream
+		// telemetry.
+		stringFields := []struct {
+			name  string
+			value string
+			max   int
+		}{
+			{"concept_id", params.ConceptID, maxShortLabelLen},
+			{"context_type", params.ContextType, maxShortLabelLen},
+		}
+		for _, f := range stringFields {
+			if err := validateString(f.name, f.value, f.max); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+		}
+
 		cs, err := deps.Store.GetConceptState(learnerID, params.ConceptID)
 		if err != nil {
 			deps.Logger.Error("transfer_challenge: failed to get concept state", "err", err, "learner", learnerID)
@@ -105,6 +125,25 @@ func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
 			deps.Logger.Error("record_transfer_result: auth failed", "err", err)
 			r, _ := errorResult(err.Error())
 			return r, nil, nil
+		}
+
+		// String length caps (issue #82). concept_id, context_type and
+		// session_id end up in transfer_records rows; without these guards a
+		// misbehaving caller could push multi-MB strings into the table.
+		stringFields := []struct {
+			name  string
+			value string
+			max   int
+		}{
+			{"concept_id", params.ConceptID, maxShortLabelLen},
+			{"context_type", params.ContextType, maxShortLabelLen},
+			{"session_id", params.SessionID, maxShortLabelLen},
+		}
+		for _, f := range stringFields {
+			if err := validateString(f.name, f.value, f.max); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
 		}
 
 		// Score is a unit-interval transfer rating. Reject NaN/Inf and any


### PR DESCRIPTION
Fixes #82

## Rationale

Issue #31 introduced `validateString` with `maxShortLabelLen=200` / `maxNoteLen=4096` and applied it to `record_interaction`, `record_affect` and `update_learner_profile`. The QA-security audit (#82) identified five other registered tools that take chat-side free-text fields persisted to SQLite (or echoed into orchestrator output) without any length validation. A misbehaving LLM (or authenticated learner) could post multi-MB strings on those endpoints and bloat / corrupt the database the same way #31 originally feared. This PR reuses the existing `stringFields` table pattern from `tools/interaction.go` on every gap.

## Handlers patched

- `record_session_close`: `implementation_intention.trigger` / `action` at `maxNoteLen`, `scheduled_for` at `maxShortLabelLen`
- `transfer_challenge`: `concept_id`, `context_type` at `maxShortLabelLen`
- `record_transfer_result`: `concept_id`, `context_type`, `session_id` at `maxShortLabelLen`
- `feynman_challenge`: `concept_id` at `maxShortLabelLen`
- `calibration_check`: `concept_id`, `domain_id` at `maxShortLabelLen`
- `learning_negotiation`: `session_id`, `learner_concept` at `maxShortLabelLen`, `learner_rationale` at `maxNoteLen`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages green
- [x] New parameterised sub-tests in `tools/length_validation_test.go` (one per affected handler) post `cap+1`-byte payloads and assert `IsError`
- [x] Existing length-validation tests still pass (regression)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_