### PR TITLE
i18n(tools): translate tool descriptions and jsonschema tags to English

### DIFF
--- a/tools/activity.go
+++ b/tools/activity.go
@@ -16,17 +16,17 @@ import (
 )
 
 type GetNextActivityParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine cible ; si absent, le dernier domaine actif de l'apprenant est utilisé"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"target domain ID; if absent, the learner's last active domain is used"`
 }
 
 func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_next_activity",
-		Description: "Détermine la prochaine activité optimale pour l'apprenant et agrège tout le contexte de routage nécessaire : miroir métacognitif, mode tuteur, brief de motivation, misconceptions actives. Tient compte de la session en cours pour éviter de répéter le même concept. " +
-			"Quand appeler : APRÈS get_pending_alerts, dès qu'aucune alerte critique ne bloque la suite et que l'apprenant a un domaine actif. C'est l'outil principal du cycle d'apprentissage. " +
-			"Quand NE PAS appeler : si get_pending_alerts a renvoyé needs_domain_setup=true (appelez init_domain d'abord) ; n'appelez pas get_metacognitive_mirror dans le même tour, le miroir est déjà inclus dans la clé metacognitive_mirror du retour. " +
-			"Précondition : un domaine doit exister ; sinon needs_domain_setup=true est renvoyé avec une activité de type setup_domain. " +
-			"Retour : {needs_domain_setup, domain_id, activity, session_concepts_done, metacognitive_mirror, tutor_mode, active_misconceptions, known_misconception_types, motivation_brief}.",
+		Description: "Determine the next optimal activity for the learner and aggregate all routing context: metacognitive_mirror, tutor_mode, motivation_brief, active misconceptions. Accounts for the current session to avoid repeating the same concept. " +
+			"When to call: AFTER get_pending_alerts, once no critical alert is blocking progress and the learner has an active domain. This is the main tool of the learning cycle. " +
+			"When NOT to call: if get_pending_alerts returned needs_domain_setup=true (call init_domain first); do not call get_metacognitive_mirror in the same turn — the mirror is already included in the metacognitive_mirror key of the response. " +
+			"Precondition: a domain must exist; otherwise needs_domain_setup=true is returned with a setup_domain activity. " +
+			"Returns: {needs_domain_setup, domain_id, activity, session_concepts_done, metacognitive_mirror, tutor_mode, active_misconceptions, known_misconception_types, motivation_brief}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetNextActivityParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/affect.go
+++ b/tools/affect.go
@@ -16,18 +16,18 @@ import (
 )
 
 type RecordAffectParams struct {
-	SessionID           string `json:"session_id" jsonschema:"Identifiant unique de la session"`
-	Energy              int    `json:"energy,omitempty" jsonschema:"Énergie disponible: 1=fatigué, 2=neutre, 3=motivé, 4=en feu"`
-	Confidence          int    `json:"confidence,omitempty" jsonschema:"Confiance sur le sujet: 1=anxieux, 2=flou, 3=ok, 4=confiant"`
-	Satisfaction        int    `json:"satisfaction,omitempty" jsonschema:"Ressenti global (fin de session): 1=frustrant, 2=difficile, 3=bien, 4=flow"`
-	PerceivedDifficulty int    `json:"perceived_difficulty,omitempty" jsonschema:"Difficulté perçue (fin de session): 1=trop dur, 2=challengeant, 3=ok, 4=trop facile"`
-	NextSessionIntent   int    `json:"next_session_intent,omitempty" jsonschema:"Prochaine session: 1=maintenant, 2=demain, 3=cette semaine, 4=je sais pas"`
+	SessionID           string `json:"session_id" jsonschema:"unique session identifier"`
+	Energy              int    `json:"energy,omitempty" jsonschema:"available energy: 1=tired, 2=neutral, 3=motivated, 4=on fire"`
+	Confidence          int    `json:"confidence,omitempty" jsonschema:"subject confidence: 1=anxious, 2=foggy, 3=ok, 4=confident"`
+	Satisfaction        int    `json:"satisfaction,omitempty" jsonschema:"overall feeling (end of session): 1=frustrating, 2=hard, 3=good, 4=flow"`
+	PerceivedDifficulty int    `json:"perceived_difficulty,omitempty" jsonschema:"perceived difficulty (end of session): 1=too hard, 2=challenging, 3=ok, 4=too easy"`
+	NextSessionIntent   int    `json:"next_session_intent,omitempty" jsonschema:"next session intent: 1=now, 2=tomorrow, 3=this week, 4=not sure"`
 }
 
 func registerRecordAffect(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_affect",
-		Description: "Enregistre l'état émotionnel de l'apprenant. Appeler en début de session (energy, confidence) et en fin (satisfaction, perceived_difficulty, next_session_intent).",
+		Description: "Record the learner's emotional state. Call at session start (energy, confidence) and at session end (satisfaction, perceived_difficulty, next_session_intent).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordAffectParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -14,17 +14,17 @@ import (
 )
 
 type GetPendingAlertsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine pour cibler les alertes activité ; si absent, agrège sur tous les domaines actifs de l'apprenant"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID to scope activity alerts; if absent, aggregates across all active domains of the learner"`
 }
 
 func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_pending_alerts",
