### PR TITLE
i18n: replace French denylist with ASCII-only check + final translation sweep

### DIFF
--- a/engine/action_selector.go
+++ b/engine/action_selector.go
@@ -279,7 +279,7 @@ func selectHighMasteryAction(history ActionHistory) Action {
 			DifficultyTarget: 0.75,
 			Format:           "build_challenge",
 			EstimatedMinutes: 45,
-			Rationale:        "mastery stable : nouveau cycle challenge",
+			Rationale:        "mastery stable: new challenge cycle",
 		}
 	}
 }

--- a/engine/alert.go
+++ b/engine/alert.go
@@ -52,7 +52,7 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 				Urgency:            urgency,
 				Retention:          retention,
 				HoursUntilCritical: hoursLeft,
-				RecommendedAction:  fmt.Sprintf("revision immediate · %d minutes", estimateReviewMinutes(cs)),
+				RecommendedAction:  fmt.Sprintf("immediate review - %d minutes", estimateReviewMinutes(cs)),
 			})
 		}
 
@@ -91,7 +91,7 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 			errorRate := float64(streak) / float64(streak+1)
 
 			// Analyze error types for richer recommendation
-			recommendedAction := "reduire la difficulte"
+			recommendedAction := "reduce difficulty"
 			errorTypeCounts := make(map[string]int)
 			for _, i := range recentInteractions {
 				if i.Concept == concept && !i.Success && i.ErrorType != "" {
@@ -99,11 +99,11 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 				}
 			}
 			if errorTypeCounts["KNOWLEDGE_GAP"] >= 3 {
-				recommendedAction = "reduire la difficulte · lacune conceptuelle — revisiter les fondamentaux"
+				recommendedAction = "reduce difficulty - conceptual gap - revisit the fundamentals"
 			} else if errorTypeCounts["LOGIC_ERROR"] >= 3 {
-				recommendedAction = "reduire la difficulte · erreurs de logique recurrentes — exercices de raisonnement"
+				recommendedAction = "reduce difficulty - recurring logic errors - reasoning exercises"
 			} else if errorTypeCounts["SYNTAX_ERROR"] >= 3 {
-				recommendedAction = "reduire la difficulte · erreurs de syntaxe recurrentes — exercices de pratique"
+				recommendedAction = "reduce difficulty - recurring syntax errors - practice exercises"
 			}
 
 			alerts = append(alerts, models.Alert{
@@ -136,7 +136,7 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 				Concept:           cs.Concept,
 				Urgency:           models.UrgencyInfo,
 				ErrorRate:         1.0 - pCorrect,
-				RecommendedAction: fmt.Sprintf("IRT: probabilite de reussite a %.0f%% — difficulte a reduire", pCorrect*100),
+				RecommendedAction: fmt.Sprintf("IRT: success probability at %.0f%% - reduce difficulty", pCorrect*100),
 			})
 		}
 	}
@@ -160,7 +160,7 @@ func ComputeAlerts(states []*models.ConceptState, recentInteractions []*models.I
 					Concept:           concept,
 					Urgency:           models.UrgencyWarning,
 					SessionsStalled:   len(interactions),
-					RecommendedAction: "changer de format · cas reel a debugger",
+					RecommendedAction: "change format - real-world case to debug",
 				})
 			}
 		}

