### PR TITLE
docs(i18n): foundations — public contract + contributing update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,16 @@ Open an issue using the **Feature request** template. Describe the user-facing p
 
 ### Language
 
-The codebase intentionally mixes English and French along a single axis: **who reads the string?**
+The codebase is English-only at the source level. This includes:
 
-- **English** for everything developers/operators read: source code, identifiers, comments, log messages, error returns, this file, every doc under `docs/`.
-- **French** for everything the **learner** ends up seeing (directly or via the LLM): MCP tool descriptions, `jsonschema` parameter descriptions, system prompts, OLM messages, learner-facing rationales.
+- All Go source: identifiers, comments, godoc, log messages, error returns.
+- All tool `Description:` fields and `jsonschema:` parameter descriptions.
+- All learner-facing strings the server composes (handler messages, recap_brief, motivation_brief, DB notifications, engine rationales).
+- All documentation under `docs/`.
 
-When in doubt: if a string is destined for the learner, write correct French with full diacritics (`é`, `è`, `à`, `ç`, …). The lint test in `tools/registration_test.go` enforces diacritic consistency.
+The tutor MCP itself is language-agnostic at runtime: the LLM mirrors the learner's language on output, persisting it via `update_learner_profile(language)` on the first turn. See `docs/i18n.md` for the contract.
+
+The lint test in `tools/registration_test.go` enforces ASCII-only in learner-facing strings.
 
 ### Formatting
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,39 @@
+# Internationalization
+
+tutor-mcp is language-agnostic at runtime. The server speaks English; the LLM
+translates for the learner on output. There are no per-locale catalogues to
+maintain and no closed list of supported languages - any language the
+underlying LLM speaks fluently works.
+
+## How it works
+
+1. The MCP client connects and fetches the system prompt (English, static).
+2. The learner writes a message in their own language.
+3. The LLM detects that language from the message itself and responds in it.
+4. On the first learner turn, the LLM persists the detected language by
+   calling `update_learner_profile(language: "<bcp47>")`.
+5. On subsequent sessions, `get_learner_context()` exposes `profile.language`
+   as an explicit override. If set, the LLM uses it regardless of what the
+   learner types in - useful when the learner is studying a foreign language
+   and wants explanations in another.
+
+## Changing language
+
+A learner can change their language at any time by telling the tutor
+("switch to Spanish", "explain in German"). The LLM picks this up and calls
+`update_learner_profile(language: "<new>")`.
+
+## Supported languages
+
+Any language the underlying LLM speaks fluently. The server accepts any
+string up to the length cap on `profile.language` - there is no whitelist
+and no syntactic validation of BCP-47 codes.
+
+Translation quality tracks the LLM's quality. Low-resource languages may
+degrade. The server has no visibility into this; it is a property of the
+LLM client.
+
+## For contributors
+
+See `CONTRIBUTING.md > Language` for the source-language contract and the
+ASCII-only lint enforced in `tools/registration_test.go`.


### PR DESCRIPTION
## Summary
- Add `docs/i18n.md` describing the runtime language contract (LLM mirrors learner's language, persists via `update_learner_profile`).
- Rewrite the Language section of `CONTRIBUTING.md` from "English for devs / French for learners" to "English-only source, LLM mirrors at runtime".

First PR in a 5-PR migration to full i18n. See `docs/superpowers/specs/2026-05-10-i18n-design.md` (local-only, gitignored) for the design.

## Test plan
- [x] No code changed — CI green by construction.
- [x] Both files ASCII-only.
- [x] CONTRIBUTING.md surrounding sections (Formatting, Tests, Documentation) untouched.