### PR TITLE
fix(auth): require explicit user approval for OAuth clients

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -133,6 +133,12 @@ func (s *OAuthServer) HandleAuthorizeGet(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
 		return
 	}
+	client, err := s.store.GetOAuthClient(clientID)
+	if err != nil {
+		s.logger.Debug("authorize GET: client lookup failed", "err", err, "client_id", clientID)
+		http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+		return
+	}
 
 	codeChallenge := q.Get("code_challenge")
 	codeChallengeMethod := q.Get("code_challenge_method")
@@ -161,6 +167,7 @@ func (s *OAuthServer) HandleAuthorizeGet(w http.ResponseWriter, r *http.Request)
 
 	data := authPageData{
 		ClientID:            clientID,
+		ClientName:          client.ClientName,
 		RedirectURI:         redirectURI,
 		ResponseType:        q.Get("response_type"),
 		State:               q.Get("state"),
@@ -217,6 +224,12 @@ func (s *OAuthServer) HandleAuthorizePost(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
 		return
 	}
+	client, err := s.store.GetOAuthClient(clientID)
+	if err != nil {
+		s.logger.Debug("authorize POST: client lookup failed", "err", err, "client_id", clientID)
+		http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+		return
+	}
 
 	codeChallenge := r.FormValue("code_challenge")
 	codeChallengeMethod := r.FormValue("code_challenge_method")
@@ -234,6 +247,7 @@ func (s *OAuthServer) HandleAuthorizePost(w http.ResponseWriter, r *http.Request
 
 	data := authPageData{
 		ClientID:            clientID,
+		ClientName:          client.ClientName,
 		RedirectURI:         redirectURI,
 		ResponseType:        r.FormValue("response_type"),
 		State:               state,
@@ -273,6 +287,10 @@ func (s *OAuthServer) HandleAuthorizePost(w http.ResponseWriter, r *http.Request
 			renderAuthPage(w, data, "An account with this email already exists.", "register")
 			return
 		}
+		if r.FormValue("approve_client") != "yes" {
+			renderAuthPage(w, data, "Please confirm that you recognize and approve this OAuth client before continuing.", "register")
+			return
+		}
 
 		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 		if err != nil {
@@ -310,6 +328,10 @@ func (s *OAuthServer) HandleAuthorizePost(w http.ResponseWriter, r *http.Request
 			return
 		}
 		s.loginFailures.Reset(email)
+		if r.FormValue("approve_client") != "yes" {
+			renderAuthPage(w, data, "Please confirm that you recognize and approve this OAuth client before continuing.", "login")
+			return
+		}
 		learnerID = existing.ID
 	}
 

--- a/auth/oauth_extra_test.go
+++ b/auth/oauth_extra_test.go
@@ -903,6 +903,38 @@ func TestGenerateCSRFToken_UniqueAndBase64URL(t *testing.T) {
 
 // ─── HandleAuthorizePost: full happy paths + remaining branches ──────────────
 
+func TestAuthorizePost_LoginRequiresClientApproval(t *testing.T) {
+	s, store := newTestServer(t)
+	seedClient(t, store, "cid", "https://attacker.example/cb")
+	seedLearner(t, store, "victim@example.com", "correct-password")
+
+	form := url.Values{}
+	form.Set("csrf_token", "tkn")
+	form.Set("mode", "login")
+	form.Set("client_id", "cid")
+	form.Set("redirect_uri", "https://attacker.example/cb")
+	form.Set("code_challenge", "ch")
+	form.Set("code_challenge_method", "S256")
+	form.Set("email", "victim@example.com")
+	form.Set("password", "correct-password")
+
+	req := httptest.NewRequest("POST", "/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "tkn"})
+	rec := httptest.NewRecorder()
+	s.HandleAuthorizePost(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("unexpected redirect without approval: %s", loc)
+	}
+	if !strings.Contains(rec.Body.String(), "approve this OAuth client") {
+		t.Fatalf("body missing approval message; body=%q", rec.Body.String())
+	}
+}
+
 func TestAuthorizePost_LoginSuccess_Redirects302WithCodeAndIss(t *testing.T) {
 	s, store := newTestServer(t)
 	seedClient(t, store, "cid", "https://good.example/cb")
@@ -919,6 +951,7 @@ func TestAuthorizePost_LoginSuccess_Redirects302WithCodeAndIss(t *testing.T) {
 	form.Set("code_challenge_method", "S256")
 	form.Set("email", "ok@e.com")
 	form.Set("password", "correct-password")
+	form.Set("approve_client", "yes")
 	form.Set("scope", "learner")
 
 	req := httptest.NewRequest("POST", "/authorize", strings.NewReader(form.Encode()))
@@ -967,6 +1000,7 @@ func TestAuthorizePost_LoginSuccess_NoState_OmitsStateParam(t *testing.T) {
 	form.Set("code_challenge_method", "S256")
 	form.Set("email", "okns@e.com")
 	form.Set("password", "correct-password")
+	form.Set("approve_client", "yes")
 
 	req := httptest.NewRequest("POST", "/authorize", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1001,6 +1035,7 @@ func TestAuthorizePost_RegisterSuccess_CreatesAndRedirects(t *testing.T) {
 	form.Set("email", "newuser@e.com")
 	form.Set("password", "password-1234")
 	form.Set("password_confirm", "password-1234")
+	form.Set("approve_client", "yes")
 
 	req := httptest.NewRequest("POST", "/authorize", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -446,6 +446,7 @@ func driveAuthorizePost(t *testing.T, s *OAuthServer, clientID, redirectURI, cod
 	form.Set("scope", "learner")
 	form.Set("email", email)
 	form.Set("password", password)
+	form.Set("approve_client", "yes")
 	if codeChallenge != "" {
 		form.Set("code_challenge", codeChallenge)
 		form.Set("code_challenge_method", codeChallengeMethod)

--- a/auth/pages.go
+++ b/auth/pages.go
@@ -36,7 +36,9 @@ func formActionOriginFromRedirectURI(redirectURI string) string {
 
 type authPageData struct {
 	ClientID            string
+	ClientName          string
 	RedirectURI         string
+	RedirectOrigin      string
 	ResponseType        string
 	State               string
 	CodeChallenge       string
@@ -200,6 +202,32 @@ var authTmpl = template.Must(template.New("auth").Parse(`<!DOCTYPE html>
       margin-bottom: 1.2rem;
     }
 
+    .consent-box {
+      margin-top: 1.2rem;
+      padding: 0.85rem 0.95rem;
+      border: 1px solid rgba(180, 150, 200, 0.35);
+      border-radius: 12px;
+      background: rgba(180, 150, 200, 0.08);
+      color: var(--ink-soft);
+      font-size: 0.84rem;
+      line-height: 1.45;
+    }
+    .consent-box strong { color: var(--ink); }
+    .consent-check {
+      display: flex;
+      gap: 0.55rem;
+      align-items: flex-start;
+      margin-top: 0.75rem;
+      font-family: system-ui, -apple-system, "Inter Tight", "Segoe UI", Roboto, sans-serif;
+      font-size: 0.84rem;
+      color: var(--ink);
+    }
+    .consent-check input {
+      width: auto;
+      margin-top: 0.15rem;
+      accent-color: var(--terracotta);
+    }
+
     label {
       display: block;
       font-family: ui-monospace, "JetBrains Mono", "Cascadia Mono", "SFMono-Regular", Menlo, Consolas, monospace;
@@ -352,6 +380,15 @@ var authTmpl = template.Must(template.New("auth").Parse(`<!DOCTYPE html>
           <label for="login-password">Password</label>
           <input id="login-password" type="password" name="password" placeholder="••••••••" required autocomplete="current-password" />
 
+          <div class="consent-box">
+            <p><strong>{{.Data.ClientName}}</strong> wants access to your tutor/mcp learner account.</p>
+            <p>After sign-in, tutor/mcp will send an authorization code to <strong>{{.Data.RedirectOrigin}}</strong>.</p>
+            <label class="consent-check" for="login-consent">
+              <input id="login-consent" type="checkbox" name="approve_client" value="yes" required />
+              <span>I recognize this client and approve sharing access.</span>
+            </label>
+          </div>
+
           <button type="submit">Sign in →</button>
         </form>
         <p class="toggle">No account? <a href="#" class="toggle-link">Create one</a></p>
@@ -379,6 +416,15 @@ var authTmpl = template.Must(template.New("auth").Parse(`<!DOCTYPE html>
 
           <label for="reg-confirm">Confirm password</label>
           <input id="reg-confirm" type="password" name="password_confirm" placeholder="••••••••" required autocomplete="new-password" />
+
+          <div class="consent-box">
+            <p><strong>{{.Data.ClientName}}</strong> wants access to your tutor/mcp learner account.</p>
+            <p>After account creation, tutor/mcp will send an authorization code to <strong>{{.Data.RedirectOrigin}}</strong>.</p>
+            <label class="consent-check" for="register-consent">
+              <input id="register-consent" type="checkbox" name="approve_client" value="yes" required />
+              <span>I recognize this client and approve sharing access.</span>
+            </label>
+          </div>
 
           <button type="submit">Create account →</button>
         </form>
@@ -417,6 +463,12 @@ type tmplData struct {
 }
 
 func renderAuthPage(w http.ResponseWriter, data authPageData, errMsg string, mode string) {
+	if data.ClientName == "" {
+		data.ClientName = data.ClientID
+	}
+	if data.RedirectOrigin == "" {
+		data.RedirectOrigin = formActionOriginFromRedirectURI(data.RedirectURI)
+	}
 	nonce, err := generateNonce()
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/auth/pages_test.go
+++ b/auth/pages_test.go
@@ -74,6 +74,9 @@ func TestRenderAuthPage_LoginNoError(t *testing.T) {
 		`value="challenge-xyz"`,
 		`value="S256"`,
 		`value="learner"`,
+		`name="approve_client"`,
+		`I recognize this client and approve sharing access.`,
+		`https://good.example`,
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(body, s) {
@@ -105,9 +108,12 @@ func TestRenderAuthPage_RegisterMode(t *testing.T) {
 	if !strings.Contains(body, "toggleView();") {
 		t.Fatal("register mode should include startup toggleView() call")
 	}
-	// Confirm-password input (register-only) must be present.
+	// Confirm-password and client-approval inputs (register-only) must be present.
 	if !strings.Contains(body, `name="password_confirm"`) {
 		t.Fatal("register mode missing password_confirm field")
+	}
+	if !strings.Contains(body, `name="approve_client"`) {
+		t.Fatal("register mode missing approve_client field")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Prevent authorization codes from being delivered to attacker-controlled registered callbacks in the current dynamic-registration + no-consent model by requiring explicit user approval before issuing codes or creating accounts.

### Description
- Add client metadata to the auth page and surface `ClientName` and the `RedirectOrigin` in the login/registration UI so learners can see who will receive the code (`auth/pages.go`).
- Add a visible consent panel with a required `approve_client` checkbox to both the sign-in and registration templates and wire the new fields into the rendered page data (`auth/pages.go`).
- Load the registered OAuth client in both `HandleAuthorizeGet` and `HandleAuthorizePost` so the server can display client context and validate approval (`auth/oauth.go`).
- Enforce server-side approval by rejecting POST /authorize when `approve_client` is not set to `yes` before creating auth codes or learner accounts, preventing an unapproved client from receiving a redirect with a code (`auth/oauth.go`).
- Update and add tests to require/submit `approve_client` on happy paths and to assert that an unapproved client does not get redirected with a code (`auth/pages_test.go`, `auth/oauth_test.go`, `auth/oauth_extra_test.go`).

### Testing
- Ran the full test suite with `go test ./... -timeout 60s`, and all packages including `auth` and `db` passed.
- Added unit tests exercising the consent UI and server-side approval check, which passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0399cd7058832dbf12dbc534819baa)