### PR TITLE
fix(engine): wait for cron jobs to drain in Scheduler.Stop

### DIFF
--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -24,7 +24,19 @@ type Scheduler struct {
 	cron   *cron.Cron
 	logger *slog.Logger
 	client *http.Client
+
+	// stopTimeout bounds how long Stop() waits for in-flight cron jobs to
+	// drain before forcing shutdown. Defaults to 25s (5s of margin within
+	// the 30s SIGTERM handler in main.go for database.Close() etc.).
+	// Overridable via test-only constructors so timeout-path tests don't
+	// need to wait the full production budget.
+	stopTimeout time.Duration
 }
+
+// defaultStopTimeout is the production budget for Stop() to wait for
+// in-flight jobs. Sized so that main.go's 30s SIGTERM handler still has
+// 5s of margin to close the database and finish other shutdown work.
+const defaultStopTimeout = 25 * time.Second
 
 func NewScheduler(store *db.Store, logger *slog.Logger) *Scheduler {
 	// cron.New() ships no recover middleware: an unrecovered panic in any
@@ -34,10 +46,11 @@ func NewScheduler(store *db.Store, logger *slog.Logger) *Scheduler {
 	// learner could DoS the entire tutor at scheduled job times. See #35.
 	cl := slogCronLogger{l: logger}
 	return &Scheduler{
-		store:  store,
-		cron:   cron.New(cron.WithChain(cron.Recover(cl))),
-		logger: logger,
-		client: &http.Client{Timeout: 10 * time.Second},
+		store:       store,
+		cron:        cron.New(cron.WithChain(cron.Recover(cl))),
+		logger:      logger,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		stopTimeout: defaultStopTimeout,
 	}
 }
 
@@ -102,7 +115,30 @@ func (s *Scheduler) Start() error {
 	return nil
 }
 
-func (s *Scheduler) Stop() { s.cron.Stop() }
+// Stop halts the cron scheduler and waits for any in-flight jobs to drain
+// before returning, capped by s.stopTimeout (default 25s).
+//
+// robfig/cron/v3's Stop() returns a context.Context that is cancelled only
+// once all running jobs have finished. Discarding that context (the previous
+// behaviour) made Stop() effectively non-blocking, so the deferred chain in
+// main.go could run database.Close() while a cron tick was mid-iteration —
+// producing "sql: database is closed" mid-loop and silent data loss on
+// webhook_message_queue + scheduled_alerts. See issue #123.
+func (s *Scheduler) Stop() {
+	ctx := s.cron.Stop()
+	timeout := s.stopTimeout
+	if timeout <= 0 {
+		timeout = defaultStopTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+		s.logger.Warn("scheduler: in-flight jobs did not finish within budget — forcing shutdown",
+			"timeout", timeout.String())
+	}
+}
 
 // ─── Daily Motivation (8h) ──────────────────────────────────────────────────
 //

--- a/engine/scheduler_stop_test.go
+++ b/engine/scheduler_stop_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSchedulerStop_WaitsForInFlightJobs_Issue123 reproduces the issue #123
+// bug: Stop() previously discarded the context returned by cron.Stop(), which
+// is the only signal that in-flight jobs have drained. As a result, main.go's
+// deferred shutdown chain could run database.Close() while a cron tick was
+// still mid-iteration over learners, producing "sql: database is closed"
+// mid-loop and silent data loss on webhook_message_queue + scheduled_alerts.
+//
+// Fix: Stop() must block until the cron context is Done (or a bounded timeout
+// elapses).
+//
+// Test strategy: register a job that takes ~150ms, start the scheduler so it
+// fires once, then call Stop() while the job is in-flight. Stop() must block
+// for at least the remaining job duration. We allow generous slack to keep
+// this stable on CI under load.
+func TestSchedulerStop_WaitsForInFlightJobs_Issue123(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewScheduler(nil, logger)
+
+	const jobDuration = 150 * time.Millisecond
+
+	var (
+		started  = make(chan struct{}, 1)
+		finished int32
+		once     sync.Once
+	)
+
+	if _, err := s.cron.AddFunc("@every 50ms", func() {
+		// Only the first tick should block; subsequent ticks (if any) are no-ops.
+		fired := false
+		once.Do(func() {
+			fired = true
+		})
+		if !fired {
+			return
+		}
+		started <- struct{}{}
+		time.Sleep(jobDuration)
+		atomic.StoreInt32(&finished, 1)
+	}); err != nil {
+		t.Fatalf("add job: %v", err)
+	}
+
+	s.cron.Start()
+
+	// Wait for the job to actually be in-flight before we call Stop().
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("job never started; cron not ticking?")
+	}
+
+	// Now Stop() must block until the in-flight job finishes.
+	begin := time.Now()
+	s.Stop()
+	elapsed := time.Since(begin)
+
+	if atomic.LoadInt32(&finished) == 0 {
+		t.Fatalf("Stop() returned before the in-flight job finished — deferred shutdown would race with running jobs (issue #123)")
+	}
+
+	// Allow 50ms slack on the lower bound for scheduler/wakeup jitter; we mainly
+	// want to assert Stop() is not instantaneous when a job is in-flight.
+	const minBlock = 100 * time.Millisecond
+	if elapsed < minBlock {
+		t.Fatalf("Stop() returned in %v, expected at least %v while a %v job was in-flight", elapsed, minBlock, jobDuration)
+	}
+}
+
+// TestSchedulerStop_TimesOutOnRunawayJob_Issue123 verifies the safety valve:
+// if a job is wedged forever, Stop() must not hang the shutdown indefinitely.
+// The production timeout is 25s — too slow for CI — so we shrink stopTimeout
+// for the test (the field is package-private, set directly here).
+func TestSchedulerStop_TimesOutOnRunawayJob_Issue123(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewScheduler(nil, logger)
+	s.stopTimeout = 50 * time.Millisecond
+
+	wedge := make(chan struct{})
+	defer close(wedge) // unblock the wedged job at end of test
+
+	started := make(chan struct{}, 1)
+	var once sync.Once
+	if _, err := s.cron.AddFunc("@every 25ms", func() {
+		fired := false
+		once.Do(func() { fired = true })
+		if !fired {
+			return
+		}
+		started <- struct{}{}
+		<-wedge // never returns until the test cleans up
+	}); err != nil {
+		t.Fatalf("add wedged job: %v", err)
+	}
+
+	s.cron.Start()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("wedged job never started")
+	}
+
+	begin := time.Now()
+	s.Stop()
+	elapsed := time.Since(begin)
+
+	// We expect Stop() to return after roughly stopTimeout — not block forever.
+	// Upper bound is generous to absorb CI scheduling jitter.
+	if elapsed > 2*time.Second {
+		t.Fatalf("Stop() took %v with stopTimeout=50ms — timeout safety valve appears broken", elapsed)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("Stop() returned in %v — should have waited at least the configured stopTimeout (50ms)", elapsed)
+	}
+}


