### PR TITLE
fix(tools): validate concept_id and context_type in record_transfer_result

### DIFF
--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -90,9 +90,19 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 
 type RecordTransferResultParams struct {
 	ConceptID   string  `json:"concept_id" jsonschema:"Le concept testé"`
-	ContextType string  `json:"context_type" jsonschema:"Type de contexte du challenge"`
+	ContextType string  `json:"context_type" jsonschema:"Type de contexte du challenge: real_world, interview, teaching, debugging, creative"`
 	Score       float64 `json:"score" jsonschema:"Score de transfert entre 0 et 1"`
 	SessionID   string  `json:"session_id,omitempty" jsonschema:"ID de session (optionnel)"`
+	DomainID    string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+}
+
+// allowedRecordTransferContextTypes enumerates the documented context_type
+// values for record_transfer_result. Issue #96: a free-string ContextType
+// allowed orphan transfer rows ("banana", "") to pollute TRANSFER_BLOCKED
+// alerts. Kept inline here (rather than in tools/validate.go) to avoid a
+// merge conflict with the cycle-2 sibling PR that introduces validateEnum.
+var allowedRecordTransferContextTypes = []string{
+	"real_world", "interview", "teaching", "debugging", "creative",
 }
 
 func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
@@ -111,6 +121,44 @@ func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
 		// value outside [0, 1] to keep transfer_score reports & the
 		// blocked < 0.50 gate meaningful (issue #25).
 		if err := validateUnitInterval("score", params.Score); err != nil {
+			r, _ := errorResult(err.Error())
+			return r, nil, nil
+		}
+
+		// Enum guard for context_type. Without this, hallucinated labels
+		// ("banana", "") flowed into the transfer_records table and
+		// poisoned downstream TRANSFER_BLOCKED alerts (issue #96).
+		ctOK := false
+		for _, v := range allowedRecordTransferContextTypes {
+			if params.ContextType == v {
+				ctOK = true
+				break
+			}
+		}
+		if !ctOK {
+			r, _ := errorResult(fmt.Sprintf(
+				"context_type %q is invalid: must be one of: real_world, interview, teaching, debugging, creative",
+				params.ContextType,
+			))
+			return r, nil, nil
+		}
+
+		// Resolve the active domain (honoring the optional domain_id) and
+		// validate the concept against its concept list. Without this guard
+		// the tool silently inserts orphan transfer rows for hallucinated
+		// or stale concept names — see issue #96.
+		domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
+		if err != nil || domain == nil {
+			if params.DomainID != "" {
+				deps.Logger.Error("record_transfer_result: domain not found by id", "err", err, "learner", learnerID, "domain_id", params.DomainID)
+				r, _ := errorResult("domain not found")
+				return r, nil, nil
+			}
+			deps.Logger.Info("record_transfer_result: no active domain — needs setup", "learner", learnerID)
+			r, _ := noActiveDomainResult()
+			return r, nil, nil
+		}
+		if err := validateConceptInDomain(domain, params.ConceptID); err != nil {
 			r, _ := errorResult(err.Error())
 			return r, nil, nil
 		}

