### PR TITLE
fix(db): make applyMigration atomic via per-migration transaction

### DIFF
--- a/db/migrations_checksum.go
+++ b/db/migrations_checksum.go
@@ -53,8 +53,15 @@ func ensureSchemaMigrationsTable(db *sql.DB) error {
 // applyMigration executes one migration if it has not been applied yet, or
 // verifies its stored checksum if it has. A mismatch returns an error
 // containing "checksum mismatch" so callers (and tests) can detect drift.
+//
+// Issue #118: the body Exec and the bookkeeping INSERT are wrapped in a
+// single transaction so a crash (or any error) between them cannot leave
+// the schema mutated but unrecorded. The IgnoreExecErrors path is a special
+// case: a failed Exec inside a sqlite tx aborts that tx, so we have to roll
+// it back and start a fresh tx for the INSERT — see recordIgnoredMigration.
 func applyMigration(db *sql.DB, m migration) error {
 	var storedChecksum string
+	// The checksum-stored check is read-only and stays outside the tx.
 	row := db.QueryRow(`SELECT checksum FROM schema_migrations WHERE version = ?`, m.Version)
 	switch err := row.Scan(&storedChecksum); err {
 	case nil:
@@ -72,22 +79,53 @@ func applyMigration(db *sql.DB, m migration) error {
 		return fmt.Errorf("schema_migrations: read version %q: %w", m.Version, err)
 	}
 
-	if _, err := db.Exec(m.Body); err != nil {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin migration tx %q: %w", m.Version, err)
+	}
+	// Rollback is a no-op once Commit succeeds; if the IgnoreExecErrors
+	// branch already rolled back manually, this returns sql.ErrTxDone
+	// which we intentionally ignore.
+	defer func() { _ = tx.Rollback() }()
+
+	if _, execErr := tx.Exec(m.Body); execErr != nil {
 		if !m.IgnoreExecErrors {
-			return fmt.Errorf("apply migration %q: %w", m.Version, err)
+			return fmt.Errorf("apply migration %q: %w", m.Version, execErr)
 		}
 		// IgnoreExecErrors covers ALTERs already applied on legacy DBs
-		// ("duplicate column name", "no such column" on DROP COLUMN, etc.).
-		// We still record the checksum so subsequent runs are pure no-ops.
-		_ = err
+		// ("duplicate column name", "no such column" on DROP COLUMN,
+		// etc.). The failed statement aborted this tx, so roll it back
+		// and record the bookkeeping row on a fresh tx — subsequent
+		// runs then take the "checksum already matches, skip" branch.
+		_ = tx.Rollback()
+		return recordIgnoredMigration(db, m)
 	}
-	if _, err := db.Exec(
+	if _, err := tx.Exec(
 		`INSERT INTO schema_migrations (version, checksum) VALUES (?, ?)`,
 		m.Version, m.checksum(),
 	); err != nil {
 		return fmt.Errorf("record migration %q: %w", m.Version, err)
 	}
-	return nil
+	return tx.Commit()
+}
+
+// recordIgnoredMigration inserts the schema_migrations bookkeeping row for
+// an IgnoreExecErrors migration whose body Exec failed. It runs on its own
+// transaction because the original tx was aborted by the failing body
+// statement (sqlite refuses further writes on an aborted tx).
+func recordIgnoredMigration(db *sql.DB, m migration) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin replacement tx %q: %w", m.Version, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(
+		`INSERT INTO schema_migrations (version, checksum) VALUES (?, ?)`,
+		m.Version, m.checksum(),
+	); err != nil {
+		return fmt.Errorf("record migration %q: %w", m.Version, err)
+	}
+	return tx.Commit()
 }
 
 // buildMigrations assembles the ordered migration list from the embedded

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -471,6 +471,98 @@ func TestMigrate_ReRunIsNoOp(t *testing.T) {
 	}
 }
 