### PR DESCRIPTION
Fixes #123

## Rationale

`engine/scheduler.go::Stop` called `s.cron.Stop()` and discarded the returned `context.Context`. Per `robfig/cron/v3` semantics, that context is the *only* signal that all in-flight jobs have finished. Discarding it made `Stop()` effectively non-blocking — so `defer scheduler.Stop()` in `main.go` returned immediately, and the next deferred call (`database.Close()`) could fire while a cron tick was still mid-iteration over learners + DB calls.

Production symptom: `sql: database is closed` errors during shutdown, with **silent data loss** on `webhook_message_queue` (`MarkWebhookSent`) and `scheduled_alerts` (`CreateScheduledAlert`) — the dispatch HTTP POST already went out, but the DB rows recording it never landed.

## Fix

`Scheduler.Stop()` now blocks on `cron.Stop()`'s context up to a configurable budget:

- Default `stopTimeout = 25s`. Sized so `main.go`'s 30s SIGTERM handler still has 5s of margin to run `database.Close()` and other shutdown work.
- On timeout we log a Warn and return — so a runaway job cannot wedge shutdown forever.
- `stopTimeout` is a package-private field on `Scheduler`, defaulted in `NewScheduler` and overridable from tests so the timeout-path is exercisable in <1s instead of waiting the full production budget.