--- a/tools/transfer_test.go
+++ b/tools/transfer_test.go
@@ -102,8 +102,11 @@ func TestRecordTransferResult_NoAuth(t *testing.T) {
 
 func TestRecordTransferResult_HappyPath(t *testing.T) {
 	store, deps := setupToolsTest(t)
+	// makeOwnerDomain creates a domain with concepts ["a","b"]; the
+	// transfer concept must be in the active domain (issue #96).
+	makeOwnerDomain(t, store, "L_owner", "math")
 	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
-		"concept_id":   "calc",
+		"concept_id":   "a",
 		"context_type": "real_world",
 		"score":        0.7,
 		"session_id":   "s1",
@@ -123,7 +126,7 @@ func TestRecordTransferResult_HappyPath(t *testing.T) {
 	}
 
 	// DB state — record persisted.
-	scores, err := store.GetTransferScores("L_owner", "calc")
+	scores, err := store.GetTransferScores("L_owner", "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,8 +137,9 @@ func TestRecordTransferResult_HappyPath(t *testing.T) {
 
 func TestRecordTransferResult_RejectsScoreOutsideUnitInterval(t *testing.T) {
 	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
 	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
-		"concept_id":   "calc",
+		"concept_id":   "a",
 		"context_type": "real_world",
 		"score":        1.5, // legal interval is [0,1]
 	})
@@ -148,7 +152,7 @@ func TestRecordTransferResult_RejectsScoreOutsideUnitInterval(t *testing.T) {
 
 	// Negative also rejected.
 	resNeg := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
-		"concept_id":   "calc",
+		"concept_id":   "a",
 		"context_type": "real_world",
 		"score":        -0.2,
 	})
@@ -157,16 +161,17 @@ func TestRecordTransferResult_RejectsScoreOutsideUnitInterval(t *testing.T) {
 	}
 
 	// Nothing persisted on rejection.
-	scores, _ := store.GetTransferScores("L_owner", "calc")
+	scores, _ := store.GetTransferScores("L_owner", "a")
 	if len(scores) != 0 {
 		t.Fatalf("expected no transfer rows, got %d", len(scores))
 	}
 }
 
 func TestRecordTransferResult_BlockedFlag(t *testing.T) {
-	_, deps := setupToolsTest(t)
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
 	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
-		"concept_id":   "calc",
+		"concept_id":   "a",
 		"context_type": "real_world",
 		"score":        0.3,
 	})
@@ -176,5 +181,123 @@ func TestRecordTransferResult_BlockedFlag(t *testing.T) {
 	out := decodeResult(t, res)
 	if out["blocked"] != true {
 		t.Fatalf("expected blocked=true for low score, got %v", out["blocked"])
+	}
+}
+
+// Issue #96: record_transfer_result must reject concept_id values that are
+// not part of the resolved domain's concept set, mirroring the
+// validateConceptInDomain guard in record_interaction. Without this,
+// orphan transfer rows pollute TRANSFER_BLOCKED alerts downstream.
+func TestRecordTransferResult_RejectsUnknownConcept(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	// Domain has concepts {"a","b"}.
+	makeOwnerDomain(t, store, "L_owner", "math")
+	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
+		"concept_id":   "ghost",
+		"context_type": "real_world",
+		"score":        0.2,
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown concept, got %q", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "ghost") {
+		t.Fatalf("expected error to mention the unknown concept, got %q", resultText(res))
+	}
+
+	// No orphan row should have been persisted.
+	scores, _ := store.GetTransferScores("L_owner", "ghost")
+	if len(scores) != 0 {
+		t.Fatalf("orphan transfer row persisted for unknown concept: %+v", scores)
+	}
+}
+
+// Issue #96: context_type must be one of the documented enum values
+// (real_world, interview, teaching, debugging, creative). A free-string
+// value such as "banana" must be rejected with a clear enum error.
+func TestRecordTransferResult_RejectsUnknownContextType(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
+		"concept_id":   "a",
+		"context_type": "banana",
+		"score":        0.2,
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown context_type, got %q", resultText(res))
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "context_type") {
+		t.Fatalf("expected error to mention 'context_type', got %q", msg)
+	}
+	if !strings.Contains(msg, "real_world") || !strings.Contains(msg, "interview") {
+		t.Fatalf("expected error to enumerate the allowed values, got %q", msg)
+	}
+}
+
+// Issue #96: each of the five documented context_type enum values must be
+// accepted. Table-driven so a future schema drift shows up as a single
+// failing row rather than an opaque enum-mismatch.
+func TestRecordTransferResult_AllowsKnownContextTypes(t *testing.T) {
+	for _, ct := range []string{"real_world", "interview", "teaching", "debugging", "creative"} {
+		ct := ct
+		t.Run(ct, func(t *testing.T) {
+			store, deps := setupToolsTest(t)
+			makeOwnerDomain(t, store, "L_owner", "math")
+			res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
+				"concept_id":   "a",
+				"context_type": ct,
+				"score":        0.6,
+			})
+			if res.IsError {
+				t.Fatalf("context_type=%q rejected unexpectedly: %q", ct, resultText(res))
+			}
+			out := decodeResult(t, res)
+			if out["recorded"] != true {
+				t.Fatalf("context_type=%q: expected recorded=true, got %v", ct, out)
+			}
+			scores, _ := store.GetTransferScores("L_owner", "a")
+			if len(scores) != 1 {
+				t.Fatalf("context_type=%q: expected 1 transfer row, got %d", ct, len(scores))
+			}
+		})
+	}
+}
+
+// Issue #96: an explicit domain_id pointing at someone else's domain must
+// be rejected — concept membership runs against the resolved domain, and
+// a foreign domain has no overlap with the learner's concept set.
+func TestRecordTransferResult_DomainIDRejectsForeignDomain(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	makeOwnerDomain(t, store, "L_owner", "math")
+	foreign, err := store.CreateDomain("L_other", "shared", "", models.KnowledgeSpace{
+		Concepts: []string{"a"},
+	})
+	if err != nil {
+		t.Fatalf("create foreign domain: %v", err)
+	}
+
+	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
+		"concept_id":   "a",
+		"domain_id":    foreign.ID,
+		"context_type": "real_world",
+		"score":        0.5,
+	})
+	if !res.IsError {
+		t.Fatalf("expected error on foreign domain_id, got %q", resultText(res))
+	}
+}
+
+// Issue #96: when no domain has been initialised the tool must emit the
+// canonical needs_domain_setup payload (mirrors record_interaction).
+func TestRecordTransferResult_NoActiveDomain(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerRecordTransferResult, "L_owner", "record_transfer_result", map[string]any{
+		"concept_id":   "a",
+		"context_type": "real_world",
+		"score":        0.5,
+	})
+	out := decodeResult(t, res)
+	if got, _ := out["needs_domain_setup"].(bool); !got {
+		t.Fatalf("expected needs_domain_setup=true, got %v (raw %q)", out, resultText(res))
 	}
 }