-		Description: "Récupère TOUTES les alertes en attente pour l'apprenant — alertes d'activité (PLATEAU, FATIGUE, …) ET alertes métacognitives (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE, TRANSFER_BLOCKED). " +
-			"Quand appeler : EN PREMIER à chaque tour, avant tout autre outil de lecture. Si une alerte critique remonte (has_critical=true), la traiter avant de poursuivre. " +
-			"Quand NE PAS appeler : une seule fois par tour suffit ; les alertes métacognitives sont déjà incluses ici, n'appelez pas un outil séparé pour les obtenir. " +
-			"Précondition : si l'apprenant n'a aucun domaine actif, retourne needs_domain_setup=true et une liste alerts vide — appelez init_domain avant de continuer. " +
-			"Retour : {alerts: [...], has_critical: bool, needs_domain_setup: bool}.",
+		Description: "Retrieve ALL pending alerts for the learner — activity alerts (PLATEAU, FATIGUE, …) AND metacognitive alerts (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE, TRANSFER_BLOCKED). " +
+			"When to call: FIRST each turn, before any other read tool. If a critical alert surfaces (has_critical=true), handle it before proceeding. " +
+			"When NOT to call: once per turn is sufficient; metacognitive alerts are already included here — do not call a separate tool to retrieve them. " +
+			"Precondition: if the learner has no active domain, returns needs_domain_setup=true and an empty alerts list — call init_domain before continuing. " +
+			"Returns: {alerts: [...], has_critical: bool, needs_domain_setup: bool}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetPendingAlertsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/autonomy.go
+++ b/tools/autonomy.go
@@ -14,13 +14,13 @@ import (
 )
 
 type GetAutonomyMetricsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si fourni, les métriques d'autonomie computées sur les interactions et états sont restreintes à ce domaine. La tendance reste learner-wide (signal cross-session)."`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional). If provided, autonomy metrics computed over interactions and states are restricted to that domain. The trend remains learner-wide (cross-session signal)."`
 }
 
 func registerGetAutonomyMetrics(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_autonomy_metrics",
-		Description: "Score d'autonomie courant avec ses 4 composantes et la tendance. Consultable par l'apprenant et le système.",
+		Description: "Current autonomy score with its 4 components and trend. Readable by the learner and the system.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetAutonomyMetricsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/availability.go
+++ b/tools/availability.go
@@ -19,7 +19,7 @@ type GetAvailabilityModelParams struct{}
 func registerGetAvailabilityModel(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_availability_model",
-		Description: "Récupère le modèle de disponibilité de l'apprenant (créneaux, durée moyenne, fréquence).",
+		Description: "Retrieve the learner's availability model (time slots, average session duration, frequency).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetAvailabilityModelParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/calibration.go
+++ b/tools/calibration.go
@@ -16,15 +16,15 @@ import (
 )
 
 type CalibrationCheckParams struct {
-	ConceptID        string  `json:"concept_id" jsonschema:"Le concept à évaluer"`
-	PredictedMastery float64 `json:"predicted_mastery" jsonschema:"Auto-évaluation de l'apprenant: 1=aucune maîtrise, 5=maîtrise parfaite"`
-	DomainID         string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	ConceptID        string  `json:"concept_id" jsonschema:"the concept to assess"`
+	PredictedMastery float64 `json:"predicted_mastery" jsonschema:"learner self-assessment: 1=no mastery, 5=perfect mastery"`
+	DomainID         string  `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "calibration_check",
-		Description: "Enregistre l'auto-évaluation de l'apprenant sur un concept avant un exercice. Retourne un prediction_id pour comparaison post-exercice.",
+		Description: "Record the learner's self-assessment on a concept before an exercise. Returns a prediction_id for post-exercise comparison.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CalibrationCheckParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -95,14 +95,14 @@ func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 }
 
 type RecordCalibrationResultParams struct {
-	PredictionID string  `json:"prediction_id" jsonschema:"ID de la prédiction retournée par calibration_check"`
-	ActualScore  float64 `json:"actual_score" jsonschema:"Score réel entre 0 et 1 (0=échec total, 1=réussite parfaite)"`
+	PredictionID string  `json:"prediction_id" jsonschema:"prediction ID returned by calibration_check"`
+	ActualScore  float64 `json:"actual_score" jsonschema:"actual score between 0 and 1 (0=total failure, 1=perfect success)"`
 }
 
 func registerRecordCalibrationResult(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_calibration_result",
-		Description: "Compare la prédiction de l'apprenant avec le résultat réel. Met à jour le biais de calibration.",
+		Description: "Compare the learner's prediction with the actual result. Updates the calibration bias.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordCalibrationResultParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/context.go
+++ b/tools/context.go
@@ -18,13 +18,13 @@ import (
 )
 
 type GetLearnerContextParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine si absent)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional; last active domain used if absent)"`
 }
 
 func registerGetLearnerContext(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_learner_context",
-		Description: "Récupère le contexte complet de l'apprenant pour le début de session.",
+		Description: "Retrieve the full learner context for session start.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetLearnerContextParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/domain.go
+++ b/tools/domain.go
@@ -225,24 +225,24 @@ func validateValueFramings(vf *ValueFramingsInput) error {
 }
 
 type ValueFramingsInput struct {
-	Financial    string `json:"financial,omitempty" jsonschema:"Gain financier (1-2 phrases)"`
-	Employment   string `json:"employment,omitempty" jsonschema:"Gain employabilité / carrière (1-2 phrases)"`
-	Intellectual string `json:"intellectual,omitempty" jsonschema:"Gain intellectuel / beau raisonnement (1-2 phrases)"`
-	Innovation   string `json:"innovation,omitempty" jsonschema:"Gain création / innovation (1-2 phrases)"`
+	Financial    string `json:"financial,omitempty" jsonschema:"financial gain (1-2 sentences)"`
+	Employment   string `json:"employment,omitempty" jsonschema:"employability / career gain (1-2 sentences)"`
+	Intellectual string `json:"intellectual,omitempty" jsonschema:"intellectual / reasoning gain (1-2 sentences)"`
+	Innovation   string `json:"innovation,omitempty" jsonschema:"creation / innovation gain (1-2 sentences)"`
 }
 
 type InitDomainParams struct {
-	Name          string              `json:"name" jsonschema:"Nom du domaine d'apprentissage"`
-	Concepts      []string            `json:"concepts" jsonschema:"Liste des concepts du domaine"`
-	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Graphe de prérequis (concept -> liste de prérequis)"`
-	PersonalGoal  string              `json:"personal_goal,omitempty" jsonschema:"Objectif personnel de l'apprenant dans ce domaine (optionnel)"`
-	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 axes de valeur (financier/emploi/intellectuel/innovation). 1-2 phrases authored par axe. Optionnel — peut être rempli à la volée par la suite."`
+	Name          string              `json:"name" jsonschema:"learning domain name"`
+	Concepts      []string            `json:"concepts" jsonschema:"list of domain concepts"`
+	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"prerequisite graph (concept -> list of prerequisites)"`
+	PersonalGoal  string              `json:"personal_goal,omitempty" jsonschema:"learner's personal goal within this domain (optional)"`
+	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 value axes (financial/employment/intellectual/innovation). 1-2 sentences per axis. Optional — can be filled in later."`
 }
 
 func registerInitDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "init_domain",
-		Description: "Initialise un domaine d'apprentissage avec ses concepts et prérequis. Ne détruit pas la progression existante.",
+		Description: "Initialize a learning domain with its concepts and prerequisites. Does not destroy existing progress.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params InitDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -358,15 +358,15 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 // ─── Add Concepts ────────────────────────────────────────────────────────────
 
 type AddConceptsParams struct {
-	DomainID      string              `json:"domain_id" jsonschema:"ID du domaine cible"`
-	Concepts      []string            `json:"concepts" jsonschema:"Nouveaux concepts à ajouter"`
-	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"Nouveaux prérequis (concept -> liste de prérequis). Peut inclure des liens vers des concepts existants."`
+	DomainID      string              `json:"domain_id" jsonschema:"target domain ID"`
+	Concepts      []string            `json:"concepts" jsonschema:"new concepts to add"`
+	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"new prerequisites (concept -> list of prerequisites). May include links to existing concepts."`
 }
 
 func registerAddConcepts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "add_concepts",
-		Description: "Ajoute des concepts à un domaine existant sans détruire la progression. Utiliser pour enrichir un domaine en cours de route.",
+		Description: "Add concepts to an existing domain without destroying progress. Use to enrich a domain mid-course.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AddConceptsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -14,14 +14,14 @@ import (
 )
 
 type FeynmanChallengeParams struct {
-	ConceptID string `json:"concept_id" jsonschema:"Le concept à expliquer avec la méthode Feynman"`
-	DomainID  string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	ConceptID string `json:"concept_id" jsonschema:"the concept to explain using the Feynman method"`
+	DomainID  string `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "feynman_challenge",
-		Description: "Demande à l'apprenant d'expliquer un concept maîtrisé avec ses propres mots. Le LLM identifie les gaps et les injecte dans le graphe BKT.",
+		Description: "Ask the learner to explain a mastered concept in their own words. The LLM identifies gaps and injects them into the BKT graph.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params FeynmanChallengeParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/get_dashboard_state.go
+++ b/tools/get_dashboard_state.go
@@ -17,8 +17,8 @@ import (
 )
 
 type GetDashboardStateParams struct {
-	DomainID        string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si absent, agrège tous les domaines actifs."`
-	IncludeArchived bool   `json:"include_archived,omitempty" jsonschema:"Si true, inclut les domaines archivés dans la réponse."`
+	DomainID        string `json:"domain_id,omitempty" jsonschema:"domain ID (optional). If absent, aggregates all active domains."`
+	IncludeArchived bool   `json:"include_archived,omitempty" jsonschema:"if true, includes archived domains in the response."`
 }
 
 type conceptProgress struct {
@@ -44,7 +44,7 @@ type domainDashboard struct {
 func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_dashboard_state",
-		Description: "Retourne l'état d'apprentissage en JSON structuré (progression par concept, alertes de rétention, signal de trajectoire, métriques d'autonomie, prochaine action). Le LLM peut formuler la réponse texte à partir de ce JSON pour l'apprenant.",
+		Description: "Return the learning state as structured JSON (per-concept progress, retention alerts, trajectory signal, autonomy metrics, next action). The LLM can formulate a text response from this JSON for the learner.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetDashboardStateParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/goal_relevance.go
+++ b/tools/goal_relevance.go
@@ -36,8 +36,8 @@ const (
 // ─── set_goal_relevance ──────────────────────────────────────────────────────
 
 type SetGoalRelevanceParams struct {
-	DomainID  string             `json:"domain_id,omitempty" jsonschema:"ID du domaine cible (optionnel, dernier domaine actif si absent)"`
-	Relevance map[string]float64 `json:"relevance" jsonschema:"Map concept_id -> score [0,1]. Concepts inconnus produisent une erreur explicite. Sémantique incrémentale : seuls les concepts fournis sont mis à jour."`
+	DomainID  string             `json:"domain_id,omitempty" jsonschema:"target domain ID (optional; last active domain if absent)"`
+	Relevance map[string]float64 `json:"relevance" jsonschema:"map of concept_id -> score [0,1]. Unknown concepts produce an explicit error. Incremental semantics: only provided concepts are updated."`
 }
 
 func registerSetGoalRelevance(server *mcp.Server, deps *Deps) {
@@ -46,11 +46,10 @@ func registerSetGoalRelevance(server *mcp.Server, deps *Deps) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "set_goal_relevance",
-		Description: "Décompose le personal_goal du learner contre les concepts du domaine. " +
-			"Pour chaque concept, fournis un score dans [0,1] : 1.0 = central au goal, " +
-			"0.0 = orthogonal. Sémantique incrémentale (merge) : seuls les concepts fournis " +
-			"sont mis à jour, les autres conservent leur score précédent. Concept inconnu " +
-			"(absent du graph) renvoie une erreur explicite.",
+		Description: "Decompose the learner's personal_goal against the domain's concepts. " +
+			"For each concept, provide a score in [0,1]: 1.0 = central to the goal, " +
+			"0.0 = orthogonal. Incremental semantics (merge): only provided concepts are updated, " +
+			"others retain their previous score. An unknown concept (absent from the graph) returns an explicit error.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params SetGoalRelevanceParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -165,7 +164,7 @@ func registerSetGoalRelevance(server *mcp.Server, deps *Deps) {
 // ─── get_goal_relevance ──────────────────────────────────────────────────────
 
 type GetGoalRelevanceParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 func registerGetGoalRelevance(server *mcp.Server, deps *Deps) {
@@ -174,9 +173,8 @@ func registerGetGoalRelevance(server *mcp.Server, deps *Deps) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_goal_relevance",
-		Description: "Lit le vecteur de pertinence stocké pour un domaine et la liste des " +
-			"concepts encore sans relevance. Outil d'observation : utiliser pour décider s'il " +
-			"faut compléter avec set_goal_relevance (ex: après add_concepts).",
+		Description: "Read the stored relevance vector for a domain and the list of concepts not yet covered. " +
+			"Observation tool: use to decide whether to complete with set_goal_relevance (e.g. after add_concepts).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetGoalRelevanceParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -15,25 +15,25 @@ import (
 )
 
 type RecordInteractionParams struct {
-	Concept             string  `json:"concept" jsonschema:"Le concept concerné"`
-	ActivityType        string  `json:"activity_type" jsonschema:"Type d'activité — DOIT être l'une des valeurs canoniques: RECALL_EXERCISE, NEW_CONCEPT, MASTERY_CHALLENGE, DEBUGGING_CASE, REST, SETUP_DOMAIN, PRACTICE, DEBUG_MISCONCEPTION, FEYNMAN_PROMPT, TRANSFER_PROBE, CLOSE_SESSION"`
-	Success             bool    `json:"success" jsonschema:"L'exercice a été réussi"`
-	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"Temps de réponse en secondes"`
-	Confidence          float64 `json:"confidence" jsonschema:"Confiance estimée entre 0 et 1"`
-	ErrorType           string  `json:"error_type,omitempty" jsonschema:"Type d'erreur si échec — laisser vide ou utiliser exactement: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP"`
-	Notes               string  `json:"notes" jsonschema:"Notes optionnelles sur l'interaction"`
-	DomainID            string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
-	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"Nombre d'indices demandés pendant l'échange (optionnel, défaut 0)"`
-	SelfInitiated       bool    `json:"self_initiated,omitempty" jsonschema:"true si la session a démarré sans alerte webhook"`
-	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"ID de la prédiction de calibration associée (optionnel)"`
-	MisconceptionType   string  `json:"misconception_type,omitempty" jsonschema:"Label libre de la misconception détectée (optionnel, ignoré si success=true)"`
-	MisconceptionDetail string  `json:"misconception_detail,omitempty" jsonschema:"Description de la misconception en une phrase (optionnel)"`
+	Concept             string  `json:"concept" jsonschema:"the concept being practiced"`
+	ActivityType        string  `json:"activity_type" jsonschema:"activity type — MUST be one of the canonical values: RECALL_EXERCISE, NEW_CONCEPT, MASTERY_CHALLENGE, DEBUGGING_CASE, REST, SETUP_DOMAIN, PRACTICE, DEBUG_MISCONCEPTION, FEYNMAN_PROMPT, TRANSFER_PROBE, CLOSE_SESSION"`
+	Success             bool    `json:"success" jsonschema:"whether the exercise was completed successfully"`
+	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"response time in seconds"`
+	Confidence          float64 `json:"confidence" jsonschema:"estimated confidence between 0 and 1"`
+	ErrorType           string  `json:"error_type,omitempty" jsonschema:"error type on failure — leave empty or use exactly: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP"`
+	Notes               string  `json:"notes" jsonschema:"optional notes about the interaction"`
+	DomainID            string  `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
+	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"number of hints requested during the exchange (optional, default 0)"`
+	SelfInitiated       bool    `json:"self_initiated,omitempty" jsonschema:"true if the session started without a webhook alert"`
+	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"ID of the associated calibration prediction (optional)"`
+	MisconceptionType   string  `json:"misconception_type,omitempty" jsonschema:"free-form label of the detected misconception (optional, ignored if success=true)"`
+	MisconceptionDetail string  `json:"misconception_detail,omitempty" jsonschema:"one-sentence description of the misconception (optional)"`
 }
 
 func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_interaction",
-		Description: "Enregistre le résultat d'un exercice et met à jour l'état cognitif de l'apprenant. Supporte error_type pour ajuster le BKT selon le type d'erreur.",
+		Description: "Record the result of an exercise and update the learner's cognitive state. Supports error_type to adjust the BKT model according to the error type.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordInteractionParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -25,7 +25,7 @@ type RecordInteractionParams struct {
 	DomainID            string  `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"number of hints requested during the exchange (optional, default 0)"`
 	SelfInitiated       bool    `json:"self_initiated,omitempty" jsonschema:"true if the session started without a webhook alert"`
-	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"ID of the associated calibration prediction (optional)"`
+	CalibrationID       string  `json:"calibration_id,omitempty" jsonschema:"id of the associated calibration prediction (optional)"`
 	MisconceptionType   string  `json:"misconception_type,omitempty" jsonschema:"free-form label of the detected misconception (optional, ignored if success=true)"`
 	MisconceptionDetail string  `json:"misconception_detail,omitempty" jsonschema:"one-sentence description of the misconception (optional)"`
 }

--- a/tools/manage_domain.go
+++ b/tools/manage_domain.go
@@ -12,13 +12,13 @@ import (
 )
 
 type ArchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine à archiver"`
+	DomainID string `json:"domain_id" jsonschema:"ID of the domain to archive"`
 }
 
 func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "archive_domain",
-		Description: "Archive un domaine — il disparaît du dashboard et du routing mais la progression est préservée. Utiliser unarchive_domain pour le réactiver.",
+		Description: "Archive a domain — it disappears from the dashboard and routing but progress is preserved. Use unarchive_domain to reactivate it.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ArchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -60,13 +60,13 @@ func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 }
 
 type UnarchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine à réactiver"`
+	DomainID string `json:"domain_id" jsonschema:"ID of the domain to reactivate"`
 }
 
 func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "unarchive_domain",
-		Description: "Réactive un domaine archivé — il réapparaît dans le dashboard et le routing avec toute sa progression préservée.",
+		Description: "Reactivate an archived domain — it reappears in the dashboard and routing with all its progress preserved.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UnarchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -107,14 +107,14 @@ func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 }
 
 type DeleteDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID du domaine à supprimer définitivement"`
-	Confirm  bool   `json:"confirm" jsonschema:"Doit être true pour confirmer la suppression"`
+	DomainID string `json:"domain_id" jsonschema:"ID of the domain to permanently delete"`
+	Confirm  bool   `json:"confirm" jsonschema:"must be true to confirm deletion"`
 }
 
 func registerDeleteDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete_domain",
-		Description: "Supprime définitivement un domaine. Les concept_states et interactions sont préservés. Nécessite confirm=true.",
+		Description: "Permanently delete a domain. The concept_states and interactions are preserved. Requires confirm=true.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params DeleteDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/manage_domain.go
+++ b/tools/manage_domain.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ArchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID of the domain to archive"`
+	DomainID string `json:"domain_id" jsonschema:"id of the domain to archive"`
 }
 
 func registerArchiveDomain(server *mcp.Server, deps *Deps) {
@@ -60,7 +60,7 @@ func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 }
 
 type UnarchiveDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID of the domain to reactivate"`
+	DomainID string `json:"domain_id" jsonschema:"id of the domain to reactivate"`
 }
 
 func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
@@ -107,7 +107,7 @@ func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 }
 
 type DeleteDomainParams struct {
-	DomainID string `json:"domain_id" jsonschema:"ID of the domain to permanently delete"`
+	DomainID string `json:"domain_id" jsonschema:"id of the domain to permanently delete"`
 	Confirm  bool   `json:"confirm" jsonschema:"must be true to confirm deletion"`
 }
 

