### PR TITLE
fix(tools): make get_dashboard_state language-consistent

### DIFF
--- a/tools/get_dashboard_state.go
+++ b/tools/get_dashboard_state.go
@@ -79,11 +79,13 @@ func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 			allDomains, derr := deps.Store.GetDomainsByLearner(learnerID, params.IncludeArchived)
 			if derr != nil {
 				deps.Logger.Error("get_dashboard_state: failed to get domains", "err", derr, "learner", learnerID)
-				r, _ := errorResult("aucun domaine configuré")
+				r, _ := errorResult("no active domain configured")
 				return r, nil, nil
 			}
 			if len(allDomains) == 0 {
-				r, _ := errorResult("aucun domaine configuré")
+				// Issue #33/#90: emit the canonical needs_domain_setup payload
+				// so the LLM can branch consistently across chat-side tools.
+				r, _ := noActiveDomainResult()
 				return r, nil, nil
 			}
 			domains = allDomains
@@ -140,7 +142,7 @@ func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 				if cp.Retention < 0.50 && cp.CardState != "new" {
 					color := "orange"
 					if cp.Retention < 0.30 {
-						color = "rouge"
+						color = "red"
 					}
 					retentionAlerts = append(retentionAlerts, map[string]interface{}{
 						"concept":   cp.Concept,

--- a/tools/get_dashboard_state_test.go
+++ b/tools/get_dashboard_state_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"testing"
+	"time"
+
+	"tutor-mcp/models"
+)
+
+// TestGetDashboardState_NoActiveDomain_UsesCanonicalShape asserts that when a
+// learner with no domain calls get_dashboard_state, the response uses the
+// canonical needs_domain_setup payload (Issue #33) instead of the previous
+// French operator-facing error string ("aucun domaine configuré"). This keeps
+// the chat-side tool surface uniform so the LLM can branch on a single signal
+// regardless of which tool it called.
+func TestGetDashboardState_NoActiveDomain_UsesCanonicalShape(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerGetDashboardState, "L_owner", "get_dashboard_state", map[string]any{})
+	if res.IsError {
+		t.Fatalf("expected canonical (non-error) payload, got error: %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+	if got, _ := out["needs_domain_setup"].(bool); !got {
+		t.Fatalf("expected needs_domain_setup=true, got %v", out)
+	}
+	if reason, _ := out["reason"].(string); reason == "" {
+		t.Fatalf("expected non-empty reason field, got %v", out)
+	}
+	if next, _ := out["next_action_for_llm"].(string); next == "" {
+		t.Fatalf("expected non-empty next_action_for_llm field, got %v", out)
+	}
+}
+
+// TestGetDashboardState_ColorEnumIsEnglish drives the dashboard into the
+// retention-alert branch where the color enum was previously the French
+// "rouge" while its sibling already used the English "orange". The fix
+// aligns the enum to a consistent English vocabulary ("red"/"orange").
+//
+// To trigger the red branch we seed a ConceptState in "review" with a low
+// stability and a LastReview far in the past, so Retrievability falls below
+// 0.30 (review concept "a", stability=1.0, last_review=60 days ago →
+// retention ≈ 0.26 < 0.30 → color=red).
+func TestGetDashboardState_ColorEnumIsEnglish(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	d := makeOwnerDomain(t, store, "L_owner", "math") // concepts: a, b
+
+	last := time.Now().UTC().Add(-60 * 24 * time.Hour)
+	seed := &models.ConceptState{
+		LearnerID:  "L_owner",
+		Concept:    "a",
+		Stability:  1.0,
+		Difficulty: 5.0,
+		Reps:       3,
+		CardState:  "review",
+		LastReview: &last,
+		PMastery:   0.4,
+	}
+	if err := store.UpsertConceptState(seed); err != nil {
+		t.Fatalf("seed concept state: %v", err)
+	}
+
+	res := callTool(t, deps, registerGetDashboardState, "L_owner", "get_dashboard_state", map[string]any{
+		"domain_id": d.ID,
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", resultText(res))
+	}
+	out := decodeResult(t, res)
+	domains, ok := out["domains"].([]any)
+	if !ok || len(domains) == 0 {
+		t.Fatalf("expected non-empty domains array, got %v", out)
+	}
+	dom, _ := domains[0].(map[string]any)
+	alerts, _ := dom["retention_alerts"].([]any)
+	if len(alerts) == 0 {
+		t.Fatalf("expected at least one retention_alert (seeded retention < 0.30), got %v", dom)
+	}
+
+	// Find the alert for concept "a" and assert its color is the English
+	// "red" (was previously the French "rouge").
+	var found bool
+	for _, raw := range alerts {
+		alert, _ := raw.(map[string]any)
+		if alert["concept"] != "a" {
+			continue
+		}
+		found = true
+		color, _ := alert["color"].(string)
+		if color == "rouge" {
+			t.Fatalf("expected color=red, got the legacy French value %q", color)
+		}
+		if color != "red" {
+			t.Fatalf("expected color=red for retention < 0.30, got %q (alert=%v)", color, alert)
+		}
+	}
+	if !found {
+		t.Fatalf("no retention_alert for concept 'a' in alerts=%v", alerts)
+	}
+}


### PR DESCRIPTION
## Rationale

Issue #90 flags two language-consistency problems on `get_dashboard_state.go`:

1. The no-domain branch returns a French operator-facing error string (`"aucun domaine configuré"`), unlike the rest of the chat-side tools, which now emit the canonical `needs_domain_setup` payload (Issue #33). The LLM cannot uniformly branch on this signal across tools today — it would have to special-case `get_dashboard_state`.
2. The retention-alert color enum mixes English (`"orange"`) and French (`"rouge"`) on the two rungs of the same enum. Any downstream consumer (LLM prompt, future UI) has to handle both vocabularies.

## Scope

In this PR (dashboard fixes only):
- `tools/get_dashboard_state.go:82,86` — replace the French `errorResult("aucun domaine configuré")` with `noActiveDomainResult()` for the empty-domains branch (per `tools/tools.go:103-111`). The DB-error sub-branch keeps an `errorResult` shape (it's a genuine fetch failure, not a setup precondition) but its message is translated to English `"no active domain configured"`.
- `tools/get_dashboard_state.go:142-143` — change the retention-alert color enum value `"rouge"` to `"red"` so both rungs use the same vocabulary as the sibling `"orange"`.

Deferred to a follow-up PR (NOT included here):
- The wording sweep on `"X is required"` errors across `interaction.go`, `calibration.go`, `feynman.go`, `transfer.go`, `mastery.go`, `affect.go`. Every one of those files is currently modified by an open cycle-1 PR (#101, #99/#108, #103/#104, #100, #102/#106). Bundling a 6-file textual sweep on top would create heavy conflicts with all of them. Issue #90 stays OPEN; a follow-up PR will pick up part (c) once the cycle-1 PRs merge — hence `Refs #90`, not `Fixes #90`.

Refs #90

## Test plan

New file `tools/get_dashboard_state_test.go`:

- `TestGetDashboardState_NoActiveDomain_UsesCanonicalShape` — a learner with no domain calls `get_dashboard_state`; asserts `IsError == false`, `needs_domain_setup == true`, and that `reason` / `next_action_for_llm` are non-empty (mirrors `TestRecordSessionClose_NoDomain`).
- `TestGetDashboardState_ColorEnumIsEnglish` — seeds a `ConceptState` for concept `a` with `Stability=1.0`, `CardState="review"`, and `LastReview` 60 days in the past, so the dashboard's `Retrievability` falls below `0.30` and the alert hits the "red" branch. Asserts that the alert's `color` field equals `"red"` (and explicitly fails on the legacy `"rouge"`).

Both tests were confirmed FAIL on `staging` before the fix and PASS after.

## Build / vet / test status

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — OK (all packages green: `algorithms`, `auth`, `db`, `engine`, `models`, `tools`)

## Hard rules respected

- No changes outside `tools/get_dashboard_state.go` and the new `tools/get_dashboard_state_test.go`.
- No `--no-verify`, no force-push, no touch of `main`.
- Issue #90 stays OPEN — body uses `Refs #90`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC)_