### PR TITLE
fix(db): require learner_id in calibration record helpers

### DIFF
--- a/db/metacognition.go
+++ b/db/metacognition.go
@@ -94,10 +94,15 @@ func (s *Store) CreateCalibrationPrediction(r *models.CalibrationRecord) error {
 	return nil
 }
 
-func (s *Store) CompleteCalibrationRecord(predictionID string, actual, delta float64) error {
+// CompleteCalibrationRecord finalises a calibration prediction owned by the
+// supplied learner. The learner_id filter is enforced at the DB layer so that
+// any future caller cannot accidentally reintroduce the IDOR closed by issues
+// #34/#87 — defence-in-depth, mirrors Store.ArchiveDomain.
+func (s *Store) CompleteCalibrationRecord(predictionID, learnerID string, actual, delta float64) error {
 	result, err := s.db.Exec(
-		`UPDATE calibration_records SET actual = ?, delta = ? WHERE prediction_id = ?`,
-		actual, delta, predictionID,
+		`UPDATE calibration_records SET actual = ?, delta = ?
+		 WHERE prediction_id = ? AND learner_id = ?`,
+		actual, delta, predictionID, learnerID,
 	)
 	if err != nil {
 		return fmt.Errorf("complete calibration record: %w", err)
@@ -109,14 +114,22 @@ func (s *Store) CompleteCalibrationRecord(predictionID string, actual, delta flo
 	return nil
 }
 
-func (s *Store) GetCalibrationRecord(predictionID string) (*models.CalibrationRecord, error) {
+// GetCalibrationRecord fetches a calibration prediction scoped to the supplied
+// learner. The learner_id filter is enforced at the DB layer so callers cannot
+// accidentally surface another learner's row — defence-in-depth, mirrors
+// Store.ArchiveDomain.
+func (s *Store) GetCalibrationRecord(predictionID, learnerID string) (*models.CalibrationRecord, error) {
 	r := &models.CalibrationRecord{}
 	var actual, delta sql.NullFloat64
 	err := s.db.QueryRow(
 		`SELECT prediction_id, learner_id, concept_id, predicted, actual, delta, created_at
-		 FROM calibration_records WHERE prediction_id = ?`, predictionID,
+		 FROM calibration_records WHERE prediction_id = ? AND learner_id = ?`,
+		predictionID, learnerID,
 	).Scan(&r.PredictionID, &r.LearnerID, &r.ConceptID, &r.Predicted, &actual, &delta, &r.CreatedAt)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("calibration record not found: %s", predictionID)
+		}
 		return nil, fmt.Errorf("get calibration record: %w", err)
 	}
 	if actual.Valid {

--- a/db/metacognition_test.go
+++ b/db/metacognition_test.go
@@ -167,7 +167,7 @@ func TestCalibrationLifecycle(t *testing.T) {
 		t.Fatalf("create prediction: %v", err)
 	}
 
-	got, err := store.GetCalibrationRecord("P1")
+	got, err := store.GetCalibrationRecord("P1", "L1")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -182,10 +182,10 @@ func TestCalibrationLifecycle(t *testing.T) {
 	}
 
 	// Complete the prediction.
-	if err := store.CompleteCalibrationRecord("P1", 0.8, -0.2); err != nil {
+	if err := store.CompleteCalibrationRecord("P1", "L1", 0.8, -0.2); err != nil {
 		t.Fatalf("complete: %v", err)
 	}
-	got, err = store.GetCalibrationRecord("P1")
+	got, err = store.GetCalibrationRecord("P1", "L1")
 	if err != nil {
 		t.Fatalf("re-get: %v", err)
 	}
@@ -197,13 +197,78 @@ func TestCalibrationLifecycle(t *testing.T) {
 	}
 
 	// Completing missing prediction returns the "not found" error.
-	if err := store.CompleteCalibrationRecord("does-not-exist", 0, 0); err == nil {
+	if err := store.CompleteCalibrationRecord("does-not-exist", "L1", 0, 0); err == nil {
 		t.Fatal("expected error completing missing record")
 	}
 
 	// GetCalibrationRecord on missing prediction also errors.
-	if _, err := store.GetCalibrationRecord("does-not-exist"); err == nil {
+	if _, err := store.GetCalibrationRecord("does-not-exist", "L1"); err == nil {
 		t.Fatal("expected error getting missing record")
+	}
+}
+
+// TestGetCalibrationRecord_FiltersByLearnerID asserts the DB query refuses to
+// return a calibration record when the supplied learner_id does not match the
+// owner — defence-in-depth for issue #87.
+func TestGetCalibrationRecord_FiltersByLearnerID(t *testing.T) {
+	store := setupTestDB(t)
+	rec := &models.CalibrationRecord{
+		PredictionID: "P_owner",
+		LearnerID:    "learner_A",
+		ConceptID:    "C1",
+		Predicted:    0.5,
+	}
+	if err := store.CreateCalibrationPrediction(rec); err != nil {
+		t.Fatalf("create prediction: %v", err)
+	}
+
+	// Fetching with the wrong learner must error with "calibration record not found".
+	if _, err := store.GetCalibrationRecord("P_owner", "learner_B"); err == nil {
+		t.Fatal("expected error when fetching another learner's calibration record")
+	}
+
+	// Sanity: rightful owner still resolves.
+	got, err := store.GetCalibrationRecord("P_owner", "learner_A")
+	if err != nil {
+		t.Fatalf("owner fetch failed: %v", err)
+	}
+	if got.LearnerID != "learner_A" {
+		t.Errorf("LearnerID = %q want learner_A", got.LearnerID)
+	}
+}
+
+// TestCompleteCalibrationRecord_FiltersByLearnerID asserts the UPDATE refuses
+// to mutate a calibration row owned by another learner — defence-in-depth for
+// issue #87.
+func TestCompleteCalibrationRecord_FiltersByLearnerID(t *testing.T) {
+	store := setupTestDB(t)
+	rec := &models.CalibrationRecord{
+		PredictionID: "P_owner",
+		LearnerID:    "learner_A",
+		ConceptID:    "C1",
+		Predicted:    0.5,
+	}
+	if err := store.CreateCalibrationPrediction(rec); err != nil {
+		t.Fatalf("create prediction: %v", err)
+	}
+
+	// Completing as the wrong learner must error "calibration record not found".
+	if err := store.CompleteCalibrationRecord("P_owner", "learner_B", 0.5, 0.0); err == nil {
+		t.Fatal("expected error when completing another learner's calibration record")
+	}
+
+	// And the row must remain unmodified (Actual still nil).
+	got, err := store.GetCalibrationRecord("P_owner", "learner_A")
+	if err != nil {
+		t.Fatalf("owner fetch failed: %v", err)
+	}
+	if got.Actual != nil {
+		t.Errorf("expected Actual nil after rejected foreign update, got %v", *got.Actual)
+	}
+
+	// Sanity: rightful owner still completes.
+	if err := store.CompleteCalibrationRecord("P_owner", "learner_A", 0.7, -0.2); err != nil {
+		t.Fatalf("owner complete failed: %v", err)
 	}
 }
 
@@ -238,7 +303,7 @@ func TestGetCalibrationBiasAndHistory(t *testing.T) {
 		if err := store.CreateCalibrationPrediction(rec); err != nil {
 			t.Fatalf("create: %v", err)
 		}
-		if err := store.CompleteCalibrationRecord(rec.PredictionID, 0.5-d, d); err != nil {
+		if err := store.CompleteCalibrationRecord(rec.PredictionID, "L1", 0.5-d, d); err != nil {
 			t.Fatalf("complete: %v", err)
 		}
 	}

--- a/tools/calibration.go
+++ b/tools/calibration.go
@@ -126,21 +126,18 @@ func registerRecordCalibrationResult(server *mcp.Server, deps *Deps) {
 			return r, nil, nil
 		}
 
-		record, err := deps.Store.GetCalibrationRecord(params.PredictionID)
+		// Ownership is enforced at the DB layer: GetCalibrationRecord returns
+		// "not found" if the prediction belongs to another learner (issue #87).
+		record, err := deps.Store.GetCalibrationRecord(params.PredictionID, learnerID)
 		if err != nil {
 			deps.Logger.Error("record_calibration_result: calibration record not found", "err", err, "learner", learnerID)
 			r, _ := errorResult(fmt.Sprintf("prediction not found: %v", err))
 			return r, nil, nil
 		}
-		if record.LearnerID != learnerID {
-			deps.Logger.Warn("record_calibration_result: learner mismatch", "prediction_id", params.PredictionID, "learner", learnerID, "owner", record.LearnerID)
-			r, _ := errorResult("calibration record not found")
-			return r, nil, nil
-		}
 
 		delta := record.Predicted - params.ActualScore
 
-		if err := deps.Store.CompleteCalibrationRecord(params.PredictionID, params.ActualScore, delta); err != nil {
+		if err := deps.Store.CompleteCalibrationRecord(params.PredictionID, learnerID, params.ActualScore, delta); err != nil {
 			deps.Logger.Error("record_calibration_result: failed to complete calibration record", "err", err, "learner", learnerID)
 			r, _ := errorResult(fmt.Sprintf("failed to record result: %v", err))
 			return r, nil, nil

--- a/tools/calibration_check_test.go
+++ b/tools/calibration_check_test.go
@@ -46,7 +46,7 @@ func TestCalibrationCheck_HappyPath(t *testing.T) {
 		t.Fatalf("expected prediction_id starting with cal_, got %q", pid)
 	}
 
-	rec, err := store.GetCalibrationRecord(pid)
+	rec, err := store.GetCalibrationRecord(pid, "L_owner")
 	if err != nil {
 		t.Fatalf("GetCalibrationRecord: %v", err)
 	}

--- a/tools/calibration_test.go
+++ b/tools/calibration_test.go
@@ -117,7 +117,7 @@ func TestRecordCalibrationResult_OwnerAllowed(t *testing.T) {
 	}
 
 	// Verify the record was actually updated.
-	saved, err := store.GetCalibrationRecord("cal_owner_1")
+	saved, err := store.GetCalibrationRecord("cal_owner_1", "L_owner")
 	if err != nil {
 		t.Fatalf("get record: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestRecordCalibrationResult_ActualScoreOutOfRange(t *testing.T) {
 			}
 
 			// Record must NOT be mutated when validation rejects.
-			saved, err := store.GetCalibrationRecord(predictionID)
+			saved, err := store.GetCalibrationRecord(predictionID, "L_owner")
 			if err != nil {
 				t.Fatalf("get record: %v", err)
 			}
@@ -233,6 +233,44 @@ func TestRecordCalibrationResult_ActualScoreOutOfRange(t *testing.T) {
 // _ = math.NaN keeps the math import required even when no sub-case below
 // directly references math; the test above relies on JSON-literal NaN.
 var _ = math.NaN
+
+// TestRecordCalibrationResult_RejectsForeignPredictionID is the issue #87
+// regression: ownership is now enforced at the DB layer, so even if the tool
+// handler skipped its (now-removed) manual check, calling the MCP tool with
+// another learner's prediction_id must error and leave the row untouched.
+func TestRecordCalibrationResult_RejectsForeignPredictionID(t *testing.T) {
+	store, deps := setupCalibTest(t)
+
+	rec := &models.CalibrationRecord{
+		PredictionID: "cal_foreign_1",
+		LearnerID:    "L_owner",
+		ConceptID:    "Concept_A",
+		Predicted:    0.40,
+	}
+	if err := store.CreateCalibrationPrediction(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := callRecordCalibration(t, deps, "L_attacker", "cal_foreign_1", 0.95)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true, got success")
+	}
+
+	// Row must remain unmodified — Actual still nil, owner still L_owner.
+	saved, err := store.GetCalibrationRecord("cal_foreign_1", "L_owner")
+	if err != nil {
+		t.Fatalf("get record: %v", err)
+	}
+	if saved.Actual != nil {
+		t.Fatalf("expected Actual nil after rejected foreign call, got %v", *saved.Actual)
+	}
+	if saved.LearnerID != "L_owner" {
+		t.Fatalf("LearnerID = %q want L_owner", saved.LearnerID)
+	}
+}
 
 func TestRecordCalibrationResult_ForeignLearnerRejected(t *testing.T) {
 	store, deps := setupCalibTest(t)
@@ -265,7 +303,7 @@ func TestRecordCalibrationResult_ForeignLearnerRejected(t *testing.T) {
 	}
 
 	// Verify the record was NOT modified.
-	saved, err := store.GetCalibrationRecord("cal_victim_1")
+	saved, err := store.GetCalibrationRecord("cal_victim_1", "L_owner")
 	if err != nil {
 		t.Fatalf("get record: %v", err)
 	}


### PR DESCRIPTION
Fixes #87

## Rationale

`db/metacognition.go` exposed `GetCalibrationRecord(predictionID)` and `CompleteCalibrationRecord(predictionID, actual, delta)` that looked up `calibration_records` by `prediction_id` alone. The MCP handler `tools/calibration.go::registerRecordCalibrationResult` performed a manual `record.LearnerID != learnerID` check to gate foreign-prediction access (closed by issue #34), but the DB methods themselves were an attractive nuisance — any future caller that forgot the manual check would silently re-introduce the IDOR.

This change is **defence-in-depth**, not a today-exploit (prediction IDs are 16-byte URL-safe base64, practically unguessable). It moves the `learner_id` filter into the SQL itself so the DB layer is safe by construction, mirroring the `Store.ArchiveDomain(domainID, learnerID)` shape already used elsewhere in the codebase.

## Changes

- `GetCalibrationRecord(predictionID, learnerID)` — adds `AND learner_id = ?` to the SELECT and returns the existing "calibration record not found" sentinel when no row matches.
- `CompleteCalibrationRecord(predictionID, learnerID, actual, delta)` — adds `AND learner_id = ?` to the UPDATE; preserves `RowsAffected == 0` → "calibration record not found" semantics.
- `registerRecordCalibrationResult` now passes `learnerID` to both helpers and drops the now-redundant `if record.LearnerID != learnerID` block (replaced with a one-line comment noting that ownership is enforced at the DB layer).
- All existing callers in tests adapted to the new two-argument signature.

## Test plan

New regression tests added (BDD: confirmed failing on the staging baseline before the fix, then green after):

- `TestGetCalibrationRecord_FiltersByLearnerID` (`db/metacognition_test.go`) — creating a record for `learner_A` and fetching with `learner_B` returns `calibration record not found`.
- `TestCompleteCalibrationRecord_FiltersByLearnerID` (`db/metacognition_test.go`) — completing the same record as `learner_B` errors, and the row remains untouched (`Actual` still nil).
- `TestRecordCalibrationResult_RejectsForeignPredictionID` (`tools/calibration_test.go`) — end-to-end MCP tool call as `L_attacker` against a prediction owned by `L_owner` returns `IsError == true` and the underlying row remains unmodified.

Existing tests `TestCalibrationLifecycle`, `TestGetCalibrationBiasAndHistory`, `TestRecordCalibrationResult_OwnerAllowed`, `TestRecordCalibrationResult_ForeignLearnerRejected`, and `TestCalibrationCheck_HappyPath` were adapted to the new signature and continue to pass.

Local verification:

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green (algorithms, auth, db, engine, models, tools)

https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC

---
_Generated by [Claude Code](https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC)_