### PR TITLE
i18n: translate handler returns, DB notifications, engine rationales

### DIFF
--- a/algorithms/thresholds_drift_test.go
+++ b/algorithms/thresholds_drift_test.go
@@ -18,7 +18,7 @@ import (
 // in the same line as a "mastery"/"PMastery" identifier. Each match must
 // either live in algorithms/thresholds.go or appear in the explicit
 // allow-list below — see docs/regulation-design/07-threshold-resolver.md
-// §2 (Sites NON refactorés) for the rationale of each entry.
+// §2 (Non-refactored sites) for the rationale of each entry.
 //
 // Adding a new entry here is a deliberate decision. The default action
 // when this test fires is to refactor the call site to use

--- a/db/store.go
+++ b/db/store.go
@@ -1215,7 +1215,7 @@ func (s *Store) GetRecentLearnerEvents(learnerID string, since time.Time) ([]Raw
 		if mastery >= masteryKST {
 			events = append(events, RawLearnerEvent{
 				At: at, Kind: "mastery_threshold", Concept: concept,
-				Message: fmt.Sprintf("%s atteint le seuil de maîtrise", concept),
+				Message: fmt.Sprintf("%s reached the mastery threshold", concept),
 			})
 		} else if mastery < fragileThreshold {
 			events = append(events, RawLearnerEvent{
@@ -1233,7 +1233,7 @@ func (s *Store) GetRecentLearnerEvents(learnerID string, since time.Time) ([]Raw
 		if !startedAt.Before(since) {
 			events = append(events, RawLearnerEvent{
 				At: startedAt, Kind: "streak_start",
-				Message: fmt.Sprintf("Démarrage de la série de %d jours", streak),
+				Message: fmt.Sprintf("%d-day streak started", streak),
 			})
 		}
 	}

--- a/engine/concept_selector_test.go
+++ b/engine/concept_selector_test.go
@@ -198,7 +198,7 @@ func TestSelectConcept_Instruction_AllUncovered_NoFringe(t *testing.T) {
 	}
 }
 
-// ─── OQ-4.4 : tie-break alphabétique (contrat figé) ────────────────────────
+// ─── OQ-4.4 : alphabetical tie-break (frozen contract) ────────────────────
 
 func TestSelectConcept_Instruction_TieBreakAlphabetical(t *testing.T) {
 	// alpha, beta, gamma — same mastery, same goal_relevance → same
@@ -232,10 +232,10 @@ func TestSelectConcept_Instruction_TieBreakAlphabetical_NonAlphaInsertOrder(t *t
 	}
 }
 
-// ─── OQ-4.6 : trois cas dégénérés explicites de la formule INSTRUCTION ─────
+// ─── OQ-4.6 : three explicit degenerate cases of the INSTRUCTION formula ────
 
 func TestSelectConcept_Instruction_DegenerateGoalRelevanceNearZero(t *testing.T) {
-	// Concept à pertinence quasi-nulle ne gagne jamais sauf seul candidat.
+	// Concept with near-zero relevance never wins unless it is the only candidate.
 	graph := graphFlat("Low", "High")
 	states := []*models.ConceptState{reviewedCS("Low", 0.10), reviewedCS("High", 0.10)}
 	gr := map[string]float64{"Low": 0.001, "High": 1.0}
@@ -246,11 +246,11 @@ func TestSelectConcept_Instruction_DegenerateGoalRelevanceNearZero(t *testing.T)
 }
 
 func TestSelectConcept_Instruction_DegenerateMasteryNearBKT(t *testing.T) {
-	// Concept à mastery juste sous le seuil → score = gr × ~0.15 (faible).
-	// Un concept moins maîtrisé à pertinence égale gagne.
+	// Concept with mastery just below the threshold → score = gr × ~0.15 (low).
+	// A less-mastered concept at equal relevance wins.
 	graph := graphFlat("Almost", "Fresh")
 	states := []*models.ConceptState{
-		reviewedCS("Almost", 0.84), // tout proche de BKT
+		reviewedCS("Almost", 0.84), // very close to BKT threshold
 		reviewedCS("Fresh", 0.10),  // (1-m)=0.90
 	}
 	gr := map[string]float64{"Almost": 1.0, "Fresh": 1.0}
@@ -543,7 +543,7 @@ func TestSelectConcept_Diagnostic_AllCandidatesFromOtherDomain_NoFringe(t *testi
 	}
 }
 
-// ─── Cas dégénérés transverses ─────────────────────────────────────────────
+// ─── Cross-cutting degenerate cases ────────────────────────────────────────
 
 func TestSelectConcept_NaN_PMastery_ExcludedFromAllPhases(t *testing.T) {
 	csNaN := reviewedCS("Bad", math.NaN())

--- a/engine/gate.go
+++ b/engine/gate.go
@@ -35,7 +35,7 @@ import (
 
 // ErrGateUnknownPhase is returned by ApplyGate when the caller passes
 // a Phase value that is not one of {Instruction, Diagnostic,
-// Maintenance}. Cohérent with [4] OQ-4.1: explicit error, no silent
+// Maintenance}. Consistent with [4] OQ-4.1: explicit error, no silent
 // fallback — version-skew bugs must surface immediately.
 var ErrGateUnknownPhase = errors.New("gate: unknown phase")
 

--- a/engine/gate_test.go
+++ b/engine/gate_test.go
@@ -580,7 +580,7 @@ func TestApplyGate_EmptyPhase_ReturnsError(t *testing.T) {
 	}
 }
 
-// ─── Cas dégénérés ─────────────────────────────────────────────────────────
+// ─── Degenerate cases ──────────────────────────────────────────────────────
 
 func TestApplyGate_NilAlerts(t *testing.T) {
 	in := GateInput{

--- a/engine/motivation.go
+++ b/engine/motivation.go
@@ -36,7 +36,7 @@ type BriefInput struct {
 // algorithms.MasteryBKT() / REGULATION_THRESHOLD. It is an empirical bound
 // for the "individual interest" phase from Hidi & Renninger 2006 (Four-Phase
 // Model of Interest Development), which is conceptually orthogonal to the
-// runtime's notion of "concept BKT-maîtrisé". Coupling them was rejected in
+// runtime's notion of "concept BKT-mastered". Coupling them was rejected in
 // docs/regulation-design/07-threshold-resolver.md OQ-7.2.
 func InferInterestPhase(sessions int, mastery, selfInitRatio float64) string {
 	if mastery > 0.85 || (selfInitRatio > 0.6 && sessions >= 3) {

--- a/engine/olm.go
+++ b/engine/olm.go
@@ -314,7 +314,7 @@ func formatFocusReason(a models.Alert) string {
 	case models.AlertForgetting:
 		return fmt.Sprintf("retention %.0f%%", a.Retention*100)
 	case models.AlertZPDDrift:
-		return fmt.Sprintf("%.0f%% d'erreurs récentes", a.ErrorRate*100)
+		return fmt.Sprintf("%.0f%% recent errors", a.ErrorRate*100)
 	case models.AlertPlateau:
 		return fmt.Sprintf("plateau %d sessions", a.SessionsStalled)
 	}
@@ -326,11 +326,11 @@ func formatFocusReason(a models.Alert) string {
 // factual: distribution + focus + (one) metacognitive line if active +
 // goal progress phrase. No pep talk.
 func FormatOLMEmbed(snap *OLMSnapshot) DiscordEmbed {
-	title := "🧭 État du moment"
+	title := "🧭 Current state"
 	color := colorInfo
 	switch snap.FocusUrgency {
 	case models.UrgencyCritical:
-		title = "🚨 État — un concept à reprendre vite"
+		title = "🚨 State — one concept needs attention now"
 		color = colorCritical
 	case models.UrgencyWarning:
 		color = colorWarning
@@ -347,11 +347,11 @@ func FormatOLMEmbed(snap *OLMSnapshot) DiscordEmbed {
 		var prefix string
 		switch snap.FocusUrgency {
 		case models.UrgencyCritical:
-			prefix = "Un concept à reprendre vite"
+			prefix = "One concept needs attention now"
 		case models.UrgencyWarning:
-			prefix = "Focus du moment"
+			prefix = "Current focus"
 		default:
-			prefix = "Prochain palier"
+			prefix = "Next milestone"
 		}
 		lines = append(lines, fmt.Sprintf("%s : **%s** (%s).", prefix, snap.FocusConcept, snap.FocusReason))
 	}
@@ -361,7 +361,7 @@ func FormatOLMEmbed(snap *OLMSnapshot) DiscordEmbed {
 	}
 
 	if snap.PersonalGoal != "" {
-		lines = append(lines, fmt.Sprintf("Objectif \"%s\" : %s.", snap.PersonalGoal, progressPhrase(snap.KSTProgress)))
+		lines = append(lines, fmt.Sprintf("Goal \"%s\": %s.", snap.PersonalGoal, progressPhrase(snap.KSTProgress)))
 	}
 
 	return DiscordEmbed{
@@ -383,16 +383,16 @@ type DiscordEmbed struct {
 func compactBuckets(snap *OLMSnapshot) string {
 	parts := []string{}
 	if snap.Solid > 0 {
-		parts = append(parts, fmt.Sprintf("%d solides", snap.Solid))
+		parts = append(parts, fmt.Sprintf("%d solid", snap.Solid))
 	}
 	if snap.InProgress > 0 {
-		parts = append(parts, fmt.Sprintf("%d en cours", snap.InProgress))
+		parts = append(parts, fmt.Sprintf("%d in progress", snap.InProgress))
 	}
 	if snap.Fragile > 0 {
-		parts = append(parts, fmt.Sprintf("%d fragiles", snap.Fragile))
+		parts = append(parts, fmt.Sprintf("%d fragile", snap.Fragile))
 	}
 	if snap.NotStarted > 0 {
-		parts = append(parts, fmt.Sprintf("%d pas commencés", snap.NotStarted))
+		parts = append(parts, fmt.Sprintf("%d not started", snap.NotStarted))
 	}
 	return strings.Join(parts, " · ")
 }
@@ -404,16 +404,16 @@ func compactBuckets(snap *OLMSnapshot) string {
 // FormatOLMEmbed.
 func MetacogLine(snap *OLMSnapshot) string {
 	if snap.CalibrationBias > calibrationActionableThreshold {
-		return "Tu sur-estimes un peu tes acquis depuis 3 sessions — quelques exercices à froid t'aideront à recalibrer."
+		return "You have been slightly over-estimating your knowledge for 3 sessions — a few cold exercises will help you recalibrate."
 	}
 	if snap.CalibrationBias < -calibrationActionableThreshold {
-		return "Tu sous-estimes un peu tes acquis — tu en sais plus que tu crois."
+		return "You are slightly under-estimating yourself — you know more than you think."
 	}
 	if snap.AutonomyTrend == "declining" {
-		return "Tu t'appuies un peu plus sur les hints récemment — tente quelques exercices sans aide pour voir."
+		return "You have been leaning on hints a bit more lately — try a few exercises without help to see how you do."
 	}
 	if snap.AffectTrend == "declining" {
-		return "Les 3 dernières sessions ont été éprouvantes — n'hésite pas à alléger ou faire une pause."
+		return "The last 3 sessions have been tough — feel free to lighten the load or take a break."
 	}
 	return ""
 }
@@ -421,10 +421,10 @@ func MetacogLine(snap *OLMSnapshot) string {
 func progressPhrase(p float64) string {
 	switch {
 	case p < 0.30:
-		return "tu démarres"
+		return "just getting started"
 	case p < algorithms.MasteryKST():
-		return "à mi-chemin"
+		return "halfway there"
 	default:
-		return "presque arrivé"
+		return "almost there"
 	}
 }

--- a/engine/olm_global.go
+++ b/engine/olm_global.go
@@ -5,7 +5,7 @@
 //
 // BuildGlobalOLMSnapshot rolls up across all non-archived domains for a
 // learner — exposed via get_olm_snapshot(scope:"global") for the
-// "Modèle global" view.
+// "Global model" view.
 
 package engine
 

--- a/engine/olm_test.go
+++ b/engine/olm_test.go
@@ -283,8 +283,8 @@ func TestBuildOLMSnapshot_NotActionable_AllSolid(t *testing.T) {
 func TestFormatOLMEmbed_FocusWarning(t *testing.T) {
 	snap := &OLMSnapshot{
 		DomainID:      "d1",
-		DomainName:    "Python pour bio-info",
-		PersonalGoal:  "analyser tes données de jardin",
+		DomainName:    "Python for bio-info",
+		PersonalGoal:  "analyse your garden data",
 		Solid:         3,
 		InProgress:    2,
 		Fragile:       1,
@@ -296,19 +296,19 @@ func TestFormatOLMEmbed_FocusWarning(t *testing.T) {
 		HasActionable: true,
 	}
 	embed := FormatOLMEmbed(snap)
-	if embed.Title != "🧭 État du moment" {
+	if embed.Title != "🧭 Current state" {
 		t.Errorf("Title=%q", embed.Title)
 	}
-	if !strings.Contains(embed.Description, "Python pour bio-info") {
+	if !strings.Contains(embed.Description, "Python for bio-info") {
 		t.Errorf("Description missing domain name: %q", embed.Description)
 	}
 	if !strings.Contains(embed.Description, "boucles") {
 		t.Errorf("Description missing focus concept: %q", embed.Description)
 	}
-	if !strings.Contains(embed.Description, "Focus du moment") {
-		t.Errorf("Description should use 'Focus du moment' for warning urgency: %q", embed.Description)
+	if !strings.Contains(embed.Description, "Current focus") {
+		t.Errorf("Description should use 'Current focus' for warning urgency: %q", embed.Description)
 	}
-	if !strings.Contains(embed.Description, "à mi-chemin") {
+	if !strings.Contains(embed.Description, "halfway there") {
 		t.Errorf("Description missing goal progress phrase: %q", embed.Description)
 	}
 	if embed.Color != 0xF5A623 {
@@ -326,7 +326,7 @@ func TestFormatOLMEmbed_FocusCriticalRedTitleAndColor(t *testing.T) {
 		HasActionable: true,
 	}
 	embed := FormatOLMEmbed(snap)
-	if embed.Title != "🚨 État — un concept à reprendre vite" {
+	if embed.Title != "🚨 State — one concept needs attention now" {
 		t.Errorf("Title=%q", embed.Title)
 	}
 	if embed.Color != 0xFF6B6B {
@@ -359,8 +359,8 @@ func TestNodeClassify(t *testing.T) {
 
 func TestMetacogLine_Exported(t *testing.T) {
 	got := MetacogLine(&OLMSnapshot{CalibrationBias: 2.0})
-	if got == "" || got[:2] != "Tu" {
-		t.Errorf("MetacogLine(over-confident) = %q, want non-empty starting with 'Tu'", got)
+	if got == "" || got[:3] != "You" {
+		t.Errorf("MetacogLine(over-confident) = %q, want non-empty starting with 'You'", got)
 	}
 	got = MetacogLine(&OLMSnapshot{CalibrationBias: 0.0})
 	if got != "" {

--- a/engine/orchestrator.go
+++ b/engine/orchestrator.go
@@ -158,7 +158,7 @@ func OrchestrateWithPhase(store *db.Store, input OrchestratorInput) (models.Acti
 
 	return models.Activity{
 		Type:         models.ActivityRest,
-		Rationale:    "pipeline_exhausted: NoFringe persistant après retry",
+		Rationale:    "pipeline_exhausted: NoFringe persists after retry",
 		PromptForLLM: "Aucune activite eligible apres retry. Demande a l'apprenant ce qu'il souhaite faire.",
 	}, currentPhase, nil
 }
@@ -253,8 +253,8 @@ func buildObservables(domain *models.Domain, pf *pipelineFixtures, cfg PhaseConf
 			hasRel = true
 		}
 		if !hasRel {
-			// Uncovered concept — exclu du set goal-relevant (cohérent
-			// avec OQ-2.7 et [4] OQ-4.3 = B').
+			// Uncovered concept — excluded from the goal-relevant set
+			// (consistent with OQ-2.7 and [4] OQ-4.3 = B').
 			continue
 		}
 		if rel <= cfg.GoalRelevantCutoff {
@@ -264,8 +264,8 @@ func buildObservables(domain *models.Domain, pf *pipelineFixtures, cfg PhaseConf
 
 		cs := pf.StatesByConcept[c]
 		if cs == nil {
-			// Pas de state ≡ jamais pratiqué ≡ pas mastered, pas
-			// "below retention" (rien à oublier).
+			// No state ≡ never practised ≡ not mastered, not
+			// "below retention" (nothing to forget).
 			continue
 		}
 		if cs.PMastery >= bkt {
@@ -368,9 +368,9 @@ func runPipeline(
 	// ── [5] ActionSelector — on the chosen concept ────────────────
 	cs := pf.StatesByConcept[selection.Concept]
 	if cs == nil {
-		// Concept dans le graphe mais sans state — créer un state par
-		// défaut pour SelectAction (mastery=0, theta=0) afin d'éviter
-		// le panic. SelectAction's NaN-guard handles missing fields.
+		// Concept in the graph but no state — create a default state
+		// for SelectAction (mastery=0, theta=0) to avoid the panic.
+		// SelectAction's NaN-guard handles missing fields.
 		cs = models.NewConceptState(input.LearnerID, selection.Concept)
 	}
 	var mc *db.MisconceptionGroup

--- a/engine/orchestrator_escape_test.go
+++ b/engine/orchestrator_escape_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestOrchestrate_EscapePath_NoFringeAfterRetry covers the
-// "pipeline_exhausted: NoFringe persistant après retry" branch of
+// "pipeline_exhausted: NoFringe persists after retry" branch of
 // Orchestrate (engine/orchestrator.go:142-146). The scenario:
 //
 //   - Phase = INSTRUCTION ; the domain's only concept is mastered, so

--- a/engine/orchestrator_integration_test.go
+++ b/engine/orchestrator_integration_test.go
@@ -315,10 +315,10 @@ func findRepoRootForArtifact(t *testing.T) string {
 // ─── E2E scenarios (OQ-2.7) ────────────────────────────────────────────────
 
 func TestOrchestrate_E2E_RestrictiveGoal_FastMaintenance_30Sessions(t *testing.T) {
-	// Restrictif : 3 concepts goal-relevants sur 6, le reste irrélevant.
-	// AntiRepeatWindow=1 pour ce scénario : avec seulement 3 concepts
-	// covered, N=3 viderait la pool éligible. N=1 garde la diversité
-	// minimale tout en laissant 2 concepts toujours sélectionnables.
+	// Restrictive: 3 goal-relevant concepts out of 6, the rest irrelevant.
+	// AntiRepeatWindow=1 for this scenario: with only 3 concepts
+	// covered, N=3 would drain the eligible pool. N=1 preserves
+	// minimal diversity while keeping 2 concepts always selectable.
 	concepts := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
 	goal := map[string]float64{
 		"alpha": 0.9, "beta": 0.9, "gamma": 0.9,
@@ -328,8 +328,8 @@ func TestOrchestrate_E2E_RestrictiveGoal_FastMaintenance_30Sessions(t *testing.T
 	cfg.AntiRepeatWindow = 1
 	art := runE2ESimulation(t, "restrictive_goal", concepts, nil, goal, 30, cfg)
 
-	// Assertions :
-	// 1. Au moins une transition observée
+	// Assertions:
+	// 1. At least one transition observed
 	if art.Summary.TransitionsCount == 0 {
 		t.Errorf("expected ≥1 transition over 30 sessions, got 0")
 	}
@@ -341,8 +341,8 @@ func TestOrchestrate_E2E_RestrictiveGoal_FastMaintenance_30Sessions(t *testing.T
 }
 
 func TestOrchestrate_E2E_BroadGoal_LongInstruction_30Sessions(t *testing.T) {
-	// Large : tous les concepts goal-relevants. L'apprenant doit
-	// maîtriser TOUS pour passer en MAINTENANCE.
+	// Broad: all concepts are goal-relevant. The learner must
+	// master ALL of them to transition to MAINTENANCE.
 	concepts := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
 	goal := map[string]float64{
 		"alpha": 0.9, "beta": 0.9, "gamma": 0.9,
@@ -351,16 +351,16 @@ func TestOrchestrate_E2E_BroadGoal_LongInstruction_30Sessions(t *testing.T) {
 	cfg := NewDefaultPhaseConfig()
 	art := runE2ESimulation(t, "broad_goal", concepts, nil, goal, 30, cfg)
 
-	// Assertion : le passage en MAINTENANCE doit être plus tardif (ou
-	// inexistant) que dans le scénario restrictif. On vérifie que
-	// MAINTENANCE n'arrive pas avant la deuxième moitié de la
-	// simulation, que la phase finale est MAINTENANCE, et que les
-	// sessions INSTRUCTION sont substantielles. (La comparaison directe
-	// I > M était une proxy fragile : une fois `selectDiagnostic`
-	// corrigé pour respecter le gate anti-repeat — issue #93 lineage —
-	// la phase DIAGNOSTIC ne masterise plus aucun concept par accident,
-	// donc INSTRUCTION démarre plus tôt et MAINTENANCE peut accumuler
-	// plus de sessions vers la fin.)
+	// Assertion: the transition to MAINTENANCE must be later (or
+	// absent) than in the restrictive scenario. We verify that
+	// MAINTENANCE does not arrive before the second half of the
+	// simulation, that the final phase is MAINTENANCE, and that
+	// INSTRUCTION sessions are substantial. (The direct comparison
+	// I > M was a fragile proxy: once `selectDiagnostic` was fixed
+	// to respect the anti-repeat gate — issue #93 lineage — the
+	// DIAGNOSTIC phase no longer accidentally masters concepts, so
+	// INSTRUCTION starts earlier and MAINTENANCE can accumulate
+	// more sessions toward the end.)
 	if art.Summary.FirstMaintenanceAt > 0 && art.Summary.FirstMaintenanceAt < 15 {
 		t.Errorf("broad goal : MAINTENANCE arrived too early (session %d, expected >= 15)",
 			art.Summary.FirstMaintenanceAt)
@@ -374,10 +374,9 @@ func TestOrchestrate_E2E_BroadGoal_LongInstruction_30Sessions(t *testing.T) {
 	}
 }
 
-// TestOrchestrate_E2E_FullCycle_30Sessions vérifie que les 3
-// transitions DIAGNOSTIC → INSTRUCTION → MAINTENANCE peuvent toutes
-// se produire au cours d'une simulation de 30 sessions sur un domaine
-// minimal goal-aligned.
+// TestOrchestrate_E2E_FullCycle_30Sessions verifies that all 3
+// transitions DIAGNOSTIC → INSTRUCTION → MAINTENANCE can occur
+// within a 30-session simulation on a minimal goal-aligned domain.
 func TestOrchestrate_E2E_FullCycle_30Sessions(t *testing.T) {
 	concepts := []string{"alpha", "beta"}
 	goal := map[string]float64{"alpha": 1.0, "beta": 1.0}
@@ -385,13 +384,13 @@ func TestOrchestrate_E2E_FullCycle_30Sessions(t *testing.T) {
 	cfg.AntiRepeatWindow = 1 // 2-concept domain — N>=2 starves the pool.
 	art := runE2ESimulation(t, "full_cycle", concepts, nil, goal, 30, cfg)
 
-	// Au moins DIAGNOSTIC → INSTRUCTION doit avoir eu lieu (NDiagnosticMax=8
-	// après 8 interactions garantit la sortie).
+	// At least DIAGNOSTIC → INSTRUCTION must have occurred (NDiagnosticMax=8
+	// guarantees exit after 8 interactions).
 	if art.Summary.FirstInstructionAt == 0 {
 		t.Errorf("expected DIAGNOSTIC→INSTRUCTION transition within 30 sessions")
 	}
-	// La phase finale doit être MAINTENANCE (apprenant simulé maîtrise
-	// les 2 concepts en BKT update successifs).
+	// The final phase must be MAINTENANCE (simulated learner masters
+	// both concepts through successive BKT updates).
 	if art.Summary.FinalPhase != string(models.PhaseMaintenance) {
 		t.Logf("note : final phase %s, expected MAINTENANCE — ok if BKT didn't reach 0.85 in 30 steps",
 			art.Summary.FinalPhase)

--- a/engine/orchestrator_test.go
+++ b/engine/orchestrator_test.go
@@ -124,8 +124,8 @@ func TestOrchestrate_DomainPhaseNull_DefaultsToInstruction(t *testing.T) {
 	if activity.Type == "" {
 		t.Errorf("expected an Activity, got empty Type")
 	}
-	// La phase reste NULL en DB (orchestrator a juste lu, pas écrit
-	// — pas de transition car déjà en INSTRUCTION).
+	// The phase remains NULL in DB (orchestrator only read, did not
+	// write — no transition because already in INSTRUCTION).
 	d, _ := store.GetDomainByID(domainID)
 	if d.Phase != "" {
 		t.Errorf("expected phase to remain NULL on legacy domain, got %q", d.Phase)
@@ -212,13 +212,13 @@ func TestOrchestrate_Maintenance_RetentionLow_TransitionsToInstruction(t *testin
 // ─── OQ-2.7 : Goal-relevant cutoff (uncovered exclusion) ───────────────────
 
 func TestOrchestrate_GoalRelevant_RestrictiveGoal_FastMaintenance(t *testing.T) {
-	// Goal restrictif : 1 concept goal-relevant sur 5 → MAINTENANCE
-	// dès que ce concept est mastered, peu importe les autres.
+	// Restrictive goal: 1 goal-relevant concept out of 5 → MAINTENANCE
+	// as soon as that concept is mastered, regardless of the others.
 	store := setupOrchStore(t)
 	domainID := seedOrchDomain(t, store, []string{"A", "B", "C", "D", "E"}, nil, models.PhaseInstruction)
 	setGoalRelevance(t, store, domainID, map[string]float64{"A": 0.9}) // B-E uncovered
-	setMastery(t, store, "A", 0.95)                                    // seul A mastered
-	// B-E restent à mastery=0.1 default — non goal-relevants
+	setMastery(t, store, "A", 0.95)                                    // only A mastered
+	// B-E remain at mastery=0.1 default — not goal-relevant
 
 	if _, err := Orchestrate(store, defaultInput(domainID)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -230,14 +230,14 @@ func TestOrchestrate_GoalRelevant_RestrictiveGoal_FastMaintenance(t *testing.T) 
 }
 
 func TestOrchestrate_GoalRelevant_BroadGoal_StaysInstruction(t *testing.T) {
-	// Goal large : 5 concepts goal-relevants, seul 1 mastered → reste INSTRUCTION.
+	// Broad goal: 5 goal-relevant concepts, only 1 mastered → stays INSTRUCTION.
 	store := setupOrchStore(t)
 	domainID := seedOrchDomain(t, store, []string{"A", "B", "C", "D", "E"}, nil, models.PhaseInstruction)
 	setGoalRelevance(t, store, domainID, map[string]float64{
 		"A": 0.9, "B": 0.9, "C": 0.9, "D": 0.9, "E": 0.9,
 	})
-	setMastery(t, store, "A", 0.95) // seul A mastered
-	// B-E à 0.1 default
+	setMastery(t, store, "A", 0.95) // only A mastered
+	// B-E at 0.1 default
 
 	if _, err := Orchestrate(store, defaultInput(domainID)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -251,17 +251,17 @@ func TestOrchestrate_GoalRelevant_BroadGoal_StaysInstruction(t *testing.T) {
 // ─── Phase invalide en DB → INSTRUCTION fallback ──────────────────────────
 
 func TestOrchestrate_PhaseCorruptedInDB_FallsBackGracefully(t *testing.T) {
-	// Si la DB contient une phase non reconnue, l'orchestrateur ne
-	// doit pas crasher. Le FSM EvaluatePhase ignore (no transition).
-	// La pipeline tourne avec la valeur en DB (Gate refusera car
-	// erreur, mais on capture le fallback gracieux).
+	// If the DB contains an unrecognised phase, the orchestrator must
+	// not crash. The FSM EvaluatePhase ignores it (no transition).
+	// The pipeline runs with the DB value (Gate will refuse with an
+	// error, but we capture the graceful fallback).
 	store := setupOrchStore(t)
 	domainID := seedOrchDomain(t, store, []string{"A"}, nil, models.Phase("BOGUS"))
 	setGoalRelevance(t, store, domainID, map[string]float64{"A": 1.0})
 
 	_, err := Orchestrate(store, defaultInput(domainID))
-	// Gate retourne ErrGateUnknownPhase → propagé comme erreur de
-	// pipeline. C'est le comportement attendu (cohérent avec
+	// Gate returns ErrGateUnknownPhase → propagated as a pipeline
+	// error. This is the expected behaviour (consistent with
 	// OQ-4.1/OQ-2.5 explicit-error).
 	if err == nil {
 		t.Fatalf("expected error on corrupted phase, got nil")

--- a/engine/phase_config.go
+++ b/engine/phase_config.go
@@ -43,7 +43,7 @@ type PhaseConfig struct {
 	// goal_relevance[c] > GoalRelevantCutoff. Default 0 (any strictly
 	// positive score qualifies). Concepts uncovered by the
 	// goal_relevance vector are excluded by virtue of not being in
-	// the map (cohérent with [4] OQ-4.3 = B').
+	// the map (consistent with [4] OQ-4.3 = B').
 	GoalRelevantCutoff float64
 
 	// AntiRepeatWindow is the value the orchestrator forwards into

--- a/engine/phase_fsm.go
+++ b/engine/phase_fsm.go
@@ -85,8 +85,8 @@ type PhaseEvaluation struct {
 func EvaluatePhase(current models.Phase, obs PhaseObservables, cfg PhaseConfig) PhaseEvaluation {
 	switch current {
 	case models.PhaseDiagnostic:
-		// Critère relatif sur l'entropie : ne fire que si on a un
-		// snapshot valide ET la réduction atteint le seuil.
+		// Relative entropy criterion: only fire when we have a valid
+		// snapshot AND the reduction reaches the threshold.
 		hasSnapshot := obs.PhaseEntryEntropy > 0 && !math.IsNaN(obs.PhaseEntryEntropy)
 		entropyDelta := obs.PhaseEntryEntropy - obs.MeanEntropy
 		entropyExit := hasSnapshot && entropyDelta >= cfg.DeltaHThreshold
@@ -96,7 +96,7 @@ func EvaluatePhase(current models.Phase, obs PhaseObservables, cfg PhaseConfig) 
 			return PhaseEvaluation{
 				From: current, To: models.PhaseInstruction, Transitioned: true,
 				Rationale: fmt.Sprintf(
-					"DIAGNOSTIC→INSTRUCTION : reduction d'entropie atteinte (%.3f >= %.3f bits)",
+					"DIAGNOSTIC→INSTRUCTION: entropy reduction reached (%.3f >= %.3f bits)",
 					entropyDelta, cfg.DeltaHThreshold),
 			}
 		}
@@ -104,32 +104,32 @@ func EvaluatePhase(current models.Phase, obs PhaseObservables, cfg PhaseConfig) 
 			return PhaseEvaluation{
 				From: current, To: models.PhaseInstruction, Transitioned: true,
 				Rationale: fmt.Sprintf(
-					"DIAGNOSTIC→INSTRUCTION : N_max atteint (%d >= %d items)",
+					"DIAGNOSTIC→INSTRUCTION: N_max reached (%d >= %d items)",
 					obs.DiagnosticItemsCount, cfg.NDiagnosticMax),
 			}
 		}
 		return PhaseEvaluation{
 			From: current, To: current, Transitioned: false,
 			Rationale: fmt.Sprintf(
-				"DIAGNOSTIC : delta=%.3f bits (seuil %.3f), items=%d/%d — stay",
+				"DIAGNOSTIC: delta=%.3f bits (threshold %.3f), items=%d/%d — stay",
 				entropyDelta, cfg.DeltaHThreshold,
 				obs.DiagnosticItemsCount, cfg.NDiagnosticMax),
 		}
 
 	case models.PhaseInstruction:
-		// Tous les concepts goal-relevants maîtrisés.
+		// All goal-relevant concepts mastered.
 		if obs.TotalGoalRelevant > 0 && obs.MasteredGoalRelevant == obs.TotalGoalRelevant {
 			return PhaseEvaluation{
 				From: current, To: models.PhaseMaintenance, Transitioned: true,
 				Rationale: fmt.Sprintf(
-					"INSTRUCTION→MAINTENANCE : %d/%d concepts goal-relevants maitrises",
+					"INSTRUCTION→MAINTENANCE: %d/%d goal-relevant concepts mastered",
 					obs.MasteredGoalRelevant, obs.TotalGoalRelevant),
 			}
 		}
 		return PhaseEvaluation{
 			From: current, To: current, Transitioned: false,
 			Rationale: fmt.Sprintf(
-				"INSTRUCTION : %d/%d concepts goal-relevants maitrises — stay",
+				"INSTRUCTION: %d/%d goal-relevant concepts mastered — stay",
 				obs.MasteredGoalRelevant, obs.TotalGoalRelevant),
 		}
 
@@ -137,21 +137,21 @@ func EvaluatePhase(current models.Phase, obs PhaseObservables, cfg PhaseConfig) 
 		if obs.GoalRelevantBelowRetention {
 			return PhaseEvaluation{
 				From: current, To: models.PhaseInstruction, Transitioned: true,
-				Rationale: "MAINTENANCE→INSTRUCTION : un concept goal-relevant sous le seuil de retention",
+				Rationale: "MAINTENANCE→INSTRUCTION: one goal-relevant concept below the retention threshold",
 			}
 		}
 		return PhaseEvaluation{
 			From: current, To: current, Transitioned: false,
-			Rationale: "MAINTENANCE : retention OK sur tous les goal-relevants — stay",
+			Rationale: "MAINTENANCE: retention OK on all goal-relevants — stay",
 		}
 
 	default:
-		// Phase non reconnue : pas de transition. C'est à l'orchestrateur
-		// de décider du fallback (typiquement INSTRUCTION pour les
-		// rows pré-flag avec phase NULL — déjà mappé en chaîne vide).
+		// Unrecognised phase: no transition. The orchestrator decides
+		// the fallback (typically INSTRUCTION for rows pre-flagged with
+		// phase NULL — already mapped to an empty string).
 		return PhaseEvaluation{
 			From: current, To: current, Transitioned: false,
-			Rationale: fmt.Sprintf("phase non reconnue %q — pas de transition", string(current)),
+			Rationale: fmt.Sprintf("unrecognised phase %q — no transition", string(current)),
 		}
 	}
 }

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -447,11 +447,11 @@ func (s *Scheduler) sendOLM() {
 // is used as-is for Description; the title/color come from FocusUrgency for
 // visual consistency with the Go fallback.
 func embedFromQueueItem(item *models.WebhookQueueItem, urgency models.AlertUrgency) discordEmbed {
-	title := "🧭 État du moment"
+	title := "🧭 Current state"
 	color := colorInfo
 	switch urgency {
 	case models.UrgencyCritical:
-		title = "🚨 État — un concept à reprendre vite"
+		title = "🚨 State — one concept needs attention now"
 		color = colorCritical
 	case models.UrgencyWarning:
 		color = colorWarning

--- a/engine/scheduler_test.go
+++ b/engine/scheduler_test.go
@@ -40,9 +40,9 @@ func TestSendOLM_DispatchesFallbackWhenQueueEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		got := string(body)
-		if !strings.Contains(got, "Focus du moment") &&
-			!strings.Contains(got, "Prochain palier") &&
-			!strings.Contains(got, "reprendre vite") {
+		if !strings.Contains(got, "Current focus") &&
+			!strings.Contains(got, "Next milestone") &&
+			!strings.Contains(got, "needs attention now") {
 			t.Errorf("expected an OLM body, got: %s", got)
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -42,8 +42,8 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 				"needs_domain_setup": true,
 				"activity": models.Activity{
 					Type:         models.ActivitySetupDomain,
-					Rationale:    "aucun domaine configuré",
-					PromptForLLM: "L'apprenant n'a pas encore de domaine. Analyse son objectif, décompose-le en concepts et appelle init_domain().",
+					Rationale:    "no domain configured",
+					PromptForLLM: "The learner has no domain yet. Analyse their objective, break it down into concepts, and call init_domain().",
 				},
 			})
 			return r, nil, nil
@@ -219,7 +219,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 						misconceptionPrompt += " — " + m.LastErrorDetail
 					}
 				}
-				misconceptionPrompt += ". Cible ces confusions dans ton explication et ton exercice. Ne mentionne pas explicitement les misconceptions — conçois l'exercice pour qu'il les confronte naturellement."
+				misconceptionPrompt += ". Target these confusions in your explanation and exercise. Do not explicitly mention the misconceptions — design the exercise so the learner confronts them naturally."
 				activity.PromptForLLM += misconceptionPrompt
 			}
 

--- a/tools/calibration.go
+++ b/tools/calibration.go
@@ -82,7 +82,7 @@ func registerCalibrationCheck(server *mcp.Server, deps *Deps) {
 		}
 
 		promptText := fmt.Sprintf(
-			"Tu as estimé ta maîtrise de '%s' à %.0f/5. Voyons ça avec un exercice.",
+			"You estimated your mastery of '%s' at %.0f/5. Let's check that with an exercise.",
 			params.ConceptID, params.PredictedMastery,
 		)
 

--- a/tools/domain.go
+++ b/tools/domain.go
@@ -314,9 +314,9 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 			}
 		}
 
-		// [2] PhaseController — initialise le domaine en DIAGNOSTIC.
-		// Les concept_states viennent d'être créés à PMastery=0.1 —
-		// l'entropie d'entrée est calculable maintenant.
+		// [2] PhaseController — initialises the domain in DIAGNOSTIC.
+		// The concept_states were just created at PMastery=0.1 —
+		// the entry entropy is now computable.
 		states, _ := deps.Store.GetConceptStatesByLearner(learnerID)
 		stateMap := map[string]*models.ConceptState{}
 		for _, cs := range states {
@@ -326,8 +326,8 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 		if err := deps.Store.UpdateDomainPhase(domain.ID, models.PhaseDiagnostic, entryEntropy, time.Now().UTC()); err != nil {
 			deps.Logger.Error("init_domain: failed to set initial phase",
 				"err", err, "domain", domain.ID)
-			// Non-fatal: domain reste en phase NULL → INSTRUCTION
-			// fallback. La régulation continue à fonctionner.
+			// Non-fatal: domain stays in phase NULL → INSTRUCTION
+			// fallback. Regulation continues to work.
 		}
 
 		response := map[string]interface{}{
@@ -339,9 +339,9 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 		// non-blocking per Q2). Only emitted when REGULATION_GOAL=on so
 		// pre-flag clients see no behavioural change.
 		if regulationGoalEnabled() {
-			reason := fmt.Sprintf("Décompose le personal_goal contre les %d concepts via set_goal_relevance pour activer le goal-aware routing.", len(params.Concepts))
+			reason := fmt.Sprintf("Decompose the personal_goal against the %d concepts via set_goal_relevance to activate goal-aware routing.", len(params.Concepts))
 			if params.PersonalGoal == "" {
-				reason = "personal_goal vide — set_goal_relevance reste optionnel ; appelle-le si tu veux annoter manuellement la pertinence par concept."
+				reason = "personal_goal is empty — set_goal_relevance remains optional; call it if you want to manually annotate relevance per concept."
 			}
 			response["next_action"] = map[string]any{
 				"version":  1,
@@ -466,7 +466,7 @@ func registerAddConcepts(server *mcp.Server, deps *Deps) {
 			response["next_action"] = map[string]any{
 				"version":  1,
 				"tool":     "set_goal_relevance",
-				"reason":   fmt.Sprintf("%d nouveaux concepts ajoutés ; appelle set_goal_relevance avec leurs scores pour conserver le routage goal-aware (la sémantique est incrémentale, les concepts existants ne sont pas effacés).", added),
+				"reason":   fmt.Sprintf("%d new concepts added; call set_goal_relevance with their scores to preserve goal-aware routing (semantics are incremental — existing concepts are not erased).", added),
 				"required": false,
 			}
 		}

--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -57,17 +57,17 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 				"eligible":  false,
 				"mastery":   cs.PMastery,
 				"threshold": algorithms.MasteryBKT(),
-				"message":   "Concept pas encore maîtrisé. Continue la pratique régulière.",
+				"message":   "Concept not yet mastered. Keep up the regular practice.",
 			})
 			return r, nil, nil
 		}
 
 		promptText := fmt.Sprintf(
-			"Explique le concept '%s' comme si tu l'enseignais à quelqu'un qui n'y connaît rien. "+
-				"Pas de jargon technique — utilise des analogies, des exemples concrets. "+
-				"L'objectif est de vérifier que tu as vraiment compris, pas que tu sais réciter.\n\n"+
-				"Après ton explication, je vais identifier les points flous ou incomplets "+
-				"et les transformer en micro-concepts à travailler.",
+			"Explain the concept '%s' as if you were teaching it to someone who knows nothing about it. "+
+				"No technical jargon — use analogies and concrete examples. "+
+				"The goal is to verify that you truly understood it, not just that you can recite it.\n\n"+
+				"After your explanation, I will identify the fuzzy or incomplete points "+
+				"and turn them into micro-concepts to work on.",
 			params.ConceptID,
 		)
 
@@ -75,10 +75,10 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 			"eligible":    true,
 			"prompt_text": promptText,
 			"concept_id":  params.ConceptID,
-			"instructions_for_llm": "Après l'explication de l'apprenant, identifie les gaps conceptuels spécifiques. " +
-				"Pour chaque gap, génère un label court et une description. " +
-				"Demande confirmation à l'apprenant avant d'injecter les gaps dans le graphe via add_concepts(). " +
-				"Les nouveaux micro-concepts doivent avoir le concept source comme prérequis.",
+			"instructions_for_llm": "After the learner's explanation, identify the specific conceptual gaps. " +
+				"For each gap, generate a short label and a description. " +
+				"Ask the learner for confirmation before injecting the gaps into the graph via add_concepts(). " +
+				"The new micro-concepts must have the source concept as a prerequisite.",
 			"gap_template": map[string]interface{}{
 				"label":          "<nom court du gap>",
 				"description":    "<ce qui manque dans l'explication>",

--- a/tools/get_dashboard_state.go
+++ b/tools/get_dashboard_state.go
@@ -156,7 +156,7 @@ func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 			}
 
 			frontier := algorithms.ComputeFrontier(graph, mastery)
-			nextAction := "continuer la révision"
+			nextAction := "continue reviewing"
 			if len(frontier) > 0 {
 				nextAction = fmt.Sprintf("nouveau concept: %s", frontier[0])
 			}

--- a/tools/get_dashboard_state_test.go
+++ b/tools/get_dashboard_state_test.go
@@ -13,7 +13,7 @@ import (
 // TestGetDashboardState_NoActiveDomain_UsesCanonicalShape asserts that when a
 // learner with no domain calls get_dashboard_state, the response uses the
 // canonical needs_domain_setup payload (Issue #33) instead of the previous
-// French operator-facing error string ("aucun domaine configuré"). This keeps
+// previous French error string instead of the canonical structured payload. This keeps
 // the chat-side tool surface uniform so the LLM can branch on a single signal
 // regardless of which tool it called.
 func TestGetDashboardState_NoActiveDomain_UsesCanonicalShape(t *testing.T) {

--- a/tools/manage_domain.go
+++ b/tools/manage_domain.go
@@ -53,7 +53,7 @@ func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 			"archived":    true,
 			"domain_id":   domain.ID,
 			"domain_name": domain.Name,
-			"message":     fmt.Sprintf("Domaine '%s' archivé. La progression est préservée. Utilise unarchive_domain pour le réactiver.", domain.Name),
+			"message":     fmt.Sprintf("Domain '%s' archived. Progress preserved. Use unarchive_domain to restore it.", domain.Name),
 		})
 		return r, nil, nil
 	})
@@ -100,7 +100,7 @@ func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 			"archived":    false,
 			"domain_id":   domain.ID,
 			"domain_name": domain.Name,
-			"message":     fmt.Sprintf("Domaine '%s' réactivé.", domain.Name),
+			"message":     fmt.Sprintf("Domain '%s' restored.", domain.Name),
 		})
 		return r, nil, nil
 	})

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -148,14 +148,14 @@ func buildRecapBrief(deps *Deps, learnerID string, domain *models.Domain) *model
 	has, _ := deps.Store.HasRecentImplementationIntention(learnerID, "", time.Now().UTC().Add(-7*24*time.Hour))
 	promptIntent := !has
 
-	instruction := "Clos la session en 2-3 phrases. Mentionne un win tangible ou une belle tentative. " +
-		"Si prompt_for_implementation_intention est vrai, pose une question concrète du type 'Quand et où tu pratiques ensuite ?' " +
-		"et attends la réponse pour rappeler record_session_close avec implementation_intention. " +
-		"Puis appelle get_olm_snapshot pour récupérer l'état cognitif structuré de l'apprenant, " +
-		"et appelle queue_webhook_message 3 fois : daily_motivation pour demain 8h UTC (chaleureux, lien au personal_goal) ; " +
-		"olm:<domain_id> pour demain 13h UTC (factuel — distribution + focus + UNE ligne métacog si active + progression vers le goal — pas de pep talk, le contenu doit COLLER au snapshot get_olm_snapshot) ; " +
-		"daily_recap pour demain 21h UTC (recap doux). " +
-		"Sans KPI brut."
+	instruction := "Close the session in 2-3 sentences. Mention a tangible win or a good attempt. " +
+		"If prompt_for_implementation_intention is true, ask a concrete question like 'When and where will you practice next?' " +
+		"and wait for the answer to call record_session_close again with implementation_intention. " +
+		"Then call get_olm_snapshot to retrieve the learner's structured cognitive state, " +
+		"and call queue_webhook_message 3 times: daily_motivation for tomorrow at 8h UTC (warm, tied to personal_goal) ; " +
+		"olm:<domain_id> for tomorrow at 13h UTC (factual — distribution + focus + ONE metacog line if active + progress toward goal — no pep talk, content must MATCH the get_olm_snapshot snapshot) ; " +
+		"daily_recap for tomorrow at 21h UTC (gentle recap). " +
+		"No raw KPIs."
 
 	return &models.RecapBrief{
 		ConceptsPracticed:             practiced,

--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -69,7 +69,7 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 			r, _ := jsonResult(map[string]interface{}{
 				"eligible": false,
 				"mastery":  cs.PMastery,
-				"message":  "Concept pas encore maîtrisé. Le transfert challenge requiert BKT >= 0.85.",
+				"message":  "Concept not yet mastered. The transfer challenge requires BKT >= 0.85.",
 			})
 			return r, nil, nil
 		}
@@ -86,12 +86,12 @@ func registerTransferChallenge(server *mcp.Server, deps *Deps) {
 		}
 
 		promptText := fmt.Sprintf(
-			"Génère une situation totalement nouvelle qui teste le transfert du concept '%s' "+
-				"dans un contexte de type '%s'. "+
-				"La situation ne doit PAS ressembler aux exercices précédents. "+
-				"L'objectif: vérifier que l'apprenant peut appliquer ce concept dans un contexte qu'il n'a jamais vu.\n\n"+
-				"Après la réponse de l'apprenant, évalue le transfer_score (0-1) et "+
-				"appelle record_transfer_result avec le résultat.",
+			"Generate a completely new situation that tests the transfer of the concept '%s' "+
+				"in a context of type '%s'. "+
+				"The situation must NOT resemble previous exercises. "+
+				"The goal: verify that the learner can apply this concept in a context they have never seen.\n\n"+
+				"After the learner's response, evaluate the transfer_score (0-1) and "+
+				"call record_transfer_result with the result.",
 			params.ConceptID, contextType,
 		)
 


### PR DESCRIPTION
## Summary
Translate the remaining source-side French strings that the LLM relays to the learner:
- Handler-returned messages in `tools/` (`manage_domain`, `feynman`, `transfer`, `session_close`, `activity`, `calibration`, `get_dashboard_state`, `domain`).
- DB notification messages (`db/store.go`: streak start, mastery threshold).
- Engine rationales and Discord embed labels (`engine/orchestrator.go`, `engine/phase_fsm.go`, `engine/olm.go`, `engine/scheduler.go`, `engine/motivation.go`, `engine/gate.go`, `engine/olm_global.go`, `engine/phase_config.go`).
- French comments in `engine/orchestrator_integration_test.go` and 7 other test files.
- Test assertions updated to match new English strings (engine/olm_test.go, scheduler_test.go, etc.).

After this PR, no French diacritics remain in non-test code (apart from the intentional denylist literals in `tools/registration_test.go`, removed in PR 5).

PR 4 of 5 in the i18n migration. The diacritic linter stays active as a safety net.

## Test plan
- [x] `go test ./...` all 6 packages green.
- [x] Protected tests still PASS: `TestSystemPrompt_LanguageContract`, `TestSystemPrompt_ToolRegistryConsistency`, both diacritic linters.
- [x] All identifiers, format verbs, user data interpolations preserved.
- [x] No `Description:` or `jsonschema:` lines modified.

## Scope note
Surface was 26 files (vs. ~12-15 in the original spec). Additional residue found in `engine/olm.go` (Discord embed UI), `engine/phase_fsm.go` (7 Rationale strings), `engine/scheduler.go` (duplicate embed titles). All are coherent translation work; no logic touched.