`main.go` is unchanged: the simpler in-method timeout approach was preferred over plumbing a context through the constructor.

## Tests

Both new tests live in `engine/scheduler_stop_test.go`:

- `TestSchedulerStop_WaitsForInFlightJobs_Issue123` — registers a 150ms job, waits for it to start, calls `Stop()`, asserts (a) the job actually completed before `Stop()` returned and (b) `Stop()` blocked at least 100ms (50ms slack for jitter).
- `TestSchedulerStop_TimesOutOnRunawayJob_Issue123` — wedges a job on a channel that never closes until cleanup, sets `s.stopTimeout = 50ms`, asserts `Stop()` returns within the budget (and at least the budget) instead of hanging.

Both tests **fail on the `staging` baseline** (verified by reverting `Stop()` to the one-liner — `Stop()` returns in ~2µs even with a 150ms job in flight) and **pass with the fix**.

## Build / vet / test status

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — clean, all packages pass
- `go test -count=2 ./...` — clean (no flakes across two runs)
- `go test ./engine/ -count=2 -run TestSchedulerStop_ -v` — both new tests pass twice

## Audit notes — `s.logger.Error` in shutdown-sensitive paths

Per the issue body, I scanned the scheduler for `s.logger.Error(... "err", err ...)` call sites that could fire during a closed-DB race. With this fix, the **happy-path shutdown no longer hits these** — `Stop()` blocks until jobs drain, so `database.Close()` runs strictly after.

The remaining concern is the **forced-shutdown path** (job runaway >25s → timeout → `database.Close()` then races with the still-running job). The Error-level call sites that would surface as alerting noise on a closed DB during forced shutdown:

| Location | Path |
| --- | --- |
| `scheduler.go:166` | `dispatchQueued` → `GetActiveLearners` |
| `scheduler.go:188` | `dispatchQueued` → `DequeueNextPending` |
| `scheduler.go:273` / `:280` / `:287` | `cleanupExpiredData` → `CleanupExpiredCodes` / `CleanupExpiredRefreshTokens` / `ExpirePastWebhookMessages` |
| `scheduler.go:386` | `sendOLM` → `GetActiveLearners` |
| `scheduler.go:405` | `sendOLM` → `GetDomainsByLearner` |
| `scheduler.go:481` | `sendMirrorMessages` → `GetActiveLearners` |
| `scheduler.go:509` | `sendMirrorMessages` → `DequeueNextPending` |
| `scheduler_metacog.go:84` | `dispatchMetacognitiveAlerts` → `GetActiveLearners` |
| `scheduler_metacog.go:146` | `dispatchMetacognitiveAlerts` → enqueue |

These would page operators with `level=Error` on what is really "we forced shutdown after the 25s budget". A cleaner fix is either (a) detect `errors.Is(err, sql.ErrConnDone)` / matching strings during shutdown and downgrade to `level=Warn`, or (b) thread a shutdown context through the jobs so they short-circuit before issuing DB calls. Both are out-of-scope per the issue and belong in a follow-up PR — keeping this PR scoped to the actual race fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (twice, no flakes)
- [x] New tests fail on `staging` baseline, pass with fix
- [x] Existing scheduler tests (`TestScheduler_PanickingJobDoesNotCrashLoop`, `TestSendOLM_*`, etc.) still pass

https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC

---
_Generated by [Claude Code](https://claude.ai/code/session_0131j6Ng2Z9o6YniRZpneLTC)_