### PR DESCRIPTION
Fixes #96

## Rationale

`record_transfer_result` previously validated only `score ∈ [0,1]`. It did **not** check:

- that `concept_id` belonged to the active domain's concept set, and
- that `context_type` was one of the documented enum values.

As a result, hallucinated concept names ("ghost") or label drift ("banana", "") silently produced orphan rows in `transfer_records`, which then polluted downstream `TRANSFER_BLOCKED` alerts.

## Changes

- Added `DomainID string` to `RecordTransferResultParams` (jsonschema in French, matching `record_interaction`).
- Resolve the active domain via `resolveDomain(deps.Store, learnerID, params.DomainID)`. Empty `domain_id` with no active domain returns the canonical `noActiveDomainResult()`; explicit unknown `domain_id` returns `errorResult("domain not found")` — same shape as `record_interaction`.
- After auth, run `validateConceptInDomain(domain, params.ConceptID)`.
- Reject `context_type` values outside `{real_world, interview, teaching, debugging, creative}` with a clear enum-error message.
- Updated the schema description for `context_type` to include the enum.

## Sibling PR coordination

Cycle-2 sibling PR #101 (open, not merged) introduces a shared `validateEnum` helper plus `allowedActivityTypes`/`allowedErrorTypes` in `tools/validate.go`. To avoid a merge conflict, the enum check here is **inlined** as a small loop over `allowedRecordTransferContextTypes`. Once #101 merges, the inline check can be folded into `validateEnum(allowedRecordTransferContextTypes)`. (Option B per the implementer brief.)

## Test plan

- [x] `TestRecordTransferResult_RejectsUnknownConcept` — concept `"ghost"` against domain `{a,b}` → IsError, no orphan row persisted.
- [x] `TestRecordTransferResult_RejectsUnknownContextType` — `"banana"` → IsError mentioning `context_type` and the allowed list.
- [x] `TestRecordTransferResult_AllowsKnownContextTypes` — table-driven over the five documented values; each persists exactly one row.
- [x] `TestRecordTransferResult_DomainIDRejectsForeignDomain` — explicit `domain_id` for another learner → IsError.
- [x] `TestRecordTransferResult_NoActiveDomain` — no domain, no `domain_id` → `needs_domain_setup:true`.
- [x] Existing happy-path / score-range / blocked-flag tests updated to use `makeOwnerDomain`.
- [x] `go build ./... && go vet ./... && go test ./...` all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qub2QXNtvdLv2XFr8VrpW4)_