### PR TITLE
fix: close cross-domain leaks in DIAGNOSTIC, MAINTENANCE, mirror, autonomy

### DIFF
--- a/engine/concept_selector.go
+++ b/engine/concept_selector.go
@@ -80,7 +80,7 @@ func SelectConcept(
 	case models.PhaseInstruction:
 		return selectInstruction(states, graph, goalRelevance), nil
 	case models.PhaseMaintenance:
-		return selectMaintenance(states, goalRelevance), nil
+		return selectMaintenance(states, graph, goalRelevance), nil
 	case models.PhaseDiagnostic:
 		return selectDiagnostic(states, graph), nil
 	default:
@@ -244,9 +244,26 @@ func selectInstruction(
 // missing fast-forgetting concepts.
 func selectMaintenance(
 	states []*models.ConceptState,
+	graph models.KnowledgeSpace,
 	goalRelevance map[string]float64,
 ) Selection {
 	bktThreshold := algorithms.MasteryBKT()
+
+	// Domain filter: states whose concept is absent from graph.Concepts
+	// are excluded. pf.StatesList is learner-wide, so without this guard
+	// a concept mastered in another domain leaks into the active
+	// domain's MAINTENANCE pool — particularly when goal_relevance is
+	// nil and urgency × 1.0 alone drives selection. Empty graph.Concepts
+	// = "no filter" preserves existing call sites passing
+	// models.KnowledgeSpace{}; the orchestrator always supplies a
+	// non-empty graph for the active domain. Issue #93.
+	var domainSet map[string]struct{}
+	if len(graph.Concepts) > 0 {
+		domainSet = make(map[string]struct{}, len(graph.Concepts))
+		for _, c := range graph.Concepts {
+			domainSet[c] = struct{}{}
+		}
+	}
 
 	// Collect mastered concepts; sort alphabetically for deterministic
 	// tie-break.
@@ -260,6 +277,11 @@ func selectMaintenance(
 		}
 		if cs.PMastery < bktThreshold {
 			continue
+		}
+		if domainSet != nil {
+			if _, ok := domainSet[cs.Concept]; !ok {
+				continue
+			}
 		}
 		mastered = append(mastered, cs)
 	}

--- a/engine/concept_selector.go
+++ b/engine/concept_selector.go
@@ -82,7 +82,7 @@ func SelectConcept(
 	case models.PhaseMaintenance:
 		return selectMaintenance(states, goalRelevance), nil
 	case models.PhaseDiagnostic:
-		return selectDiagnostic(states), nil
+		return selectDiagnostic(states, graph), nil
 	default:
 		slog.Error("concept_selector: unknown phase",
 			"phase", string(phase))
@@ -325,7 +325,24 @@ func selectMaintenance(
 // Saturation pre-filter: P(L) <= 0.05 or >= 0.95 → info-gain ≈ 0
 // already, but excluding them up-front keeps the score interpretation
 // clean (the argmax is over genuinely ambiguous concepts only).
-func selectDiagnostic(states []*models.ConceptState) Selection {
+//
+// Domain filter: states whose concept is absent from graph.Concepts are
+// excluded. pf.StatesList is learner-wide (GetConceptStatesByLearner),
+// so without this guard a concept mastered in another domain leaks into
+// the active domain's DIAGNOSTIC selection — symmetric to the
+// MAINTENANCE leak fixed for issue #93. An empty graph.Concepts is
+// treated as "no filter" to preserve existing call sites that pass
+// models.KnowledgeSpace{}; the orchestrator always supplies a non-empty
+// graph for the active domain.
+func selectDiagnostic(states []*models.ConceptState, graph models.KnowledgeSpace) Selection {
+	var domainSet map[string]struct{}
+	if len(graph.Concepts) > 0 {
+		domainSet = make(map[string]struct{}, len(graph.Concepts))
+		for _, c := range graph.Concepts {
+			domainSet[c] = struct{}{}
+		}
+	}
+
 	var candidates []*models.ConceptState
 	for _, cs := range states {
 		if cs == nil || math.IsNaN(cs.PMastery) {
@@ -333,6 +350,11 @@ func selectDiagnostic(states []*models.ConceptState) Selection {
 		}
 		if cs.PMastery <= 0.05 || cs.PMastery >= 0.95 {
 			continue
+		}
+		if domainSet != nil {
+			if _, ok := domainSet[cs.Concept]; !ok {
+				continue
+			}
 		}
 		candidates = append(candidates, cs)
 	}

--- a/engine/concept_selector_test.go
+++ b/engine/concept_selector_test.go
@@ -350,6 +350,76 @@ func TestSelectConcept_Maintenance_TieBreakAlphabetical(t *testing.T) {
 	}
 }
 
+func TestSelectConcept_Maintenance_FiltersByActiveDomainGraph(t *testing.T) {
+	// Regression: selectMaintenance must restrict its mastered pool to
+	// states whose concept is in domain.Graph.Concepts. pf.StatesList is
+	// learner-wide (GetConceptStatesByLearner is not domain-scoped), so
+	// without this filter a concept mastered in another domain leaks
+	// into the active domain's MAINTENANCE selection — particularly
+	// when goal_relevance is nil and urgency × 1.0 alone drives
+	// selection. Issue #93.
+	//
+	// Setup: active domain D2 has only "a"; "x" lives in D1 but is in
+	// the learner-wide states. Both are mastered (PMastery=0.95). "x"
+	// has higher urgency (Stability=1, ElapsedDays=30) so without the
+	// filter it would win over "a" (Stability=30, ElapsedDays=1).
+	csA := reviewedCS("a", 0.95)
+	csA.Stability = 30
+	csA.ElapsedDays = 1
+	csX := reviewedCS("x", 0.95)
+	csX.Stability = 1
+	csX.ElapsedDays = 30
+
+	activeGraph := graphFlat("a")
+
+	sel, err := SelectConcept(
+		models.PhaseMaintenance,
+		[]*models.ConceptState{csA, csX},
+		activeGraph,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sel.Concept == "x" {
+		t.Fatalf("cross-domain leak: MAINTENANCE selected %q (not in graph), expected %q", sel.Concept, "a")
+	}
+	if sel.Concept != "a" {
+		t.Errorf("expected concept=a, got %q", sel.Concept)
+	}
+}
+
+func TestSelectConcept_Maintenance_AllMasteredFromOtherDomain_NoFringe(t *testing.T) {
+	// Companion regression: when every mastered state belongs to
+	// another domain, MAINTENANCE must return NoFringe rather than
+	// silently returning a foreign concept. Symmetric to the
+	// DIAGNOSTIC case above.
+	csY := reviewedCS("y", 0.95)
+	csY.Stability = 1
+	csY.ElapsedDays = 30
+	csZ := reviewedCS("z", 0.95)
+	csZ.Stability = 1
+	csZ.ElapsedDays = 30
+
+	activeGraph := graphFlat("a")
+
+	sel, err := SelectConcept(
+		models.PhaseMaintenance,
+		[]*models.ConceptState{csY, csZ},
+		activeGraph,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sel.NoFringe {
+		t.Errorf("expected NoFringe when all mastered are from other domains, got %+v", sel)
+	}
+	if sel.Concept != "" {
+		t.Errorf("expected empty concept on NoFringe, got %q", sel.Concept)
+	}
+}
+
 // ─── DIAGNOSTIC ────────────────────────────────────────────────────────────
 
 func TestSelectConcept_Diagnostic_PicksMaxInfoGain(t *testing.T) {

--- a/engine/concept_selector_test.go
+++ b/engine/concept_selector_test.go
@@ -400,6 +400,79 @@ func TestSelectConcept_Diagnostic_IgnoresGoalRelevance(t *testing.T) {
 	}
 }
 
+func TestSelectConcept_Diagnostic_FiltersByActiveDomainGraph(t *testing.T) {
+	// Regression: selectDiagnostic must restrict its candidate pool to
+	// states whose concept is in domain.Graph.Concepts. pf.StatesList is
+	// learner-wide (GetConceptStatesByLearner is not domain-scoped), so
+	// without this filter a concept mastered in another domain (or simply
+	// in another active domain's `concept_states`) leaks into the active
+	// domain's DIAGNOSTIC selection. Mirrors the MAINTENANCE filter
+	// applied via issue #93 / PR #102.
+	//
+	// Setup: active domain D2 has only "a"; "x" lives in D1 but is in
+	// the learner-wide states. "x" is at PMastery=0.5 (peak BKT
+	// info-gain), "a" at PMastery=0.2 (lower info-gain). Pre-fix the
+	// selector picks "x" because info-gain wins; post-fix "x" is
+	// excluded by the domain set and "a" is selected.
+	csA := reviewedCS("a", 0.2)
+	csA.PSlip = 0.1
+	csA.PGuess = 0.2
+	csX := reviewedCS("x", 0.5)
+	csX.PSlip = 0.1
+	csX.PGuess = 0.2
+
+	activeGraph := graphFlat("a")
+
+	sel, err := SelectConcept(
+		models.PhaseDiagnostic,
+		[]*models.ConceptState{csA, csX},
+		activeGraph,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sel.Concept == "x" {
+		t.Fatalf("cross-domain leak: DIAGNOSTIC selected %q (not in graph), expected %q", sel.Concept, "a")
+	}
+	if sel.Concept != "a" {
+		t.Errorf("expected concept=a, got %q", sel.Concept)
+	}
+}
+
+func TestSelectConcept_Diagnostic_AllCandidatesFromOtherDomain_NoFringe(t *testing.T) {
+	// Companion regression: when every non-saturated state belongs to
+	// another domain, DIAGNOSTIC must return NoFringe rather than
+	// silently returning a foreign concept. This ensures the orchestrator
+	// can react (e.g., transition or surface a needs-setup signal)
+	// instead of routing to a concept that the writer side will reject
+	// at validateConceptInDomain.
+	csY := reviewedCS("y", 0.4)
+	csY.PSlip = 0.1
+	csY.PGuess = 0.2
+	csZ := reviewedCS("z", 0.6)
+	csZ.PSlip = 0.1
+	csZ.PGuess = 0.2
+
+	activeGraph := graphFlat("a")
+
+	sel, err := SelectConcept(
+		models.PhaseDiagnostic,
+		[]*models.ConceptState{csY, csZ},
+		activeGraph,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sel.NoFringe {
+		t.Errorf("expected NoFringe when all candidates are from other domains, got %+v", sel)
+	}
+	if sel.Concept != "" {
+		t.Errorf("expected empty concept on NoFringe, got %q", sel.Concept)
+	}
+}
+
 // ─── Cas dégénérés transverses ─────────────────────────────────────────────
 
 func TestSelectConcept_NaN_PMastery_ExcludedFromAllPhases(t *testing.T) {

--- a/engine/orchestrator_integration_test.go
+++ b/engine/orchestrator_integration_test.go
@@ -352,13 +352,25 @@ func TestOrchestrate_E2E_BroadGoal_LongInstruction_30Sessions(t *testing.T) {
 	art := runE2ESimulation(t, "broad_goal", concepts, nil, goal, 30, cfg)
 
 	// Assertion : le passage en MAINTENANCE doit être plus tardif (ou
-	// inexistant) que dans le scénario restrictif. On vérifie qu'on a
-	// passé plus de sessions en INSTRUCTION qu'en MAINTENANCE.
+	// inexistant) que dans le scénario restrictif. On vérifie que
+	// MAINTENANCE n'arrive pas avant la deuxième moitié de la
+	// simulation, que la phase finale est MAINTENANCE, et que les
+	// sessions INSTRUCTION sont substantielles. (La comparaison directe
+	// I > M était une proxy fragile : une fois `selectDiagnostic`
+	// corrigé pour respecter le gate anti-repeat — issue #93 lineage —
+	// la phase DIAGNOSTIC ne masterise plus aucun concept par accident,
+	// donc INSTRUCTION démarre plus tôt et MAINTENANCE peut accumuler
+	// plus de sessions vers la fin.)
+	if art.Summary.FirstMaintenanceAt > 0 && art.Summary.FirstMaintenanceAt < 15 {
+		t.Errorf("broad goal : MAINTENANCE arrived too early (session %d, expected >= 15)",
+			art.Summary.FirstMaintenanceAt)
+	}
+	if art.Summary.FinalPhase != string(models.PhaseMaintenance) {
+		t.Errorf("broad goal : expected final phase MAINTENANCE, got %s", art.Summary.FinalPhase)
+	}
 	instructionCount := art.Summary.PhaseDistribution[string(models.PhaseInstruction)]
-	maintenanceCount := art.Summary.PhaseDistribution[string(models.PhaseMaintenance)]
-	if maintenanceCount > instructionCount {
-		t.Errorf("broad goal : expected more INSTRUCTION than MAINTENANCE sessions, got I=%d M=%d",
-			instructionCount, maintenanceCount)
+	if instructionCount < 8 {
+		t.Errorf("broad goal : INSTRUCTION should be substantial (>= 8 sessions), got %d", instructionCount)
 	}
 }
 

--- a/tools/autonomy.go
+++ b/tools/autonomy.go
@@ -14,7 +14,7 @@ import (
 )
 
 type GetAutonomyMetricsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si fourni, les métriques d'autonomie computées sur les interactions et états sont restreintes à ce domaine. La tendance reste learner-wide (signal cross-session)."`
 }
 
 func registerGetAutonomyMetrics(server *mcp.Server, deps *Deps) {
@@ -33,6 +33,26 @@ func registerGetAutonomyMetrics(server *mcp.Server, deps *Deps) {
 		interactions, _ := deps.Store.GetInteractionsSince(learnerID, since)
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
 		calibBias, _ := deps.Store.GetCalibrationBias(learnerID, 20)
+
+		// Domain filter (#95): if domain_id is supplied, restrict the
+		// concept-keyed inputs (interactions, states) to that domain's
+		// concept set. resolveDomain enforces learner ownership and
+		// rejects archived/foreign IDs. Trend stays learner-wide
+		// because it's computed from affect rows (session-keyed, not
+		// concept-keyed) and represents a cross-session learner signal.
+		if params.DomainID != "" {
+			domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
+			if err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+			conceptSet := make(map[string]bool, len(domain.Graph.Concepts))
+			for _, c := range domain.Graph.Concepts {
+				conceptSet[c] = true
+			}
+			interactions = filterInteractionsByConcepts(interactions, conceptSet)
+			states = filterStatesByConcepts(states, conceptSet)
+		}
 
 		metrics := engine.ComputeAutonomyMetrics(engine.AutonomyInput{
 			Interactions:    interactions,

--- a/tools/autonomy_test.go
+++ b/tools/autonomy_test.go
@@ -5,6 +5,8 @@ package tools
 
 import (
 	"testing"
+
+	"tutor-mcp/models"
 )
 
 func TestGetAutonomyMetrics_NoAuth(t *testing.T) {
@@ -27,5 +29,78 @@ func TestGetAutonomyMetrics_HappyPath(t *testing.T) {
 	}
 	if _, ok := out["trend"]; !ok {
 		t.Fatalf("expected trend in result, got %v", out)
+	}
+}
+
+func TestGetAutonomyMetrics_UnknownDomainIDRejected(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerGetAutonomyMetrics, "L_owner", "get_autonomy_metrics", map[string]any{
+		"domain_id": "nonexistent_domain_id",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown domain_id, got success")
+	}
+}
+
+func TestGetAutonomyMetrics_DomainIDFiltersForeignInteractions(t *testing.T) {
+	// Regression: get_autonomy_metrics must filter the concept-keyed
+	// inputs (Interactions, ConceptStates) to the active domain's
+	// concept set when domain_id is provided. Otherwise a learner with
+	// proactive-review activity in domain D2 sees that signal show up
+	// in D1's autonomy score — a cross-domain leak. Issue #95.
+	store, deps := setupToolsTest(t)
+
+	// Seed two domains. Only D1 will be queried; D2's interactions
+	// must be filtered out.
+	d1, err := store.CreateDomain("L_owner", "active", "",
+		models.KnowledgeSpace{Concepts: []string{"a"}, Prerequisites: map[string][]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, err := store.CreateDomain("L_owner", "foreign", "",
+		models.KnowledgeSpace{Concepts: []string{"x"}, Prerequisites: map[string][]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 5 proactive-review interactions on x (in D2 only).
+	for i := 0; i < 5; i++ {
+		interaction := &models.Interaction{
+			LearnerID: "L_owner", Concept: "x", DomainID: d2.ID,
+			ActivityType:      "PRACTICE",
+			Success:           true,
+			IsProactiveReview: true,
+			SelfInitiated:     true,
+			ResponseTime:      4.0,
+		}
+		if err := store.CreateInteraction(interaction); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Query 1: domain_id=D1 (foreign data must be filtered out).
+	res1 := callTool(t, deps, registerGetAutonomyMetrics, "L_owner", "get_autonomy_metrics", map[string]any{
+		"domain_id": d1.ID,
+	})
+	if res1.IsError {
+		t.Fatalf("D1 query errored: %s", resultText(res1))
+	}
+	out1 := decodeResult(t, res1)
+	pr1, _ := out1["proactive_review_rate"].(float64)
+	if pr1 != 0.0 {
+		t.Errorf("cross-domain leak: with domain_id=D1, proactive_review_rate should be 0 (no x in D1), got %v", pr1)
+	}
+
+	// Query 2: domain_id=D2 (in-scope, signal must surface).
+	res2 := callTool(t, deps, registerGetAutonomyMetrics, "L_owner", "get_autonomy_metrics", map[string]any{
+		"domain_id": d2.ID,
+	})
+	if res2.IsError {
+		t.Fatalf("D2 query errored: %s", resultText(res2))
+	}
+	out2 := decodeResult(t, res2)
+	pr2, _ := out2["proactive_review_rate"].(float64)
+	if pr2 == 0.0 {
+		t.Errorf("with domain_id=D2 (where x lives), proactive_review_rate should be > 0, got %v", pr2)
 	}
 }

--- a/tools/mirror.go
+++ b/tools/mirror.go
@@ -14,7 +14,7 @@ import (
 )
 
 type GetMetacognitiveMirrorParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine de contexte (optionnel) ; le miroir est calculé au niveau apprenant et n'est pas filtré par domaine"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si fourni, le miroir est restreint aux interactions et états de concept de ce domaine. Si absent, le calcul reste learner-wide."`
 }
 
 func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
@@ -38,6 +38,26 @@ func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
 		calibBias, _ := deps.Store.GetCalibrationBias(learnerID, 20)
 		affects, _ := deps.Store.GetRecentAffectStates(learnerID, 10)
+
+		// Domain filter (#95): if domain_id is supplied, restrict the
+		// concept-keyed inputs (interactions, states) to that domain's
+		// concept set. resolveDomain enforces learner ownership and
+		// rejects archived/foreign IDs. AutonomyScores stay learner-wide
+		// because they are session-keyed (from affect rows, not concept-
+		// keyed) — autonomy is a learner trait, not a domain trait.
+		if params.DomainID != "" {
+			domain, err := resolveDomain(deps.Store, learnerID, params.DomainID)
+			if err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+			conceptSet := make(map[string]bool, len(domain.Graph.Concepts))
+			for _, c := range domain.Graph.Concepts {
+				conceptSet[c] = true
+			}
+			interactions = filterInteractionsByConcepts(interactions, conceptSet)
+			states = filterStatesByConcepts(states, conceptSet)
+		}
 
 		var autonomyScores []float64
 		for _, a := range affects {

--- a/tools/mirror_test.go
+++ b/tools/mirror_test.go
@@ -5,6 +5,8 @@ package tools
 
 import (
 	"testing"
+
+	"tutor-mcp/models"
 )
 
 func TestGetMetacognitiveMirror_NoAuth(t *testing.T) {
@@ -24,5 +26,63 @@ func TestGetMetacognitiveMirror_NoPattern(t *testing.T) {
 	out := decodeResult(t, res)
 	if _, ok := out["mirror"]; !ok {
 		t.Fatalf("expected mirror key, got %v", out)
+	}
+}
+
+func TestGetMetacognitiveMirror_UnknownDomainIDRejected(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerGetMetacognitiveMirror, "L_owner", "get_metacognitive_mirror", map[string]any{
+		"domain_id": "nonexistent_domain_id",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown domain_id, got success")
+	}
+}
+
+func TestGetMetacognitiveMirror_DomainIDFiltersForeignSignal(t *testing.T) {
+	// Regression: get_metacognitive_mirror must filter the concept-keyed
+	// inputs (Interactions, ConceptStates) to the active domain's
+	// concept set when domain_id is provided. Seeding a strong
+	// no_initiative pattern on foreign concept "x" (D2) and querying
+	// with domain_id=D1 (which has only "a") must produce mirror=null
+	// because the signal is filtered out. Issue #95.
+	store, deps := setupToolsTest(t)
+
+	d1, err := store.CreateDomain("L_owner", "active", "",
+		models.KnowledgeSpace{Concepts: []string{"a"}, Prerequisites: map[string][]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, err := store.CreateDomain("L_owner", "foreign", "",
+		models.KnowledgeSpace{Concepts: []string{"x"}, Prerequisites: map[string][]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed 6 non-self-initiated interactions on x in D2 — strong
+	// no_initiative signal IF visible to the detector.
+	for i := 0; i < 6; i++ {
+		interaction := &models.Interaction{
+			LearnerID: "L_owner", Concept: "x", DomainID: d2.ID,
+			ActivityType:  "PRACTICE",
+			Success:       true,
+			SelfInitiated: false,
+			ResponseTime:  4.0,
+		}
+		if err := store.CreateInteraction(interaction); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Query with domain_id=D1: x's signal must be filtered out → mirror null.
+	res := callTool(t, deps, registerGetMetacognitiveMirror, "L_owner", "get_metacognitive_mirror", map[string]any{
+		"domain_id": d1.ID,
+	})
+	if res.IsError {
+		t.Fatalf("D1 query errored: %s", resultText(res))
+	}
+	out := decodeResult(t, res)
+	if mirror, ok := out["mirror"]; ok && mirror != nil {
+		t.Errorf("cross-domain leak: with domain_id=D1, mirror should be nil (x's signal filtered out), got %v", mirror)
 	}
 }


### PR DESCRIPTION
Fixes #130 (DIAGNOSTIC)
Fixes #93 (MAINTENANCE)
Fixes #95 (mirror / autonomy domain scope)

Bundles the three symmetric fixes for the same class of bug: the candidate pool / signal pool was learner-wide and not re-filtered by the active domain. Three sites are closed in one PR because they share the same root cause and the same fix shape.

## What changed

### `engine.selectDiagnostic` (origin of the user-reported CDN bug)
- Builds a `domainSet` from `graph.Concepts`, skips foreign states.
- Empty graph = "no filter" preserves test back-compat.
- Side benefit: now also honors the gate's anti-repeat window (which it was silently bypassing). Documented in the broad-goal E2E test rewrite.

### `engine.selectMaintenance`
- Same `domainSet` pattern. Closes #93. Supersedes PR #102.

### `tools.get_metacognitive_mirror` and `tools.get_autonomy_metrics`
- When `domain_id` is supplied, resolve via `resolveDomain` (rejects archived/foreign/unknown), then filter interactions + states with the existing `filterInteractionsByConcepts` / `filterStatesByConcepts` helpers.
- `AutonomyScores` (mirror) and `Trend` (autonomy) stay learner-wide because they are session-keyed (affect rows) — autonomy is a learner trait, not a domain trait. Schema descriptions on the `DomainID` fields are updated.
- Closes #95. Supersedes PR #109.

## Side benefit (DIAGNOSTIC)

In the E2E broad-goal simulation, pre-fix DIAGNOSTIC was sticking on alpha 4× then beta 4× because it ignored the gate's anti-repeat. Post-fix it rotates correctly. The `I > M` proxy assertion was rewritten to the real intent: *MAINTENANCE arrives in the second half, INSTRUCTION substantial, final phase MAINTENANCE.*

## Test plan

| Test | Pre-fix | Post-fix |
|---|---|---|
| `TestSelectConcept_Diagnostic_FiltersByActiveDomainGraph` | FAIL (selects "x", cross-domain) | PASS (selects "a") |
| `TestSelectConcept_Diagnostic_AllCandidatesFromOtherDomain_NoFringe` | FAIL (returns "z") | PASS (NoFringe) |
| `TestSelectConcept_Maintenance_FiltersByActiveDomainGraph` | FAIL | PASS |
| `TestSelectConcept_Maintenance_AllMasteredFromOtherDomain_NoFringe` | FAIL | PASS |
| `TestGetMetacognitiveMirror_UnknownDomainIDRejected` | FAIL (silent accept) | PASS (error) |
| `TestGetMetacognitiveMirror_DomainIDFiltersForeignSignal` | FAIL (mirror non-null on foreign concept's pattern) | PASS (mirror=null) |
| `TestGetAutonomyMetrics_UnknownDomainIDRejected` | FAIL | PASS |
| `TestGetAutonomyMetrics_DomainIDFiltersForeignInteractions` | FAIL (proactive_review_rate>0 when D1 has no x) | PASS (=0 for D1, >0 for D2) |

All pre-existing tests still green:
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (algorithms, auth, db, engine, models, tools)
- [x] Broad-goal E2E test passes with new assertion

## Supersedes
- PR #102 (MAINTENANCE filter) — close as superseded
- PR #109 (mirror/autonomy domain scope) — close as superseded

## After this lands
The 3 phases (DIAGNOSTIC, INSTRUCTION, MAINTENANCE) are domain-bounded.
The 4 read tools that accept `domain_id` (`get_metacognitive_mirror`, `get_autonomy_metrics`, `get_pending_alerts`, `get_dashboard_state`, `get_learner_context`) all filter consistently.