+// TestApplyMigration_NonAtomicBody_IsRolledBack_Issue118 is the regression
+// guard for issue #118. A migration body that succeeds partway and then
+// fails on a later statement must leave NO schema artefacts behind: neither
+// the partially-created tables/columns from the body nor a row in
+// schema_migrations claiming the migration succeeded. Without the
+// per-migration transaction added in #118 the first statement's effect
+// persists and operators are left with a half-migrated database.
+//
+// We synthesise a migration whose body has two statements: the first
+// creates table `issue118_x`, the second is invalid SQL. After
+// applyMigration returns an error we assert (a) the table does NOT exist,
+// and (b) schema_migrations has no row for the synthetic version.
+func TestApplyMigration_NonAtomicBody_IsRolledBack_Issue118(t *testing.T) {
+	db := openMigrateTestDB(t, "atomic_body")
+	if err := ensureSchemaMigrationsTable(db); err != nil {
+		t.Fatalf("ensureSchemaMigrationsTable: %v", err)
+	}
+
+	m := migration{
+		Version: "9999_issue118_synthetic",
+		Body: `CREATE TABLE issue118_x (a INTEGER);
+` +
+			`CREATE TABLE issue118_x INVALID SYNTAX;`,
+	}
+
+	err := applyMigration(db, m)
+	if err == nil {
+		t.Fatal("expected applyMigration to return an error for invalid second statement, got nil")
+	}
+
+	// (a) The first statement's table must NOT survive — the whole body
+	// has to be rolled back as a unit.
+	var tableName string
+	scanErr := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='issue118_x'`,
+	).Scan(&tableName)
+	if scanErr == nil {
+		t.Errorf("table issue118_x should not exist after failed migration, but it does")
+	} else if scanErr != sql.ErrNoRows {
+		t.Fatalf("unexpected error checking table existence: %v", scanErr)
+	}
+
+	// (b) schema_migrations must not record the failed migration.
+	var version string
+	scanErr = db.QueryRow(
+		`SELECT version FROM schema_migrations WHERE version = ?`, m.Version,
+	).Scan(&version)
+	if scanErr == nil {
+		t.Errorf("schema_migrations should not contain row for failed version %q", m.Version)
+	} else if scanErr != sql.ErrNoRows {
+		t.Fatalf("unexpected error reading schema_migrations: %v", scanErr)
+	}
+}
+
+// TestApplyMigration_IgnoreExecErrors_StillRecords is the regression guard
+// for the IgnoreExecErrors path under the per-migration transaction added in
+// issue #118. When a migration's body fails (e.g. a legacy ALTER that
+// targets a column that does not exist) and IgnoreExecErrors is true, the
+// row in schema_migrations must still be inserted so subsequent runs treat
+// the migration as applied. Without careful handling, the failed body
+// statement aborts the transaction and the bookkeeping INSERT also fails.
+func TestApplyMigration_IgnoreExecErrors_StillRecords(t *testing.T) {
+	db := openMigrateTestDB(t, "ignore_exec_errors")
+	if err := ensureSchemaMigrationsTable(db); err != nil {
+		t.Fatalf("ensureSchemaMigrationsTable: %v", err)
+	}
+	// Seed a small base table so the failing ALTER has a concrete target.
+	if _, err := db.Exec(`CREATE TABLE issue118_t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("seed base table: %v", err)
+	}
+
+	m := migration{
+		Version:          "9999_issue118_ignore_exec_errors",
+		Body:             `ALTER TABLE issue118_t DROP COLUMN does_not_exist`,
+		IgnoreExecErrors: true,
+	}
+
+	if err := applyMigration(db, m); err != nil {
+		t.Fatalf("applyMigration with IgnoreExecErrors must not return an error, got: %v", err)
+	}
+
+	var version string
+	if err := db.QueryRow(
+		`SELECT version FROM schema_migrations WHERE version = ?`, m.Version,
+	).Scan(&version); err != nil {
+		t.Fatalf("schema_migrations must record the IgnoreExecErrors migration even when body fails: %v", err)
+	}
+	if version != m.Version {
+		t.Errorf("recorded version = %q, want %q", version, m.Version)
+	}
+}
+
 // TestMigrate_DetectsChecksumDrift simulates an operator (or a corrupted
 // replica) editing a migration body after it was applied. The next call to
 // Migrate must refuse to start and surface a "checksum mismatch" error so


### PR DESCRIPTION
Fixes #118

## Rationale

`db/migrations_checksum.go::applyMigration` previously executed the migration body and the bookkeeping `INSERT INTO schema_migrations` as two separate non-transactional `db.Exec` calls. A crash (or any error path) between them would leave the schema mutated but unrecorded:

- The next startup would re-run a body that may not be idempotent, or
- A subsequent partial body apply would surface as a phantom checksum mismatch.

The fix wraps the body Exec and the bookkeeping INSERT in a single `db.BeginTx` per migration so the two writes commit or roll back as a unit. The read-only checksum lookup at the top of `applyMigration` still runs outside the tx (no need to lock the row).

## IgnoreExecErrors handling

The IgnoreExecErrors branch (used by legacy `ALTER` statements that may already have been applied to a pre-existing database) needs special care: when a body statement fails inside a sqlite transaction, the transaction is aborted and further writes on it are rejected. Naively reusing the same `tx` for the bookkeeping INSERT would always fail.

The new `recordIgnoredMigration` helper handles this: after the failing body Exec we explicitly roll back the aborted tx and record the bookkeeping row on a fresh `db.Begin`. The legacy "ALTER already applied" case still ends with a row in `schema_migrations`, so subsequent runs take the checksum-match no-op branch as before.

The `defer func(){ _ = tx.Rollback() }()` in the strict path is intentionally kept after manual rollback in the IgnoreExecErrors branch — `Rollback` on an already-rolled-back tx returns `sql.ErrTxDone`, which we swallow.

## Notes on the third proposed test

The original spec also suggested a `TestApplyMigration_BookkeepingInsertFailure_RollsBackBody` test that simulates the schema_migrations INSERT failing while the body succeeded. Reliably forcing that failure requires either monkey-patching `db.Exec` or pre-corrupting `schema_migrations` in a way that does not also trip the checksum read at the top of `applyMigration`. Both approaches were too fragile to add as a deterministic test against modernc.org/sqlite. The atomicity guarantee is exercised symmetrically by the body-rollback case below — if the tx scope is correct in one direction, it is correct in the other.

## Test plan

- [x] `TestApplyMigration_NonAtomicBody_IsRolledBack_Issue118` — synthetic two-statement migration where the second statement is invalid SQL must leave neither the table created by the first statement nor a row in `schema_migrations`. Confirmed FAILING on `staging` (table persists), PASSING with the fix.
- [x] `TestApplyMigration_IgnoreExecErrors_StillRecords` — a failing `ALTER TABLE ... DROP COLUMN does_not_exist` with `IgnoreExecErrors:true` must still produce a `schema_migrations` row under the new tx-rollback-and-restart flow.
- [x] All existing `db/migrations_test.go` tests continue to pass: idempotence, PFA drop (fresh + upgrade-from-pre-#55), legacy profile-field scrub (issue #61), schema_migrations bookkeeping rows, re-run no-op, checksum drift detection.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (run twice in a row, plus `go test ./db/... -count=3` to catch non-determinism — all green).

## Files changed

- `db/migrations_checksum.go` — wrap body + bookkeeping in one tx; add `recordIgnoredMigration` helper.
- `db/migrations_test.go` — two new regression tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC)_