--- a/engine/alert_more_test.go
+++ b/engine/alert_more_test.go
@@ -52,9 +52,9 @@ func TestComputeAlerts_ErrorTypeRecommendations(t *testing.T) {
 		errorType string
 		wantSub   string
 	}{
-		{"knowledge gap", "KNOWLEDGE_GAP", "lacune"},
-		{"logic error", "LOGIC_ERROR", "logique"},
-		{"syntax error", "SYNTAX_ERROR", "syntaxe"},
+		{"knowledge gap", "KNOWLEDGE_GAP", "conceptual gap"},
+		{"logic error", "LOGIC_ERROR", "logic errors"},
+		{"syntax error", "SYNTAX_ERROR", "syntax errors"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/engine/concept_selector.go
+++ b/engine/concept_selector.go
@@ -186,7 +186,7 @@ func selectInstruction(
 		return Selection{
 			NoFringe:  true,
 			Phase:     models.PhaseInstruction,
-			Rationale: "frange externe vide : tout maitrise ou prereqs absents",
+			Rationale: "outer fringe empty: everything mastered or prereqs missing",
 		}
 	}
 
@@ -218,7 +218,7 @@ func selectInstruction(
 		return Selection{
 			NoFringe:  true,
 			Phase:     models.PhaseInstruction,
-			Rationale: "frange non vide mais aucun concept couvert par goal_relevance — appeler set_goal_relevance",
+			Rationale: "fringe non-empty but no concept covered by goal_relevance - call set_goal_relevance",
 		}
 	}
 	return Selection{
@@ -289,7 +289,7 @@ func selectMaintenance(
 		return Selection{
 			NoFringe:  true,
 			Phase:     models.PhaseMaintenance,
-			Rationale: "aucun concept maitrise : MAINTENANCE non applicable",
+			Rationale: "no mastered concept: MAINTENANCE not applicable",
 		}
 	}
 	sort.Slice(mastered, func(i, j int) bool {
@@ -327,7 +327,7 @@ func selectMaintenance(
 		return Selection{
 			NoFringe:  true,
 			Phase:     models.PhaseMaintenance,
-			Rationale: "concepts maitrises mais aucun couvert par goal_relevance — appeler set_goal_relevance",
+			Rationale: "mastered concepts but none covered by goal_relevance - call set_goal_relevance",
 		}
 	}
 	return Selection{

--- a/engine/metacognition.go
+++ b/engine/metacognition.go
@@ -205,8 +205,8 @@ func DetectMirrorPattern(input MirrorInput) *models.MirrorMessage {
 		if declining {
 			return &models.MirrorMessage{
 				Pattern:      "dependency_increasing",
-				Message:      "Ton score d'autonomie a baisse sur les 3 dernieres sessions.",
-				OpenQuestion: "Est-ce que tu sens que tu as besoin de plus de guidage en ce moment, ou est-ce que tu voudrais essayer de travailler plus en autonomie ?",
+				Message:      "Your autonomy score has dropped over the last 3 sessions.",
+				OpenQuestion: "Do you feel you need more guidance right now, or would you like to try working more independently?",
 			}
 		}
 	}
@@ -231,8 +231,8 @@ func DetectMirrorPattern(input MirrorInput) *models.MirrorMessage {
 		if totalOnMastered >= 5 && float64(hintsOnMastered)/float64(totalOnMastered) > 0.5 {
 			return &models.MirrorMessage{
 				Pattern:      "hint_overuse",
-				Message:      "Tu demandes souvent des indices sur des concepts que tu maitrises deja.",
-				OpenQuestion: "Est-ce que c'est par reflexe, ou est-ce qu'il y a un aspect de ces concepts qui te semble encore flou ?",
+				Message:      "You often ask for hints on concepts you have already mastered.",
+				OpenQuestion: "Is it by reflex, or is there an aspect of these concepts that still feels unclear to you?",
 			}
 		}
 	}

--- a/engine/metacognition_push_test.go
+++ b/engine/metacognition_push_test.go
@@ -23,8 +23,8 @@ func TestEnqueueMirrorWebhook_PersistsAndDedups(t *testing.T) {
 
 	mirror := &models.MirrorMessage{
 		Pattern:      "hint_overuse",
-		Message:      "Tu demandes souvent des indices sur des concepts maitrises.",
-		OpenQuestion: "Reflexe ou flou ?",
+		Message:      "You often ask for hints on concepts you have mastered.",
+		OpenQuestion: "Reflex or unclear?",
 	}
 	now := time.Now().UTC()
 
@@ -245,8 +245,8 @@ func TestEnqueueMirrorWebhook_ThenSchedulerSeesDedup(t *testing.T) {
 
 	mirror := &models.MirrorMessage{
 		Pattern:      "dependency_increasing",
-		Message:      "Ton score d'autonomie a baisse.",
-		OpenQuestion: "Plus de guidage ?",
+		Message:      "Your autonomy score has dropped.",
+		OpenQuestion: "More guidance?",
 	}
 	if _, _, err := EnqueueMirrorWebhook(store, learnerID, mirror, time.Now().UTC()); err != nil {
 		t.Fatalf("EnqueueMirrorWebhook: %v", err)

--- a/engine/motivation.go
+++ b/engine/motivation.go
@@ -192,7 +192,7 @@ func ComposeBrief(in BriefInput, kind, pickedAxis string) *models.MotivationBrie
 				Threshold:  threshold,
 			}
 		}
-		brief.Instruction = "Celebre brievement le franchissement du seuil, sans emphase excessive. Relie a la progression globale en une phrase."
+		brief.Instruction = "Briefly celebrate crossing the threshold, without excessive emphasis. Tie it to overall progress in one sentence."
 
 	case models.MotivationKindCompetenceValue:
 		var framings *models.DomainValueFramings
@@ -211,9 +211,9 @@ func ComposeBrief(in BriefInput, kind, pickedAxis string) *models.MotivationBrie
 			Statement: statement,
 		}
 		if statement == "" {
-			brief.Instruction = "Compose une phrase soulignant le gain concret sur l'axe " + pickedAxis + " de la maitrise de ce concept. Puis persiste-la en rappelant a l'utilisateur que c'est une vue parmi d'autres."
+			brief.Instruction = "Compose one sentence highlighting the concrete gain on the " + pickedAxis + " axis from mastering this concept. Then ground it by reminding the user this is one view among others."
 		} else {
-			brief.Instruction = "Integre le gain sur l'axe " + pickedAxis + " en une phrase, relie au concept de l'exercice. Pas de chiffres invente, pas de copie verbatim du statement."
+			brief.Instruction = "Integrate the gain on the " + pickedAxis + " axis in one sentence, tied to the exercise concept. No invented numbers, no verbatim copy of the statement."
 		}
 		if in.Domain != nil {
 			brief.GoalLink = in.Domain.PersonalGoal
@@ -264,7 +264,7 @@ func ComposeBrief(in BriefInput, kind, pickedAxis string) *models.MotivationBrie
 		if in.Domain != nil {
 			brief.GoalLink = in.Domain.PersonalGoal
 		}
-		brief.Instruction = "Relie exercice -> concept -> goal_link en UNE phrase. Ni plus ni moins."
+		brief.Instruction = "Tie exercise -> concept -> goal_link in ONE sentence. No more, no less."
 	}
 
 	return brief

--- a/engine/orchestrator.go
+++ b/engine/orchestrator.go
@@ -427,8 +427,8 @@ func composeActivity(a Action, sel Selection, phase models.Phase) models.Activit
 		DifficultyTarget: a.DifficultyTarget,
 		Format:           a.Format,
 		EstimatedMinutes: a.EstimatedMinutes,
-		Rationale:        fmt.Sprintf("[phase=%s] %s · %s", phase, sel.Rationale, a.Rationale),
-		PromptForLLM:     fmt.Sprintf("Genere une activite %s sur %s. Format: %s. Difficulte cible: %.2f.", a.Type, sel.Concept, a.Format, a.DifficultyTarget),
+		Rationale:        fmt.Sprintf("[phase=%s] %s - %s", phase, sel.Rationale, a.Rationale),
+		PromptForLLM:     fmt.Sprintf("Generate a %s activity on %s. Format: %s. Target difficulty: %.2f.", a.Type, sel.Concept, a.Format, a.DifficultyTarget),
 	}
 }
 

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -224,11 +224,11 @@ func (s *Scheduler) dispatchQueued(kind, alertTag string, fallback func(*models.
 func queueKindTitle(kind string) string {
 	switch kind {
 	case "daily_motivation":
-		return "☀️ Bonjour"
+		return "☀️ Good morning"
 	case "daily_recap":
-		return "🌙 Ce soir"
+		return "🌙 Tonight"
 	case "reactivation":
-		return "👋 Reprends quand tu veux"
+		return "👋 Come back whenever you want"
 	case "reminder":
 		return "📚 Note"
 	}
@@ -251,16 +251,16 @@ func queueKindColor(kind string) int {
 
 func fallbackDailyMotivation(_ *models.Learner) discordPayload {
 	return discordPayload{Embeds: []discordEmbed{{
-		Title:       "☀️ Bonjour",
-		Description: "Meme 5 minutes aujourd'hui, ca tient la trajectoire. Reviens quand tu veux.",
+		Title:       "☀️ Good morning",
+		Description: "Even 5 minutes today keeps the trajectory. Come back whenever you want.",
 		Color:       0x5865F2,
 	}}}
 }
 
 func fallbackDailyRecap(_ *models.Learner) discordPayload {
 	return discordPayload{Embeds: []discordEmbed{{
-		Title:       "🌙 Ce soir",
-		Description: "Si tu passes, on continue. Sinon, a demain.",
+		Title:       "🌙 Tonight",
+		Description: "If you stop by, we keep going. Otherwise, see you tomorrow.",
 		Color:       0x57F287,
 	}}}
 }
@@ -539,7 +539,7 @@ func mirrorEmbedFromContent(content string) discordEmbed {
 		}
 	}
 	return discordEmbed{
-		Title:       "🪞 Reflet du jour",
+		Title:       "🪞 Mirror of the day",
 		Description: desc,
 		Color:       0x9B59B6,
 	}

--- a/engine/scheduler_http_test.go
+++ b/engine/scheduler_http_test.go
@@ -323,9 +323,9 @@ func TestQueueKindTitleAndColor(t *testing.T) {
 		color    int
 		titleSub string
 	}{
-		{"daily_motivation", "", 0x5865F2, "Bonjour"},
-		{"daily_recap", "", 0x57F287, "Ce soir"},
-		{"reactivation", "", 0xFEE75C, "Reprends"},
+		{"daily_motivation", "", 0x5865F2, "Good morning"},
+		{"daily_recap", "", 0x57F287, "Tonight"},
+		{"reactivation", "", 0xFEE75C, "Come back"},
 		{"reminder", "", 0x99AAB5, "Note"},
 		{"unknown", "", 0x99AAB5, "Message"},
 	}
@@ -347,8 +347,8 @@ func TestQueueKindTitleAndColor(t *testing.T) {
 
 func TestFallbackPayloads(t *testing.T) {
 	p := fallbackDailyMotivation(&models.Learner{ID: "L1"})
-	if len(p.Embeds) != 1 || !strings.Contains(p.Embeds[0].Title, "Bonjour") {
-		t.Errorf("fallbackDailyMotivation = %+v, want title with 'Bonjour'", p)
+	if len(p.Embeds) != 1 || !strings.Contains(p.Embeds[0].Title, "Good morning") {
+		t.Errorf("fallbackDailyMotivation = %+v, want title with 'Good morning'", p)
 	}
 	if p.Embeds[0].Color != 0x5865F2 {
 		t.Errorf("fallbackDailyMotivation color = %#x, want 0x5865F2", p.Embeds[0].Color)
@@ -358,8 +358,8 @@ func TestFallbackPayloads(t *testing.T) {
 	}
 
 	p2 := fallbackDailyRecap(&models.Learner{ID: "L1"})
-	if len(p2.Embeds) != 1 || !strings.Contains(p2.Embeds[0].Title, "Ce soir") {
-		t.Errorf("fallbackDailyRecap = %+v, want title with 'Ce soir'", p2)
+	if len(p2.Embeds) != 1 || !strings.Contains(p2.Embeds[0].Title, "Tonight") {
+		t.Errorf("fallbackDailyRecap = %+v, want title with 'Tonight'", p2)
 	}
 	if p2.Embeds[0].Color != 0x57F287 {
 		t.Errorf("fallbackDailyRecap color = %#x, want 0x57F287", p2.Embeds[0].Color)

--- a/engine/scheduler_jobs_test.go
+++ b/engine/scheduler_jobs_test.go
@@ -258,8 +258,8 @@ func TestDispatchQueued_FallbackWhenQueueEmpty(t *testing.T) {
 	if len(bodies) != 1 {
 		t.Fatalf("got %d webhook hits, want 1 (fallback)", len(bodies))
 	}
-	if !contains(bodies[0], "Ce soir") {
-		t.Errorf("fallback payload should mention 'Ce soir', got %s", bodies[0])
+	if !contains(bodies[0], "Tonight") {
+		t.Errorf("fallback payload should mention 'Tonight', got %s", bodies[0])
 	}
 }
 

--- a/engine/scheduler_metacog.go
+++ b/engine/scheduler_metacog.go
@@ -37,23 +37,23 @@ func metacogKindToWebhookKind(t models.AlertType) string {
 func metacogFallbackContent(a models.Alert) string {
 	switch a.Type {
 	case models.AlertDependencyIncreasing:
-		return "Ton score d'autonomie a baisse sur les 3 dernieres sessions. " +
-			"Quand tu reprends, on peut en parler — appelle get_metacognitive_mirror."
+		return "Your autonomy score has dropped over the last 3 sessions. " +
+			"When you come back, we can talk about it - call get_metacognitive_mirror."
 	case models.AlertCalibrationDiverging:
-		return "Ta calibration s'est ecartee de la realite (" + a.RecommendedAction + "). " +
-			"Une courte session de calibration peut aider — calibration_check."
+		return "Your calibration has drifted from reality (" + a.RecommendedAction + "). " +
+			"A short calibration session can help - calibration_check."
 	case models.AlertAffectNegative:
-		return "Deux sessions consecutives ont ete dures. " +
-			"On peut adapter le tutor_mode quand tu reviens."
+		return "The last two sessions have been hard. " +
+			"We can adjust tutor_mode when you return."
 	case models.AlertTransferBlocked:
 		concept := a.Concept
 		if concept == "" {
-			concept = "un concept maitrise"
+			concept = "a mastered concept"
 		}
-		return "Le transfert sur \"" + concept + "\" reste faible malgre la maitrise. " +
-			"Un Feynman challenge debloquerait probablement la situation."
+		return "Transfer on \"" + concept + "\" remains weak despite mastery. " +
+			"A Feynman challenge would likely unblock the situation."
 	}
-	return "Une nouvelle observation metacognitive est disponible."
+	return "A new metacognitive observation is available."
 }
 
 // dispatchMetacognitiveAlerts iterates over every active learner, computes

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -24,7 +24,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 		Name: "get_next_activity",
 		Description: "Determine the next optimal activity for the learner and aggregate all routing context: metacognitive_mirror, tutor_mode, motivation_brief, active misconceptions. Accounts for the current session to avoid repeating the same concept. " +
 			"When to call: AFTER get_pending_alerts, once no critical alert is blocking progress and the learner has an active domain. This is the main tool of the learning cycle. " +
-			"When NOT to call: if get_pending_alerts returned needs_domain_setup=true (call init_domain first); do not call get_metacognitive_mirror in the same turn — the mirror is already included in the metacognitive_mirror key of the response. " +
+			"When NOT to call: if get_pending_alerts returned needs_domain_setup=true (call init_domain first); do not call get_metacognitive_mirror in the same turn - the mirror is already included in the metacognitive_mirror key of the response. " +
 			"Precondition: a domain must exist; otherwise needs_domain_setup=true is returned with a setup_domain activity. " +
 			"Returns: {needs_domain_setup, domain_id, activity, session_concepts_done, metacognitive_mirror, tutor_mode, active_misconceptions, known_misconception_types, motivation_brief}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetNextActivityParams) (*mcp.CallToolResult, any, error) {
@@ -216,10 +216,10 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 					}
 					misconceptionPrompt += m.MisconceptionType
 					if m.LastErrorDetail != "" {
-						misconceptionPrompt += " — " + m.LastErrorDetail
+						misconceptionPrompt += " - " + m.LastErrorDetail
 					}
 				}
-				misconceptionPrompt += ". Target these confusions in your explanation and exercise. Do not explicitly mention the misconceptions — design the exercise so the learner confronts them naturally."
+				misconceptionPrompt += ". Target these confusions in your explanation and exercise. Do not explicitly mention the misconceptions - design the exercise so the learner confronts them naturally."
 				activity.PromptForLLM += misconceptionPrompt
 			}
 

--- a/tools/alerts.go
+++ b/tools/alerts.go
@@ -20,10 +20,10 @@ type GetPendingAlertsParams struct {
 func registerGetPendingAlerts(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_pending_alerts",
-		Description: "Retrieve ALL pending alerts for the learner — activity alerts (PLATEAU, FATIGUE, …) AND metacognitive alerts (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE, TRANSFER_BLOCKED). " +
+		Description: "Retrieve ALL pending alerts for the learner - activity alerts (PLATEAU, FATIGUE, etc.) AND metacognitive alerts (DEPENDENCY_INCREASING, CALIBRATION_DIVERGING, AFFECT_NEGATIVE, TRANSFER_BLOCKED). " +
 			"When to call: FIRST each turn, before any other read tool. If a critical alert surfaces (has_critical=true), handle it before proceeding. " +
-			"When NOT to call: once per turn is sufficient; metacognitive alerts are already included here — do not call a separate tool to retrieve them. " +
-			"Precondition: if the learner has no active domain, returns needs_domain_setup=true and an empty alerts list — call init_domain before continuing. " +
+			"When NOT to call: once per turn is sufficient; metacognitive alerts are already included here - do not call a separate tool to retrieve them. " +
+			"Precondition: if the learner has no active domain, returns needs_domain_setup=true and an empty alerts list - call init_domain before continuing. " +
 			"Returns: {alerts: [...], has_critical: bool, needs_domain_setup: bool}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetPendingAlertsParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)

--- a/tools/context.go
+++ b/tools/context.go
@@ -88,13 +88,13 @@ func registerGetLearnerContext(server *mcp.Server, deps *Deps) {
 		}
 
 		// Build opening message
-		openingMessage := fmt.Sprintf("Jour %d", dayNumber)
+		openingMessage := fmt.Sprintf("Day %d", dayNumber)
 		if learner.Objective != "" {
-			openingMessage += fmt.Sprintf(" · Objectif: %s", learner.Objective)
+			openingMessage += fmt.Sprintf(" - Goal: %s", learner.Objective)
 		}
-		openingMessage += fmt.Sprintf(" · %s", lastSessionInfo)
+		openingMessage += fmt.Sprintf(" - %s", lastSessionInfo)
 		if priorityConcept != "" {
-			openingMessage += fmt.Sprintf(" · Priorite: %s (retention %.0f%%)", priorityConcept, priorityRetention*100)
+			openingMessage += fmt.Sprintf(" - Priority: %s (retention %.0f%%)", priorityConcept, priorityRetention*100)
 		}
 
 		// List active domains for multi-domain awareness

--- a/tools/domain.go
+++ b/tools/domain.go
@@ -236,7 +236,7 @@ type InitDomainParams struct {
 	Concepts      []string            `json:"concepts" jsonschema:"list of domain concepts"`
 	Prerequisites map[string][]string `json:"prerequisites" jsonschema:"prerequisite graph (concept -> list of prerequisites)"`
 	PersonalGoal  string              `json:"personal_goal,omitempty" jsonschema:"learner's personal goal within this domain (optional)"`
-	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 value axes (financial/employment/intellectual/innovation). 1-2 sentences per axis. Optional — can be filled in later."`
+	ValueFramings *ValueFramingsInput `json:"value_framings,omitempty" jsonschema:"4 value axes (financial/employment/intellectual/innovation). 1-2 sentences per axis. Optional - can be filled in later."`
 }
 
 func registerInitDomain(server *mcp.Server, deps *Deps) {
@@ -341,7 +341,7 @@ func registerInitDomain(server *mcp.Server, deps *Deps) {
 		if regulationGoalEnabled() {
 			reason := fmt.Sprintf("Decompose the personal_goal against the %d concepts via set_goal_relevance to activate goal-aware routing.", len(params.Concepts))
 			if params.PersonalGoal == "" {
-				reason = "personal_goal is empty — set_goal_relevance remains optional; call it if you want to manually annotate relevance per concept."
+				reason = "personal_goal is empty - set_goal_relevance remains optional; call it if you want to manually annotate relevance per concept."
 			}
 			response["next_action"] = map[string]any{
 				"version":  1,
@@ -466,7 +466,7 @@ func registerAddConcepts(server *mcp.Server, deps *Deps) {
 			response["next_action"] = map[string]any{
 				"version":  1,
 				"tool":     "set_goal_relevance",
-				"reason":   fmt.Sprintf("%d new concepts added; call set_goal_relevance with their scores to preserve goal-aware routing (semantics are incremental — existing concepts are not erased).", added),
+				"reason":   fmt.Sprintf("%d new concepts added; call set_goal_relevance with their scores to preserve goal-aware routing (semantics are incremental - existing concepts are not erased).", added),
 				"required": false,
 			}
 		}

--- a/tools/feynman.go
+++ b/tools/feynman.go
@@ -64,7 +64,7 @@ func registerFeynmanChallenge(server *mcp.Server, deps *Deps) {
 
 		promptText := fmt.Sprintf(
 			"Explain the concept '%s' as if you were teaching it to someone who knows nothing about it. "+
-				"No technical jargon — use analogies and concrete examples. "+
+				"No technical jargon - use analogies and concrete examples. "+
 				"The goal is to verify that you truly understood it, not just that you can recite it.\n\n"+
 				"After your explanation, I will identify the fuzzy or incomplete points "+
 				"and turn them into micro-concepts to work on.",

--- a/tools/get_dashboard_state.go
+++ b/tools/get_dashboard_state.go
@@ -158,7 +158,7 @@ func registerGetDashboardState(server *mcp.Server, deps *Deps) {
 			frontier := algorithms.ComputeFrontier(graph, mastery)
 			nextAction := "continue reviewing"
 			if len(frontier) > 0 {
-				nextAction = fmt.Sprintf("nouveau concept: %s", frontier[0])
+				nextAction = fmt.Sprintf("new concept: %s", frontier[0])
 			}
 
 			progressPct := 0.0

--- a/tools/goal_relevance.go
+++ b/tools/goal_relevance.go
@@ -84,7 +84,7 @@ func registerSetGoalRelevance(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("set_goal_relevance: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("set_goal_relevance: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}
@@ -97,7 +97,7 @@ func registerSetGoalRelevance(server *mcp.Server, deps *Deps) {
 		}
 		for k := range params.Relevance {
 			if !known[k] {
-				r, _ := errorResult(fmt.Sprintf("unknown concept %q — not present in domain %q (call get_learner_context to see the concept list)", k, domain.ID))
+				r, _ := errorResult(fmt.Sprintf("unknown concept %q - not present in domain %q (call get_learner_context to see the concept list)", k, domain.ID))
 				return r, nil, nil
 			}
 		}
@@ -190,7 +190,7 @@ func registerGetGoalRelevance(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("get_goal_relevance: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("get_goal_relevance: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}

--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -16,11 +16,11 @@ import (
 
 type RecordInteractionParams struct {
 	Concept             string  `json:"concept" jsonschema:"the concept being practiced"`
-	ActivityType        string  `json:"activity_type" jsonschema:"activity type — MUST be one of the canonical values: RECALL_EXERCISE, NEW_CONCEPT, MASTERY_CHALLENGE, DEBUGGING_CASE, REST, SETUP_DOMAIN, PRACTICE, DEBUG_MISCONCEPTION, FEYNMAN_PROMPT, TRANSFER_PROBE, CLOSE_SESSION"`
+	ActivityType        string  `json:"activity_type" jsonschema:"activity type - MUST be one of the canonical values: RECALL_EXERCISE, NEW_CONCEPT, MASTERY_CHALLENGE, DEBUGGING_CASE, REST, SETUP_DOMAIN, PRACTICE, DEBUG_MISCONCEPTION, FEYNMAN_PROMPT, TRANSFER_PROBE, CLOSE_SESSION"`
 	Success             bool    `json:"success" jsonschema:"whether the exercise was completed successfully"`
 	ResponseTimeSeconds float64 `json:"response_time_seconds" jsonschema:"response time in seconds"`
 	Confidence          float64 `json:"confidence" jsonschema:"estimated confidence between 0 and 1"`
-	ErrorType           string  `json:"error_type,omitempty" jsonschema:"error type on failure — leave empty or use exactly: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP"`
+	ErrorType           string  `json:"error_type,omitempty" jsonschema:"error type on failure - leave empty or use exactly: SYNTAX_ERROR, LOGIC_ERROR, KNOWLEDGE_GAP"`
 	Notes               string  `json:"notes" jsonschema:"optional notes about the interaction"`
 	DomainID            string  `json:"domain_id,omitempty" jsonschema:"domain ID (optional)"`
 	HintsRequested      int     `json:"hints_requested,omitempty" jsonschema:"number of hints requested during the exchange (optional, default 0)"`
@@ -117,7 +117,7 @@ func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("record_interaction: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("record_interaction: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}

--- a/tools/manage_domain.go
+++ b/tools/manage_domain.go
@@ -18,7 +18,7 @@ type ArchiveDomainParams struct {
 func registerArchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "archive_domain",
-		Description: "Archive a domain — it disappears from the dashboard and routing but progress is preserved. Use unarchive_domain to reactivate it.",
+		Description: "Archive a domain - it disappears from the dashboard and routing but progress is preserved. Use unarchive_domain to reactivate it.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ArchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -66,7 +66,7 @@ type UnarchiveDomainParams struct {
 func registerUnarchiveDomain(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "unarchive_domain",
-		Description: "Reactivate an archived domain — it reappears in the dashboard and routing with all its progress preserved.",
+		Description: "Reactivate an archived domain - it reappears in the dashboard and routing with all its progress preserved.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params UnarchiveDomainParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {

--- a/tools/mastery.go
+++ b/tools/mastery.go
@@ -60,10 +60,10 @@ func registerCheckMastery(server *mcp.Server, deps *Deps) {
 			"current_mastery": cs.PMastery,
 			"challenge": map[string]interface{}{
 				"prompt_for_llm": fmt.Sprintf(
-					"Genere un mastery challenge sur %s. "+
-						"L'apprenant doit construire quelque chose de complet qui demontre le transfert. "+
-						"Evalue: application autonome, gestion des cas limites, qualite du code. "+
-						"Ne guide pas — observe si l'apprenant peut appliquer seul.",
+					"Generate a mastery challenge on %s. "+
+						"The learner must build something complete that demonstrates transfer. "+
+						"Evaluate: autonomous application, edge-case handling, code quality. "+
+						"Do not guide - observe whether the learner can apply the concept alone.",
 					params.Concept,
 				),
 				"evaluation_criteria": []string{

--- a/tools/mirror.go
+++ b/tools/mirror.go
@@ -21,8 +21,8 @@ func registerGetMetacognitiveMirror(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_metacognitive_mirror",
 		Description: "Return a factual mirror message if a dependency pattern is consolidated over the last 7 days, otherwise mirror=null. On-demand metacognitive reflection tool. " +
-			"When to call: ONLY outside the activity cycle — for example, on an explicit request for a metacognitive review, or when the learner asks about their own learning patterns. " +
-			"When NOT to call: if get_next_activity was already called in the same turn, the mirror is already present in its metacognitive_mirror key — a second call here duplicates work (same computation, same webhook queue deduplicated per day). " +
+			"When to call: ONLY outside the activity cycle - for example, on an explicit request for a metacognitive review, or when the learner asks about their own learning patterns. " +
+			"When NOT to call: if get_next_activity was already called in the same turn, the mirror is already present in its metacognitive_mirror key - a second call here duplicates work (same computation, same webhook queue deduplicated per day). " +
 			"Precondition: none; if no pattern is detected, mirror=null is returned without error. " +
 			"Returns: {mirror: <object or null>}.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GetMetacognitiveMirrorParams) (*mcp.CallToolResult, any, error) {

--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -33,7 +33,7 @@ type tradeoff struct {
 func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "learning_negotiation",
-		Description: "Expose the session plan with rationale. The learner can propose an alternative — the system accepts or explains the trade-offs.",
+		Description: "Expose the session plan with rationale. The learner can propose an alternative - the system accepts or explains the trade-offs.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params LearningNegotiationParams) (*mcp.CallToolResult, any, error) {
 		learnerID, err := getLearnerID(ctx)
 		if err != nil {
@@ -70,7 +70,7 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("learning_negotiation: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("learning_negotiation: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}
@@ -142,7 +142,7 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 					tradeoffs = append(tradeoffs, tradeoff{
 						Factor:      "retention",
 						SystemPlan:  fmt.Sprintf("reviser %s maintient retention a %.0f%%", systemConcept, currentRet*100),
-						LearnerPlan: fmt.Sprintf("reporter %s — retention tombera a %.0f%% demain", systemConcept, futureRet*100),
+						LearnerPlan: fmt.Sprintf("postpone %s - retention will drop to %.0f%% tomorrow", systemConcept, futureRet*100),
 						Delta:       currentRet - futureRet,
 					})
 				}

--- a/tools/negotiation.go
+++ b/tools/negotiation.go
@@ -141,7 +141,7 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 					futureRet := algorithms.Retrievability(elapsed+1, systemCS.Stability)
 					tradeoffs = append(tradeoffs, tradeoff{
 						Factor:      "retention",
-						SystemPlan:  fmt.Sprintf("reviser %s maintient retention a %.0f%%", systemConcept, currentRet*100),
+						SystemPlan:  fmt.Sprintf("reviewing %s keeps retention at %.0f%%", systemConcept, currentRet*100),
 						LearnerPlan: fmt.Sprintf("postpone %s - retention will drop to %.0f%% tomorrow", systemConcept, futureRet*100),
 						Delta:       currentRet - futureRet,
 					})
@@ -186,8 +186,8 @@ func registerLearningNegotiation(server *mcp.Server, deps *Deps) {
 					DifficultyTarget: difficulty,
 					Format:           "mixed",
 					EstimatedMinutes: 15,
-					Rationale:        fmt.Sprintf("choix negocie de l'apprenant: %s", params.LearnerRationale),
-					PromptForLLM:     fmt.Sprintf("L'apprenant a choisi de travailler sur %s. Genere un exercice adapte.", params.LearnerConcept),
+					Rationale:        fmt.Sprintf("learner-negotiated choice: %s", params.LearnerRationale),
+					PromptForLLM:     fmt.Sprintf("The learner chose to work on %s. Generate a suitable exercise.", params.LearnerConcept),
 				}
 			}
 

--- a/tools/queue_webhook_test.go
+++ b/tools/queue_webhook_test.go
@@ -100,7 +100,7 @@ func TestQueueWebhookMessage_HappyPath(t *testing.T) {
 		"kind":          "daily_motivation",
 		"scheduled_for": "2026-05-03T08:00:00Z",
 		"expires_at":    "2026-05-03T20:00:00Z",
-		"content":       "Bonjour, garde le cap.",
+		"content":       "Good morning, stay the course.",
 		"priority":      5,
 	})
 	if res.IsError {
@@ -122,7 +122,7 @@ func TestQueueWebhookMessage_HappyPath(t *testing.T) {
 	if len(pending) != 1 {
 		t.Fatalf("expected 1 pending message, got %d", len(pending))
 	}
-	if pending[0].Content != "Bonjour, garde le cap." {
+	if pending[0].Content != "Good morning, stay the course." {
 		t.Fatalf("content mismatch: %q", pending[0].Content)
 	}
 	if pending[0].Priority != 5 {

--- a/tools/registration_test.go
+++ b/tools/registration_test.go
@@ -15,59 +15,18 @@ import (
 	"testing"
 )
 
-// strippedFrenchStems is a denylist of French stems that have lost their
-// diacritics. We only flag French words whose accented form is canonical and
-// for which the stripped form has no plausible English collision.
-//
-// Each entry must match a substring inside a Go string literal taken from a
-// `Description:` field (or `jsonschema:` tag). Keep this list small and
-// audited — false positives block CI.
-var strippedFrenchStems = []string{
-	"Determine la",     // "Détermine la" — French phrase
-	"Recupere",         // "Récupère"
-	"Genere ",          // "Génère " (with trailing space to avoid hitting English "Genere..." ids)
-	"activite ",        // "activité "
-	"activite.",        // "activité."
-	"disponibilite",    // "disponibilité"
-	"creneaux",         // "créneaux"
-	"duree moyenne",    // "durée moyenne"
-	"frequence)",       // "fréquence)"
-	"prediction de l'", // "prédiction de l'apprenant" — French only
-	"resultat reel",    // "résultat réel"
-	"etat cognitif",    // "état cognitif"
-	"etat emotionnel",  // "état émotionnel"
-	"debut de session", // "début de session"
-	"reponse en sec",   // "réponse en secondes"
-	"detectees par",    // "détectées par"
-	"maitrise",         // "maîtrise" / "maîtrisé"
-	"prerequis ",       // "prérequis " (space-bounded to avoid English "prerequisites")
-	"prerequis (",      // "prérequis ("
-	"prerequis)",       // "prérequis)"
-	"prerequis.",       // "prérequis."
-	"detruire",         // "détruire" / "détruit"
-	"definitivement",   // "définitivement"
-	"preserves.",       // "préservés."
-	"preservee",        // "préservée"
-	"reactiver",        // "réactiver"
-	"domaine archive",  // French past participle "domaine archivé"
-	"Reactive un",      // French "Réactive un domaine"
-	"systeme",          // "système"
-	"methode Feynman",  // "méthode Feynman"
-	"inedite",          // "inédite"
-	"fenetre",          // "fenêtre"
-	"caracteres recommande", // "caractères recommandé"
-	"Cloture",          // "Clôture"
-	"structures pour",  // French "structurés pour"
-	"metadonnees",      // "métadonnées"
-	"modifies.",        // "modifiés."
-	"Necessite",        // "Nécessite"
-}
+// nonASCII matches any byte outside the 7-bit ASCII range.
+var nonASCII = regexp.MustCompile(`[^\x00-\x7F]`)
 
-// TestToolDescriptions_NoStrippedFrenchDiacritics walks every tool source file
-// and asserts no `Description:` value (or `jsonschema:` tag) contains a known
-// stripped-accent French stem. The denylist is conservative: it only flags
-// stems that are unambiguously French (no plausible English collision).
-func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
+// TestToolDescriptions_ASCIIOnly walks every non-test Go file in the tools/
+// package and asserts that Description: literals and jsonschema:"..." struct
+// tags contain only 7-bit ASCII characters.
+//
+// Rationale: the source language is English (see CONTRIBUTING.md > Language
+// and docs/i18n.md). Non-ASCII characters in learner-facing strings indicate
+// a leaked non-English string, which the runtime LLM-mediated translation
+// contract forbids.
+func TestToolDescriptions_ASCIIOnly(t *testing.T) {
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatal(err)
@@ -77,11 +36,9 @@ func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
 	var failures []string
 
 	for _, path := range files {
-		// Skip test files — denylist literals appear there legitimately.
 		if strings.HasSuffix(path, "_test.go") {
 			continue
 		}
-
 		src, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
@@ -94,7 +51,6 @@ func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
 		ast.Inspect(f, func(n ast.Node) bool {
 			switch x := n.(type) {
 			case *ast.KeyValueExpr:
-				// Catch `Description: "..."` literals.
 				key, ok := x.Key.(*ast.Ident)
 				if !ok || key.Name != "Description" {
 					return true
@@ -103,28 +59,20 @@ func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
 				if !ok || lit.Kind != token.STRING {
 					return true
 				}
-				val := lit.Value
-				for _, stem := range strippedFrenchStems {
-					if strings.Contains(val, stem) {
-						pos := fset.Position(lit.Pos())
-						failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
-					}
+				if nonASCII.MatchString(lit.Value) {
+					pos := fset.Position(lit.Pos())
+					failures = append(failures, formatFailure(pos.Filename, pos.Line, "non-ASCII in Description", lit.Value))
 				}
 			case *ast.BasicLit:
-				// Catch raw struct-tag string literals containing
-				// `jsonschema:"..."`.
 				if x.Kind != token.STRING {
 					return true
 				}
-				val := x.Value
-				if !strings.Contains(val, "jsonschema:") {
+				if !strings.Contains(x.Value, "jsonschema:") {
 					return true
 				}
-				for _, stem := range strippedFrenchStems {
-					if strings.Contains(val, stem) {
-						pos := fset.Position(x.Pos())
-						failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
-					}
+				if nonASCII.MatchString(x.Value) {
+					pos := fset.Position(x.Pos())
+					failures = append(failures, formatFailure(pos.Filename, pos.Line, "non-ASCII in jsonschema tag", x.Value))
 				}
 			}
 			return true
@@ -132,60 +80,22 @@ func TestToolDescriptions_NoStrippedFrenchDiacritics(t *testing.T) {
 	}
 
 	if len(failures) > 0 {
-		t.Fatalf("found %d stripped-accent French stem(s) in tool descriptions:\n%s",
+		t.Fatalf("found %d non-ASCII learner-facing string(s):\n%s",
 			len(failures), strings.Join(failures, "\n"))
 	}
 }
 
-// learnerFacingStrippedStems are stripped-French stems that have appeared in
-// learner-facing string literals (handler-returned map values, error
-// messages, prompts) — anywhere outside `Description:` / `jsonschema:`.
-//
-// These are matched as whole words inside *any* string literal in the files
-// listed by stringLiteralLintFiles. Whole-word boundaries (\b) keep us safe
-// from collisions with English fragments and from Go identifier matches
-// (which are not BasicLit anyway). Trailing-s is allowed so plural French
-// stems are caught too.
-var learnerFacingStrippedStems = []string{
-	"maitrise",   // "maîtrise" / "maîtrisé"
-	"Apres",      // "Après"
-	"verifier",   // "vérifier"
-	"prerequis",  // "prérequis"
-	"reguliere",  // "régulière"
-	"regulier",   // "régulier"
-	"specifique", // "spécifique" / "spécifiques"
-	"genere",     // "génère"
-	"reciter",    // "réciter"
-	"connait",    // "connaît"
-	"enleve",     // "enlève"
-	"reflechi",   // "réfléchi"
-}
-
-// stringLiteralLintFiles is the set of source files whose every string
-// literal is checked against learnerFacingStrippedStems. The narrower
-// `Description:` / `jsonschema:` lint above runs across all tool files; this
-// stricter walk targets handlers known to emit learner-facing strings inside
-// returned maps / formatted prompts (see issue #28). Add files here as new
-// regressions are caught.
+// stringLiteralLintFiles lists files whose every string literal is checked
+// against the ASCII-only rule, not just Description / jsonschema tags. Use
+// this for handlers known to return learner-facing strings inside map values
+// or formatted prompts.
 var stringLiteralLintFiles = []string{
 	"feynman.go",
 }
 
-// TestToolStringLiterals_NoStrippedFrenchDiacritics widens the diacritic lint
-// to every string literal (any *ast.BasicLit of kind STRING) in the files
-// listed in stringLiteralLintFiles, not just `Description:` / `jsonschema:`
-// tags. This catches handler-returned map values like
-// `"message": "Concept pas encore maitrise..."` that the narrower lint
-// missed (see issue #28).
-func TestToolStringLiterals_NoStrippedFrenchDiacritics(t *testing.T) {
-	// Pre-compile whole-word regexps for each stem. Trailing-s is allowed
-	// (so "specifique" matches "specifiques") because plural French stems
-	// are a single transformation away from the singular.
-	stemREs := make(map[string]*regexp.Regexp, len(learnerFacingStrippedStems))
-	for _, stem := range learnerFacingStrippedStems {
-		stemREs[stem] = regexp.MustCompile(`\b` + regexp.QuoteMeta(stem) + `s?\b`)
-	}
-
+// TestToolStringLiterals_ASCIIOnly widens the ASCII check to every string
+// literal in the files listed by stringLiteralLintFiles.
+func TestToolStringLiterals_ASCIIOnly(t *testing.T) {
 	fset := token.NewFileSet()
 	var failures []string
 
@@ -208,29 +118,26 @@ func TestToolStringLiterals_NoStrippedFrenchDiacritics(t *testing.T) {
 				return true
 			}
 			val := lit.Value
-			// Skip raw struct tags so we don't double-fire with the
-			// narrower lint above on `jsonschema:` / `json:` literals.
+			// Skip struct tags handled by the narrower lint above.
 			if strings.Contains(val, "jsonschema:") || strings.Contains(val, "json:\"") {
 				return true
 			}
-			for _, stem := range learnerFacingStrippedStems {
-				if stemREs[stem].MatchString(val) {
-					pos := fset.Position(lit.Pos())
-					failures = append(failures, formatFailure(pos.Filename, pos.Line, stem, val))
-				}
+			if nonASCII.MatchString(val) {
+				pos := fset.Position(lit.Pos())
+				failures = append(failures, formatFailure(pos.Filename, pos.Line, "non-ASCII in learner-facing string", val))
 			}
 			return true
 		})
 	}
 
 	if len(failures) > 0 {
-		t.Fatalf("found %d stripped-accent French stem(s) in tool string literals:\n%s",
+		t.Fatalf("found %d non-ASCII learner-facing string literal(s):\n%s",
 			len(failures), strings.Join(failures, "\n"))
 	}
 }
 
-func formatFailure(file string, line int, stem, val string) string {
-	return "  " + file + ":" + itoa(line) + ": stripped stem " + quote(stem) + " in " + truncate(val, 120)
+func formatFailure(file string, line int, label, val string) string {
+	return "  " + file + ":" + itoa(line) + ": " + label + " in " + truncate(val, 120)
 }
 
 func itoa(i int) string {
@@ -253,10 +160,6 @@ func itoa(i int) string {
 		buf[pos] = '-'
 	}
 	return string(buf[pos:])
-}
-
-func quote(s string) string {
-	return "\"" + s + "\""
 }
 
 func truncate(s string, n int) string {

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -44,7 +44,7 @@ func registerRecordSessionClose(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("record_session_close: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("record_session_close: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}
@@ -153,7 +153,7 @@ func buildRecapBrief(deps *Deps, learnerID string, domain *models.Domain) *model
 		"and wait for the answer to call record_session_close again with implementation_intention. " +
 		"Then call get_olm_snapshot to retrieve the learner's structured cognitive state, " +
 		"and call queue_webhook_message 3 times: daily_motivation for tomorrow at 8h UTC (warm, tied to personal_goal) ; " +
-		"olm:<domain_id> for tomorrow at 13h UTC (factual — distribution + focus + ONE metacog line if active + progress toward goal — no pep talk, content must MATCH the get_olm_snapshot snapshot) ; " +
+		"olm:<domain_id> for tomorrow at 13h UTC (factual - distribution + focus + ONE metacog line if active + progress toward goal - no pep talk, content must MATCH the get_olm_snapshot snapshot) ; " +
 		"daily_recap for tomorrow at 21h UTC (gentle recap). " +
 		"No raw KPIs."
 

--- a/tools/transfer.go
+++ b/tools/transfer.go
@@ -193,7 +193,7 @@ func registerRecordTransferResult(server *mcp.Server, deps *Deps) {
 				r, _ := errorResult("domain not found")
 				return r, nil, nil
 			}
-			deps.Logger.Info("record_transfer_result: no active domain — needs setup", "learner", learnerID)
+			deps.Logger.Info("record_transfer_result: no active domain - needs setup", "learner", learnerID)
 			r, _ := noActiveDomainResult()
 			return r, nil, nil
 		}

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -18,7 +18,7 @@ import (
 // self-correct (call get_learner_context to refresh the concept list).
 func validateConceptInDomain(d *models.Domain, concept string) error {
 	if d == nil {
-		return fmt.Errorf("no active domain — call init_domain first")
+		return fmt.Errorf("no active domain - call init_domain first")
 	}
 	for _, c := range d.Graph.Concepts {
 		if c == concept {
@@ -120,7 +120,7 @@ func validateNonNegativeCount(field string, v, max int) error {
 const (
 	maxShortLabelLen = 200    // concept names, error_type, activity_type, session_id, kind labels
 	maxNoteLen       = 4096   // notes, misconception_detail, intent prompts
-	maxLongTextLen   = 16_384 // free-form payloads (rationale, content) — last-resort cap
+	maxLongTextLen   = 16_384 // free-form payloads (rationale, content) - last-resort cap
 )
 
 // validateString rejects strings longer than max bytes. Empty values are


### PR DESCRIPTION
## Summary

Final PR of the i18n migration. Two commits:

1. **Linter swap**: Replace the French-stem denylist in `tools/registration_test.go` (~270 lines) with a generic ASCII-only check (~150 lines). Tests renamed `*_NoStrippedFrenchDiacritics` → `*_ASCIIOnly`. Plus 14 em-dash → hyphen residue fixes in `tools/` that PR 4 had missed.

2. **Accent-stripped French sweep**: 15 more files cleaned. These were French strings without diacritics — invisible to both the old denylist and the new ASCII linter. Found via manual review during this PR. Surface: `engine/concept_selector.go`, `motivation.go`, `alert.go`, `orchestrator.go`, `scheduler.go`, `scheduler_metacog.go`, `metacognition.go`, `action_selector.go`, plus `tools/negotiation.go`, `get_dashboard_state.go`, and 5 test assertion updates.

After this PR merges, no French remains in any non-test source file (apart from the intentional denylist literals which are gone from `tools/registration_test.go` since it was rewritten).

PR 5 of 5 — closes the i18n migration.

## Test plan
- [x] `go test ./...` all 6 packages green.
- [x] `TestToolDescriptions_ASCIIOnly` and `TestToolStringLiterals_ASCIIOnly` PASS (replace the old French-stem tests).
- [x] `TestSystemPrompt_LanguageContract` and `TestSystemPrompt_ToolRegistryConsistency` still PASS.
- [x] Manual grep for accent-stripped French (`maitrise`, `frange`, `Bonjour`, etc.) returns no hits in production code.

## Migration recap (PRs 1-5)
- **PR 1** (#132): Public i18n contract docs + CONTRIBUTING update.
- **PR 2** (#133): English system prompt + LANGUAGE block + `TestSystemPrompt_LanguageContract`.
- **PR 3** (#134): 22 tool Description / jsonschema fields translated.
- **PR 4** (#135): 26 files of handler-body / DB / engine French translated.
- **PR 5** (this one): Linter swap + final residue cleanup.