--- a/tools/mastery.go
+++ b/tools/mastery.go
@@ -14,14 +14,14 @@ import (
 )
 
 type CheckMasteryParams struct {
-	Concept  string `json:"concept" jsonschema:"Le concept à vérifier pour la maîtrise"`
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	Concept  string `json:"concept" jsonschema:"the concept to check for mastery"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 func registerCheckMastery(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "check_mastery",
-		Description: "Vérifie si un concept est prêt pour le mastery challenge (BKT >= 0.85).",
+		Description: "Check whether a concept is ready for the mastery challenge (BKT >= 0.85).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CheckMasteryParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/mirror.go
+++ b/tools/mirror.go
@@ -14,17 +14,17 @@ import (
 )
 
 type GetMetacognitiveMirrorParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel). Si fourni, le miroir est restreint aux interactions et états de concept de ce domaine. Si absent, le calcul reste learner-wide."`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional). If provided, the mirror is restricted to interactions and concept states of that domain. If absent, the computation remains learner-wide."`
 }
 
 func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_metacognitive_mirror",
-		Description: "Retourne un message miroir factuel si un pattern de dépendance est consolidé sur les 7 derniers jours, sinon mirror=null. Outil de réflexion métacognitive à la demande. " +
-			"Quand appeler : UNIQUEMENT hors du cycle d'activité — par exemple lors d'une demande explicite de bilan métacognitif, ou si l'apprenant interroge ses propres patterns d'apprentissage. " +
-			"Quand NE PAS appeler : si get_next_activity a déjà été appelé dans le même tour, le miroir est déjà présent dans sa clé metacognitive_mirror — un second appel ici fait du travail dupliqué (même calcul, même file webhook dédupliquée par jour). " +
-			"Précondition : aucune ; si aucun pattern n'est détecté, mirror=null est renvoyé sans erreur. " +
-			"Retour : {mirror: <objet ou null>}.",
+		Description: "Return a factual mirror message if a dependency pattern is consolidated over the last 7 days, otherwise mirror=null. On-demand metacognitive reflection tool. " +
+			"When to call: ONLY outside the activity cycle — for example, on an explicit request for a metacognitive review, or when the learner asks about their own learning patterns. " +
+			"When NOT to call: if get_next_activity was already called in the same turn, the mirror is already present in its metacognitive_mirror key — a second call here duplicates work (same computation, same webhook queue deduplicated per day). " +
+			"Precondition: none; if no pattern is detected, mirror=null is returned without error. " +
+			"Returns: {mirror: <object or null>}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMetacognitiveMirrorParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/misconceptions.go
+++ b/tools/misconceptions.go
@@ -14,14 +14,14 @@ import (
 )
 
 type GetMisconceptionsParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, tous les domaines si absent)"`
