### PR TITLE
chore(tools): disambiguate routing descriptions for read tools

### DIFF
--- a/tools/activity.go
+++ b/tools/activity.go
@@ -16,13 +16,17 @@ import (
 )
 
 type GetNextActivityParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine cible ; si absent, le dernier domaine actif de l'apprenant est utilisé"`
 }
 
 func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_next_activity",
-		Description: "Détermine la prochaine activité optimale pour l'apprenant selon son état cognitif. Tient compte de la session en cours pour éviter de répéter le même concept.",
+		Name: "get_next_activity",
+		Description: "Détermine la prochaine activité optimale pour l'apprenant et agrège tout le contexte de routage nécessaire : miroir métacognitif, mode tuteur, brief de motivation, misconceptions actives. Tient compte de la session en cours pour éviter de répéter le même concept. " +
+			"Quand appeler : APRÈS get_pending_alerts, dès qu'aucune alerte critique ne bloque la suite et que l'apprenant a un domaine actif. C'est l'outil principal du cycle d'apprentissage. " +
+			"Quand NE PAS appeler : si get_pending_alerts a renvoyé needs_domain_setup=true (appelez init_domain d'abord) ; n'appelez pas get_metacognitive_mirror dans le même tour, le miroir est déjà inclus dans la clé metacognitive_mirror du retour. " +
+			"Précondition : un domaine doit exister ; sinon needs_domain_setup=true est renvoyé avec une activité de type setup_domain. " +
+			"Retour : {needs_domain_setup, domain_id, activity, session_concepts_done, metacognitive_mirror, tutor_mode, active_misconceptions, known_misconception_types, motivation_brief}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetNextActivityParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -14,13 +14,17 @@ import (
 )
 
 type GetPendingAlertsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine pour cibler les alertes activité ; si absent, agrège sur tous les domaines actifs de l'apprenant"`
 }
 
 func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_pending_alerts",
-		Description: "Récupère les alertes en attente pour l'apprenant. Appeler en premier à chaque réponse.",
+		Name: "get_pending_alerts",
+		Description: "Récupère TOUTES les alertes en attente pour l'apprenant — alertes d'activité (PLATEAU, FATIGUE, …) ET alertes métacognitives (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE, TRANSFER_BLOCKED). " +
+			"Quand appeler : EN PREMIER à chaque tour, avant tout autre outil de lecture. Si une alerte critique remonte (has_critical=true), la traiter avant de poursuivre. " +
+			"Quand NE PAS appeler : une seule fois par tour suffit ; les alertes métacognitives sont déjà incluses ici, n'appelez pas un outil séparé pour les obtenir. " +
+			"Précondition : si l'apprenant n'a aucun domaine actif, retourne needs_domain_setup=true et une liste alerts vide — appelez init_domain avant de continuer. " +
+			"Retour : {alerts: [...], has_critical: bool, needs_domain_setup: bool}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetPendingAlertsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/mirror.go
+++ b/tools/mirror.go
@@ -14,13 +14,17 @@ import (
 )
 
 type GetMetacognitiveMirrorParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine de contexte (optionnel) ; le miroir est calculé au niveau apprenant et n'est pas filtré par domaine"`
 }
 
 func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_metacognitive_mirror",
-		Description: "Retourne un message miroir factuel si un pattern de dépendance est consolidé. Null sinon.",
+		Name: "get_metacognitive_mirror",
+		Description: "Retourne un message miroir factuel si un pattern de dépendance est consolidé sur les 7 derniers jours, sinon mirror=null. Outil de réflexion métacognitive à la demande. " +
+			"Quand appeler : UNIQUEMENT hors du cycle d'activité — par exemple lors d'une demande explicite de bilan métacognitif, ou si l'apprenant interroge ses propres patterns d'apprentissage. " +
+			"Quand NE PAS appeler : si get_next_activity a déjà été appelé dans le même tour, le miroir est déjà présent dans sa clé metacognitive_mirror — un second appel ici fait du travail dupliqué (même calcul, même file webhook dédupliquée par jour). " +
+			"Précondition : aucune ; si aucun pattern n'est détecté, mirror=null est renvoyé sans erreur. " +
+			"Retour : {mirror: <objet ou null>}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMetacognitiveMirrorParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {


### PR DESCRIPTION
Fixes #84

## Rationale

The three read tools `get_pending_alerts`, `get_next_activity`, and `get_metacognitive_mirror` had short, overlapping descriptions that did not tell the LLM when to call each one, when to skip, or what shape was returned. In particular the metacognitive mirror is computed inline by `get_next_activity` (and exposed under the `metacognitive_mirror` key of its return), so a model that called both within the same turn was duplicating work (same calculation, same webhook queue dedup-by-day). This PR rewrites each `Description` and the corresponding parameter `jsonschema` tag to:

- state what the tool returns in one sentence,
- give explicit "Quand appeler" / "Quand NE PAS appeler" bullets,
- name the precondition (e.g. `init_domain` when no active domain),
- and list the return shape keys.

Wording-only change, kept in French per the project's language conventions. No tool behaviour, parameters, or return shapes were touched.

## Test plan

- [x] `go build ./...` green.
- [x] `go vet ./...` green.
- [x] `go test ./tools/` green (after stashing unrelated sibling-implementer changes in the shared worktree); the diacritic linter (`TestToolDescriptions_NoStrippedFrenchDiacritics`, `TestToolStringLiterals_NoStrippedFrenchDiacritics`) passes against the new wording.
- [x] No new tests added — locking exact wording in tests would be premature for a documentation-style change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_