-	Concept  string `json:"concept,omitempty" jsonschema:"Filtre par concept (optionnel)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional; all domains if absent)"`
+	Concept  string `json:"concept,omitempty" jsonschema:"filter by concept (optional)"`
 }
 
 func registerGetMisconceptions(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_misconceptions",
-		Description: "Liste les misconceptions détectées par concept, avec leur statut (active/resolved) et fréquence. Permet de suivre les confusions récurrentes de l'apprenant.",
+		Description: "List misconceptions detected per concept, with their status (active/resolved) and frequency. Enables tracking of the learner's recurring confusions.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMisconceptionsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -17,10 +17,10 @@ import (
 )
 
 type LearningNegotiationParams struct {
-	SessionID        string `json:"session_id" jsonschema:"ID de la session courante"`
-	LearnerConcept   string `json:"learner_concept,omitempty" jsonschema:"Concept proposé par l'apprenant (optionnel)"`
-	LearnerRationale string `json:"learner_rationale,omitempty" jsonschema:"Justification de l'apprenant (optionnel)"`
-	DomainID         string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	SessionID        string `json:"session_id" jsonschema:"current session ID"`
+	LearnerConcept   string `json:"learner_concept,omitempty" jsonschema:"concept proposed by the learner (optional)"`
+	LearnerRationale string `json:"learner_rationale,omitempty" jsonschema:"learner's rationale (optional)"`
+	DomainID         string `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 type tradeoff struct {
@@ -33,7 +33,7 @@ type tradeoff struct {
 func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "learning_negotiation",
-		Description: "Expose le plan de session avec justifications. L'apprenant peut proposer une alternative — le système accepte ou explique les compromis.",
+		Description: "Expose the session plan with rationale. The learner can propose an alternative — the system accepts or explains the trade-offs.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params LearningNegotiationParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/olm.go
+++ b/tools/olm.go
@@ -12,14 +12,14 @@ import (
 )
 
 type GetOLMSnapshotParams struct {
-	DomainID string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel, utilisé le dernier domaine actif si absent)"`
-	Scope    string `json:"scope,omitempty" jsonschema:"'session' (défaut, snapshot d'un domaine) ou 'global' (agrégation multi-domaine)"`
+	DomainID string `json:"domain_id,omitempty" jsonschema:"domain ID (optional; last active domain used if absent)"`
+	Scope    string `json:"scope,omitempty" jsonschema:"'session' (default, single-domain snapshot) or 'global' (multi-domain aggregation)"`
 }
 
 func registerGetOLMSnapshot(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_olm_snapshot",
-		Description: "Retourne un snapshot transparent de l'état d'apprentissage : distribution mastery, concept en focus, signaux métacognitifs actifs, progression vers le goal. Apprenant et tuteur regardent les mêmes données. Appeler avant queue_webhook_message(kind='olm:<domain_id>') ou pour reflet métacognitif en session.",
+		Description: "Return a transparent snapshot of the learning state: mastery distribution, focus concept, active metacognitive signals, progress toward the goal. Learner and tutor see the same data. Call before queue_webhook_message(kind='olm:<domain_id>') or for in-session metacognitive reflection.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetOLMSnapshotParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/profile.go
+++ b/tools/profile.go
@@ -27,18 +27,18 @@ import (
 // for ImplementationIntention in record_session_close. The ,omitempty on
 // the JSON tag is dropped because nil already serialises to absent.
 type UpdateLearnerProfileParams struct {
-	Device          string   `json:"device,omitempty" jsonschema:"Appareil principal (ex: laptop, phone, tablet)"`
-	Objective       string   `json:"objective,omitempty" jsonschema:"Objectif d'apprentissage mis à jour"`
-	Language        string   `json:"language,omitempty" jsonschema:"Langue préférée pour les exercices"`
-	CalibrationBias *float64 `json:"calibration_bias,omitempty" jsonschema:"Biais de calibration (positif=sur-estimé, négatif=sous-estimé). Fournir explicitement pour écraser; omettre pour laisser inchangé. 0 = calibration parfaite."`
-	AffectBaseline  string   `json:"affect_baseline,omitempty" jsonschema:"Baseline émotionnelle de l'apprenant"`
-	AutonomyScore   *float64 `json:"autonomy_score,omitempty" jsonschema:"Score d'autonomie actuel (0-1). Fournir explicitement pour écraser; omettre pour laisser inchangé. 0 = totalement dépendant."`
+	Device          string   `json:"device,omitempty" jsonschema:"primary device (e.g. laptop, phone, tablet)"`
+	Objective       string   `json:"objective,omitempty" jsonschema:"updated learning objective"`
+	Language        string   `json:"language,omitempty" jsonschema:"preferred language for exercises (BCP-47 hint to the LLM)"`
+	CalibrationBias *float64 `json:"calibration_bias,omitempty" jsonschema:"calibration bias (positive=over-estimated, negative=under-estimated). Provide explicitly to overwrite; omit to leave unchanged. 0 = perfect calibration."`
+	AffectBaseline  string   `json:"affect_baseline,omitempty" jsonschema:"learner's emotional baseline"`
+	AutonomyScore   *float64 `json:"autonomy_score,omitempty" jsonschema:"current autonomy score (0-1). Provide explicitly to overwrite; omit to leave unchanged. 0 = fully dependent."`
 }
 
 func registerUpdateLearnerProfile(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_learner_profile",
-		Description: "Met à jour les métadonnées persistantes de l'apprenant (device, objectif, langue, calibration, affect, autonomie). Seuls les champs fournis sont modifiés.",
+		Description: "Update the learner's persistent metadata (device, objective, language, calibration, affect, autonomy). Only provided fields are modified.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UpdateLearnerProfileParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/queue_webhook.go
+++ b/tools/queue_webhook.go
@@ -16,11 +16,11 @@ import (
 )
 
 type QueueWebhookMessageParams struct {
-	Kind         string `json:"kind" jsonschema:"Type de nudge : daily_motivation | daily_recap | reactivation | reminder | mirror_message | olm:<domain_id> (snapshot OLM par domaine)"`
-	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 timestamp UTC de la fenêtre de tir (ex: 2026-04-13T08:00:00Z)"`
-	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 timestamp UTC après lequel le message ne doit plus être envoyé"`
-	Content      string `json:"content" jsonschema:"Contenu Markdown prêt à poster sur le webhook Discord (max ~300 caractères recommandé)"`
-	Priority     int    `json:"priority,omitempty" jsonschema:"Priorité (plus grand = plus prioritaire, défaut 0)"`
+	Kind         string `json:"kind" jsonschema:"nudge type: daily_motivation | daily_recap | reactivation | reminder | mirror_message | olm:<domain_id> (per-domain OLM snapshot)"`
+	ScheduledFor string `json:"scheduled_for" jsonschema:"UTC ISO 8601 timestamp for the delivery window (e.g. 2026-04-13T08:00:00Z)"`
+	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"UTC ISO 8601 timestamp after which the message must not be sent"`
+	Content      string `json:"content" jsonschema:"Markdown content ready to post to the Discord webhook (max ~300 characters recommended)"`
+	Priority     int    `json:"priority,omitempty" jsonschema:"priority (higher = more important, default 0)"`
 }
 
 const maxWebhookContentLen = 1500
@@ -28,7 +28,7 @@ const maxWebhookContentLen = 1500
 func registerQueueWebhookMessage(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "queue_webhook_message",
-		Description: "Met en queue un message de nudge que le scheduler postera sur le webhook Discord de l'apprenant à la fenêtre voulue. Le LLM compose le texte (chaleureux, sans KPI brut) ; le scheduler dispatche.",
+		Description: "Queue a nudge message that the scheduler will post to the learner's Discord webhook at the desired window. The LLM composes the text (warm, no raw KPIs); the scheduler dispatches.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params QueueWebhookMessageParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/queue_webhook.go
+++ b/tools/queue_webhook.go
@@ -17,9 +17,9 @@ import (
 
 type QueueWebhookMessageParams struct {
 	Kind         string `json:"kind" jsonschema:"nudge type: daily_motivation | daily_recap | reactivation | reminder | mirror_message | olm:<domain_id> (per-domain OLM snapshot)"`
-	ScheduledFor string `json:"scheduled_for" jsonschema:"UTC ISO 8601 timestamp for the delivery window (e.g. 2026-04-13T08:00:00Z)"`
-	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"UTC ISO 8601 timestamp after which the message must not be sent"`
-	Content      string `json:"content" jsonschema:"Markdown content ready to post to the Discord webhook (max ~300 characters recommended)"`
+	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 UTC timestamp for the delivery window (e.g. 2026-04-13T08:00:00Z)"`
+	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 UTC timestamp after which the message must not be sent"`
+	Content      string `json:"content" jsonschema:"markdown content ready to post to the Discord webhook (max ~300 characters recommended)"`
 	Priority     int    `json:"priority,omitempty" jsonschema:"priority (higher = more important, default 0)"`
 }
 

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -15,20 +15,20 @@ import (
 )
 
 type ImplementationIntentionInput struct {
-	Trigger      string `json:"trigger" jsonschema:"Clause 'quand' (ex: 'demain matin au café')"`
-	Action       string `json:"action" jsonschema:"Clause 'alors je' (ex: 'ferai 1 exercice de dérivées')"`
-	ScheduledFor string `json:"scheduled_for,omitempty" jsonschema:"ISO 8601 timestamp optionnel (UTC)"`
+	Trigger      string `json:"trigger" jsonschema:"'when' clause (e.g. 'tomorrow morning at the coffee shop')"`
+	Action       string `json:"action" jsonschema:"'then I will' clause (e.g. 'do 1 derivatives exercise')"`
+	ScheduledFor string `json:"scheduled_for,omitempty" jsonschema:"optional ISO 8601 timestamp (UTC)"`
 }
 
 type RecordSessionCloseParams struct {
-	DomainID                 string                        `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
-	ImplementationIntention  *ImplementationIntentionInput `json:"implementation_intention,omitempty" jsonschema:"Engagement if-then optionnel (Gollwitzer)"`
+	DomainID                string                        `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
+	ImplementationIntention *ImplementationIntentionInput `json:"implementation_intention,omitempty" jsonschema:"optional if-then commitment (Gollwitzer)"`
 }
 
 func registerRecordSessionClose(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_session_close",
-		Description: "Clôture la session : enregistre optionnellement une implementation intention (if-then) et retourne des signaux structurés pour composer le message de fin (concepts pratiqués, wins, intent prompt, message queue filler).",
+		Description: "Close the session: optionally record an implementation intention (if-then) and return structured signals for composing the closing message (concepts practiced, wins, intent prompt, message queue filler).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordSessionCloseParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -15,15 +15,15 @@ import (
 )
 
 type TransferChallengeParams struct {
-	ConceptID   string `json:"concept_id" jsonschema:"Le concept à tester en transfert"`
-	ContextType string `json:"context_type,omitempty" jsonschema:"Type de contexte: real_world, interview, teaching, debugging, creative (optionnel)"`
-	DomainID    string `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	ConceptID   string `json:"concept_id" jsonschema:"the concept to test in transfer"`
+	ContextType string `json:"context_type,omitempty" jsonschema:"context type: real_world, interview, teaching, debugging, creative (optional)"`
+	DomainID    string `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "transfer_challenge",
-		Description: "Génère une situation inédite pour tester le transfert d'un concept maîtrisé hors du contexte initial.",
+		Description: "Generate a novel situation to test the transfer of a mastered concept outside its original context.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params TransferChallengeParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -109,11 +109,11 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 // ─── record_transfer_result ─────────────────────────────────────────────────
 
 type RecordTransferResultParams struct {
-	ConceptID   string  `json:"concept_id" jsonschema:"Le concept testé"`
-	ContextType string  `json:"context_type" jsonschema:"Type de contexte du challenge: real_world, interview, teaching, debugging, creative"`
-	Score       float64 `json:"score" jsonschema:"Score de transfert entre 0 et 1"`
-	SessionID   string  `json:"session_id,omitempty" jsonschema:"ID de session (optionnel)"`
-	DomainID    string  `json:"domain_id,omitempty" jsonschema:"ID du domaine (optionnel)"`
+	ConceptID   string  `json:"concept_id" jsonschema:"the concept being tested"`
+	ContextType string  `json:"context_type" jsonschema:"challenge context type: real_world, interview, teaching, debugging, creative"`
+	Score       float64 `json:"score" jsonschema:"transfer score between 0 and 1"`
+	SessionID   string  `json:"session_id,omitempty" jsonschema:"session ID (optional)"`
+	DomainID    string  `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 }
 
 // allowedRecordTransferContextTypes enumerates the documented context_type
@@ -128,7 +128,7 @@ var allowedRecordTransferContextTypes = []string{
 func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_transfer_result",
-		Description: "Enregistre le résultat d'un transfer challenge.",
+		Description: "Record the result of a transfer challenge.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params RecordTransferResultParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary
Translate every `Description:` field and `jsonschema:` tag value across 22 tool registration files from French to English. 7 commits grouped by functional cluster (activity loop, calibration & mastery, reflection, affect & profile, domain, session & nudges, observability), plus 1 capitalization-consistency fixup.

Mechanical translation. No handler bodies touched (those land in PR 4). No logic modified.

PR 3 of 5 in the i18n migration.

## Test plan
- [x] `go test ./...` green
- [x] French diacritic linter (`TestToolDescriptions_NoStrippedFrenchDiacritics`) PASS
- [x] `TestToolStringLiterals_NoStrippedFrenchDiacritics` PASS
- [x] `TestSystemPrompt_LanguageContract` and `TestSystemPrompt_ToolRegistryConsistency` still PASS
- [x] All identifiers, format verbs (`%s`/`%d`), and `domain.Name`-style user data preserved verbatim
- [x] `tools/profile.go` `language` field tag updated to BCP-47 i18n hint

## Note
Handler-body French strings remain in 7 files (`activity.go`, `feynman.go`, `transfer.go`, `manage_domain.go`, `session_close.go`, `get_dashboard_state.go`, `domain.go`). That is the scope of PR 4.