### PR TITLE
Add pedagogical runtime audit issue drafts and README

### DIFF
--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/01-overload-session-start.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/01-overload-session-start.md
@@ -1,0 +1,35 @@
+# [BUG] Regulation Gate never receives real sessionStart for OVERLOAD
+
+Suggested labels: `bug`, `p0`, `todo`, `next-up`
+
+## Description
+
+> Priority: p0
+> Classification: BUG
+
+`OVERLOAD` should force the regulation Gate to emit `CLOSE_SESSION`, but the orchestrator recomputes alerts with `input.Now` where `ComputeAlerts` expects the session start timestamp.
+
+`tools/activity.go` computes alerts correctly with `sessionStart`, but `engine/orchestrator.go` recomputes them inside `fetchPipelineFixtures` as `ComputeAlerts(states, recentInteractions, input.Now)`. Since `engine/alert.go` emits `OVERLOAD` only when `time.Since(sessionStart) > 45*time.Minute`, passing `input.Now` makes the condition almost always false.
+
+Affected files:
+
+- `tools/activity.go` — correct `sessionStart` is already available before the orchestrator call.
+- `engine/orchestrator.go` — `fetchPipelineFixtures` passes `input.Now` as the session timestamp.
+- `engine/alert.go` — `ComputeAlerts` interprets the third argument as `sessionStart`.
+- `engine/gate.go` — `ApplyGate` only emits `CLOSE_SESSION` if it receives `AlertOverload`.
+
+## Expected behavior
+
+When the active session is older than the overload threshold, `get_next_activity` should return a `CLOSE_SESSION` activity with `session_overload` format.
+
+## Suggested fix
+
+Add `SessionStart time.Time` or precomputed `Alerts []models.Alert` to `engine.OrchestratorInput`, then ensure `fetchPipelineFixtures` uses the real session start instead of `input.Now`.
+
+## Acceptance criteria
+
+- [ ] `fetchPipelineFixtures` no longer calls `ComputeAlerts(..., input.Now)` as if `input.Now` were `sessionStart`.
+- [ ] `get_next_activity` propagates the real session start or precomputed alerts into the orchestrator.
+- [ ] A test proves a session older than 45 minutes returns `CLOSE_SESSION`.
+- [ ] A test proves a fresh session does not return `CLOSE_SESSION`.
+- [ ] Existing Gate unit tests still pass.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/02-stale-prompt-difficulty.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/02-stale-prompt-difficulty.md
@@ -1,0 +1,30 @@
+# [BUG] PromptForLLM can contain stale difficulty after tutor-mode and calibration adjustments
+
+Suggested labels: `bug`, `p1`, `todo`
+
+## Description
+
+> Priority: p1
+> Classification: BUG
+
+`engine.composeActivity` embeds the numeric target difficulty directly in `PromptForLLM`. Later, `tools/get_next_activity` mutates `activity.DifficultyTarget` for tutor mode (`lighter`, `scaffolding`) and calibration bias. The structured field can therefore disagree with the textual prompt.
+
+Affected files:
+
+- `engine/orchestrator.go` — `composeActivity` writes `Target difficulty: %.2f` into the prompt.
+- `tools/activity.go` — tutor mode and calibration bias mutate `activity.DifficultyTarget` after composition.
+
+## Expected behavior
+
+The LLM should receive one final, consistent difficulty signal.
+
+## Suggested fix
+
+Prefer removing the numeric difficulty from `PromptForLLM` and instruct the LLM to use the final structured `activity.difficulty_target`. Alternatively, recompute `PromptForLLM` after all post-orchestrator adjustments.
+
+## Acceptance criteria
+
+- [ ] `PromptForLLM` cannot contradict `activity.DifficultyTarget`.
+- [ ] A test covers `tutor_mode=lighter` and verifies prompt consistency.
+- [ ] A test covers `tutor_mode=scaffolding` and verifies prompt consistency.
+- [ ] A test covers calibration-bias clamping and verifies prompt consistency.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/03-pedagogical-contract.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/03-pedagogical-contract.md
@@ -1,0 +1,50 @@
+# [FEATURE] Return a structured pedagogical_contract from get_next_activity
+
+Suggested labels: `enhancement`, `p1`, `todo`, `next-up`
+
+## Description
+
+> Priority: p1
+> Classification: ARCHITECTURE
+
+The runtime currently returns a thin `Activity` object: type, concept, difficulty, format, minutes, rationale, and `PromptForLLM`. That is useful for routing, but it is not LLM-native enough for adaptive tutoring. The LLM receives a directive to generate an activity, not a policy contract explaining intent, constraints, allowed variation, evidence requirements, or negotiability.
+
+Affected files:
+
+- `models/domain.go` — `Activity` has no structured pedagogical affordances.
+- `engine/orchestrator.go` — `composeActivity` creates a minimal prompt.
+- `tools/activity.go` — `get_next_activity` already collects tutor mode, motivation, misconceptions, evidence, uncertainty, transfer, and Rasch/Elo signals that can feed the contract.
+
+## Proposed solution
+
+Add a non-breaking sibling object to `get_next_activity`, for example:
+
+```json
+{
+  "pedagogical_contract": {
+    "intent": "stabilize_near_mastery",
+    "target_concept": "goroutines",
+    "recommended_activity_type": "PRACTICE",
+    "constraints": {
+      "must_collect": ["learner_answer", "rubric_score"],
+      "avoid": ["introducing_new_prerequisite", "long_explanation_first"]
+    },
+    "allowed_variants": ["socratic_prompt", "contrastive_example", "worked_example_completion", "micro_debug"],
+    "llm_discretion": {
+      "can_change_format": true,
+      "can_request_clarification": true,
+      "can_propose_negotiation": true,
+      "cannot_mark_mastery_without_evidence": true
+    },
+    "learner_explanation": "On stabilise ce point avant un transfert plus ouvert.",
+    "audit_rationale": "phase=INSTRUCTION; selected by relevance × mastery gap"
+  }
+}
+```
+
+## Acceptance criteria
+
+- [ ] `get_next_activity` returns `pedagogical_contract` without breaking existing clients.
+- [ ] Contract includes `intent`, `constraints`, `allowed_variants`, `llm_discretion`, `learner_explanation`, and `audit_rationale`.
+- [ ] Tests cover at least `PRACTICE`, `RECALL_EXERCISE`, `DEBUG_MISCONCEPTION`, `FEYNMAN_PROMPT`, `TRANSFER_PROBE`, and `CLOSE_SESSION`.
+- [ ] The system prompt tells the LLM to follow the contract rather than only `PromptForLLM` prose.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/04-negotiation-overrides.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/04-negotiation-overrides.md
@@ -1,0 +1,38 @@
+# [FEATURE] Make learning_negotiation support structured, one-shot activity overrides
+
+Suggested labels: `enhancement`, `p1`, `todo`
+
+## Description
+
+> Priority: p1
+> Classification: ARCHITECTURE
+
+`learning_negotiation` currently negotiates mostly a concept. It accepts `learner_concept` and `learner_rationale`, computes the system plan, then either rejects the proposal or returns an accepted plan. When accepted, the plan is always rewritten as `RECALL_EXERCISE` with `format=mixed` and `estimated_minutes=15`.
+
+The accepted plan is returned in JSON but is not persisted as a one-shot override for the next `get_next_activity` call.
+
+Affected files:
+
+- `tools/negotiation.go` — narrow params and non-persistent accepted plan.
+- `tools/activity.go` — no consumption path for negotiated one-shot plans.
+
+## Proposed solution
+
+Extend negotiation beyond concept changes:
+
+- `concept_change`
+- `format_change`
+- `activity_type_change`
+- `scaffold_change`
+- `micro_diagnostic`
+- `defer_activity`
+
+Persist accepted overrides with one-shot semantics and consume them in the next `get_next_activity`, without allowing them to bypass hard constraints such as overload, unknown concept, invalid domain, or unsatisfied hard prerequisites.
+
+## Acceptance criteria
+
+- [ ] `learning_negotiation` supports at least concept, format, and activity-type changes.
+- [ ] Accepted negotiation creates a persisted one-shot override.
+- [ ] Next `get_next_activity` consumes the override exactly once.
+- [ ] Rejected negotiations explain tradeoffs.
+- [ ] Tests cover accepted, rejected, expired, and consumed override paths.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/05-evidence-controller.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/05-evidence-controller.md
@@ -1,0 +1,34 @@
+# [FEATURE] Use mastery evidence, uncertainty, and transfer before final activity selection
+
+Suggested labels: `enhancement`, `p1`, `todo`, `next-up`
+
+## Description
+
+> Priority: p1
+> Classification: PEDAGOGY
+
+`get_next_activity` computes `mastery_evidence`, `mastery_uncertainty`, `transfer_profile`, and `rasch_elo_calibration` after the orchestrator has already selected the activity. The LLM sees those diagnostics, but the runtime selection itself does not use them to adjust the final activity.
+
+Affected files:
+
+- `tools/activity.go` — evidence, uncertainty, transfer, and Rasch/Elo diagnostics are computed post-selection.
+- `engine/orchestrator.go` — `SelectAction` result is composed before those diagnostics are available.
+- `engine/evidence.go` and `engine/uncertainty.go` — existing signals can feed the selection path.
+
+## Proposed solution
+
+Introduce an `EvidenceController` or extend `ActionSelector` input so the runtime can adjust the final action before returning it.
+
+Examples:
+
+- High BKT + weak evidence → avoid `MASTERY_CHALLENGE`; request varied proof.
+- High mastery + unobserved transfer → prefer `TRANSFER_PROBE`.
+- Transfer blocked → prefer `FEYNMAN_PROMPT`.
+- Recall-only evidence → prefer practice/Feynman/transfer before mastery claim.
+
+## Acceptance criteria
+
+- [ ] Runtime can redirect high-mastery actions when evidence is weak.
+- [ ] Runtime can prioritize transfer when transfer is missing or weak.
+- [ ] Runtime rationale includes the evidence-based adjustment.
+- [ ] Tests cover high BKT + weak evidence, high BKT + no transfer, transfer blocked, and strong evidence.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/06-fade-runtime-application.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/06-fade-runtime-application.md
@@ -1,0 +1,31 @@
+# [FEATURE] Apply FadeController parameters beyond motivation text
+
+Suggested labels: `enhancement`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: ADAPTIVITY
+
+`FadeController` returns `HintLevel`, `WebhookFrequency`, `ZPDAggressiveness`, and `ProactiveReviewEnabled`. In `get_next_activity`, the current integration mainly applies `HintLevel` to the motivation brief and exposes `fade_params` in JSON. The other fade parameters are not yet applied deeply to runtime behavior.
+
+Affected files:
+
+- `engine/fade_controller.go` — returns four autonomy-dependent parameters.
+- `tools/activity.go` — applies fade only to motivation brief and exposes the bundle.
+
+## Proposed solution
+
+Short term: inject fade into `pedagogical_contract` so the LLM adapts hinting, autonomy handoff, and challenge framing.
+
+Medium term:
+
+- Use `ZPDAggressiveness` in difficulty targeting.
+- Use `WebhookFrequency` in scheduler dispatch.
+- Use `ProactiveReviewEnabled` in proactive review scheduling.
+
+## Acceptance criteria
+
+- [ ] `fade_params` influence LLM-facing scaffolding guidance, not only motivation text.
+- [ ] Low, mid, and high autonomy produce distinct pedagogical contract outputs.
+- [ ] Follow-up issues or TODOs exist for scheduler-level `WebhookFrequency` and `ProactiveReviewEnabled` integration.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/07-review-intent-pipeline.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/07-review-intent-pipeline.md
@@ -1,0 +1,34 @@
+# [FEATURE] Route review intent through the regulation pipeline
+
+Suggested labels: `enhancement`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: REFACTOR
+
+When `intent=review`, `get_next_activity` bypasses the orchestrator and uses `selectReviewIntentActivity`. This creates a second routing policy with its own scoring and activity selection logic instead of expressing review as a constraint inside the regulation pipeline.
+
+Affected files:
+
+- `tools/activity.go` — review intent bypasses `engine.OrchestrateWithPhase`.
+- `tools/activity_intent.go` — separate review selector and scoring policy.
+- `engine/orchestrator.go` — no intent-aware routing input today.
+
+## Proposed solution
+
+Add intent awareness to the regulation pipeline. For `intent=review`, bias selection toward retention and previously studied concepts while preserving Gate, ConceptSelector, ActionSelector, and evidence logic.
+
+Suggested semantics:
+
+- phase bias: `MAINTENANCE`
+- allowed activity families: `RECALL_EXERCISE`, `PRACTICE`, `DEBUG_MISCONCEPTION`
+- concept scoring: retention-first, no new concepts
+
+## Acceptance criteria
+
+- [ ] `intent=review` goes through the orchestrator path.
+- [ ] Review still avoids introducing new concepts.
+- [ ] Review still prioritizes low retention and active misconceptions.
+- [ ] Existing review behavior has migration tests.
+- [ ] The duplicate review selector is removed or clearly marked as fallback-only.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/08-stale-regulation-appendices.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/08-stale-regulation-appendices.md
@@ -1,0 +1,29 @@
+# [BUG] Regulation prompt appendices still say components are not wired
+
+Suggested labels: `documentation`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: DOCS
+
+Some prompt appendix comments still imply that regulation components are not wired into the runtime, even though `get_next_activity` calls `engine.OrchestrateWithPhase` and the orchestrator runs Gate, ConceptSelector, and ActionSelector.
+
+Affected file:
+
+- `tools/prompt.go`
+
+Examples:
+
+- Action selector appendix references behavior “once the regulation orchestrator is wired”.
+- Concept selector appendix says the function is “not yet wired into the runtime”.
+
+## Expected behavior
+
+Comments and prompt wording should match the current runtime state. The appendices should explain that the components are wired and that the corresponding flags only control whether explanatory prompt appendices are shown.
+
+## Acceptance criteria
+
+- [ ] Remove stale “not wired yet” / “once wired” language.
+- [ ] Clarify that the runtime components are active in the orchestrator path.
+- [ ] Prompt-related tests are updated if they assert old wording.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/09-regulation-flags-prompt-only.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/09-regulation-flags-prompt-only.md
@@ -1,0 +1,32 @@
+# [FEATURE] Clarify REGULATION_ACTION/CONCEPT/GATE as prompt-only flags or implement real runtime switches
+
+Suggested labels: `documentation`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: CONFIG
+
+`REGULATION_ACTION`, `REGULATION_CONCEPT`, and `REGULATION_GATE` are used by `buildSystemPrompt` to include or omit explanatory appendices. They do not disable the runtime components: the normal `get_next_activity` path always calls the orchestrator, and the orchestrator always invokes Gate, ConceptSelector, and ActionSelector.
+
+Affected files:
+
+- `tools/prompt.go` — prompt appendix flags.
+- `tools/activity.go` — always calls the orchestrator in auto mode.
+- `engine/orchestrator.go` — always runs the regulation components.
+
+## Proposed solution
+
+Either document these as prompt-only flags or introduce clearer aliases:
+
+- `REGULATION_ACTION_PROMPT`
+- `REGULATION_CONCEPT_PROMPT`
+- `REGULATION_GATE_PROMPT`
+
+If real runtime kill switches are required, implement them explicitly as a separate design.
+
+## Acceptance criteria
+
+- [ ] Operator-facing docs/comments say the existing flags are prompt-only.
+- [ ] Prompt tests still cover flag-gated appendices.
+- [ ] If aliases are added, old names remain backward-compatible.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/10-goal-relevance-status.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/10-goal-relevance-status.md
@@ -1,0 +1,40 @@
+# [FEATURE] Expose goal_relevance_status in get_next_activity
+
+Suggested labels: `enhancement`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: PERSONALIZATION
+
+Goal relevance is optional. After `init_domain`, the runtime suggests `set_goal_relevance`, but marks it as not required. If no relevance vector exists, the orchestrator and selector fall back to uniform relevance (`rel=1.0`), which keeps routing functional but silently reduces personalization.
+
+Affected files:
+
+- `tools/domain.go` — `init_domain` emits an optional `set_goal_relevance` next action.
+- `engine/orchestrator.go` — missing goal relevance becomes uniform relevance.
+- `engine/concept_selector.go` — nil relevance falls back to uniform scoring.
+- `tools/activity.go` — response does not expose whether goal-aware routing is missing, partial, stale, or valid.
+
+## Proposed solution
+
+Add `goal_relevance_status` to `get_next_activity`:
+
+```json
+{
+  "goal_relevance_status": {
+    "status": "missing",
+    "message": "Goal-aware routing is using uniform relevance because no relevance vector exists.",
+    "recommended_tool": "set_goal_relevance"
+  }
+}
+```
+
+Statuses should distinguish at least `missing`, `partial`, and `valid`; `stale` can be included if graph-version drift is already available.
+
+## Acceptance criteria
+
+- [ ] `get_next_activity` includes `goal_relevance_status`.
+- [ ] Missing, partial, and valid relevance vectors are distinguishable.
+- [ ] Missing status recommends `set_goal_relevance`.
+- [ ] Tests cover missing, partial, and valid statuses.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/11-semantic-observations.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/11-semantic-observations.md
@@ -1,0 +1,41 @@
+# [FEATURE] Add semantic_observation_json to record_interaction
+
+Suggested labels: `enhancement`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: LLM_DETECTION
+
+`record_interaction` accepts `error_type`, `notes`, `misconception_type`, `misconception_detail`, `rubric_json`, and `rubric_score_json`. That captures some LLM-detected signals, but there is no structured field for richer semantic observations such as brittle success, correct answer with flawed reasoning, partial transfer, overconfidence, or suggested next move.
+
+Affected files:
+
+- `tools/interaction.go` — request schema and validation.
+- `tools/interaction_apply.go` — interaction persistence and pedagogical snapshot observation.
+- `db/schema.sql` / migrations — if persisted as a first-class interaction column.
+
+## Proposed solution
+
+Add optional `semantic_observation_json`, validated as a JSON object and included in pedagogical snapshots. Do not let it directly mutate BKT/FSRS in the first implementation.
+
+Example:
+
+```json
+{
+  "reasoning_quality": "brittle",
+  "success_mode": "procedural_without_explanation",
+  "transfer_quality": "near_with_scaffold",
+  "confidence_alignment": "overconfident",
+  "suggested_next_move": "contrastive_example",
+  "evidence": "Learner produced the formula but could not justify why it applies."
+}
+```
+
+## Acceptance criteria
+
+- [ ] `record_interaction` accepts `semantic_observation_json`.
+- [ ] Invalid JSON is rejected.
+- [ ] Observation is persisted or included in pedagogical snapshots.
+- [ ] Tests cover valid, invalid, and absent semantic observations.
+- [ ] No probabilistic model update directly depends on this field in the first implementation.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/12-rationale-split.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/12-rationale-split.md
@@ -1,0 +1,35 @@
+# [FEATURE] Split audit rationale, LLM instruction, and learner explanation
+
+Suggested labels: `enhancement`, `p2`, `todo`
+
+## Description
+
+> Priority: p2
+> Classification: LLM_UX
+
+The current `Activity` contains a single `Rationale`. The orchestrator fills it with technical details combining phase, selection rationale, and action rationale. The system prompt also tells the LLM not to explain algorithmic reasoning to the learner. This creates an avoidable ambiguity: the same field is useful for audit but not learner-facing communication.
+
+Affected files:
+
+- `models/domain.go` — single `Activity.Rationale` field.
+- `engine/orchestrator.go` — technical rationale construction.
+- `tools/prompt.go` — instructs the LLM not to expose algorithmic reasoning.
+
+## Proposed solution
+
+Add separate outputs, either in `pedagogical_contract` or as a sibling object:
+
+```json
+{
+  "audit_rationale": "phase=INSTRUCTION; selected by relevance × mastery gap",
+  "llm_instruction": "Use a short contrastive practice prompt and collect a rubric score.",
+  "learner_explanation": "On consolide ce point car il débloque la suite de ton objectif."
+}
+```
+
+## Acceptance criteria
+
+- [ ] Technical rationale remains available for audit.
+- [ ] LLM receives a concise operational instruction.
+- [ ] Learner-safe explanation is available without raw thresholds unless intentionally included.
+- [ ] Tests verify the learner explanation does not leak internal algorithm details by default.

--- a/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/README.md
+++ b/.github/ISSUE_DRAFTS/pedagogical-runtime-audit/README.md
@@ -1,0 +1,20 @@
+# Pedagogical runtime audit — GitHub issue drafts
+
+These drafts follow the repository's current issue presentation style observed on open issues such as `[#8] FSRS sub-day intervals`: concise title, `## Description`, a priority/classification quote block, implementation summary, tracking context, and `## Acceptance criteria`.
+
+They are ready to paste into GitHub issues. Suggested labels use the repository's existing label vocabulary: `bug`, `enhancement`, `documentation`, `p0`, `p1`, `p2`, `todo`, `next-up`.
+
+## Drafts
+
+1. `01-overload-session-start.md` — P0 bug: `OVERLOAD` is not propagated into the orchestrator.
+2. `02-stale-prompt-difficulty.md` — P1 bug: `PromptForLLM` can disagree with adjusted difficulty.
+3. `03-pedagogical-contract.md` — P1 feature: expose an LLM-native pedagogical contract.
+4. `04-negotiation-overrides.md` — P1 feature: make negotiation structured and durable.
+5. `05-evidence-controller.md` — P1 feature: use evidence/uncertainty/transfer before final activity selection.
+6. `06-fade-runtime-application.md` — P2 feature: apply fade beyond motivation text.
+7. `07-review-intent-pipeline.md` — P2 refactor: route review intent through the regulation pipeline.
+8. `08-stale-regulation-appendices.md` — P2 docs: update stale prompt appendix wording.
+9. `09-regulation-flags-prompt-only.md` — P2 config/docs: clarify prompt-only regulation flags.
+10. `10-goal-relevance-status.md` — P2 feature: expose goal relevance status.
+11. `11-semantic-observations.md` — P2 feature: persist structured LLM semantic observations.
+12. `12-rationale-split.md` — P2 feature: split audit rationale, LLM instruction, learner explanation.


### PR DESCRIPTION
### Motivation

- Add a collection of GitHub issue drafts to capture a focused audit of the pedagogical runtime covering bugs, enhancements, and documentation gaps.  
- Surface short proposals, acceptance criteria, and suggested fixes for regulation, orchestration, negotiation, evidence handling, fade parameters, and prompt wording.  

### Description

- Add a set of draft issue files under `.github/ISSUE_DRAFTS/pedagogical-runtime-audit/` (`01-...` through `12-...`) each describing a specific bug or feature request such as the `OVERLOAD` session-start bug, stale difficulty in `PromptForLLM`, pedagogical contract, negotiation overrides, evidence controller, fade parameters, review-intent routing, stale prompt appendices, regulation flags clarification, goal relevance status, semantic observations, and rationale splitting.  
- Add a `README.md` in the `pedagogical-runtime-audit` folder that summarizes the drafts and suggested labels and priorities.  
- All changes are documentation-only and do not modify runtime code or tests.  

### Testing

- No automated tests were added or modified because this PR contains only documentation and issue drafts.  
- Repository CI/static checks were not altered by these files and will run normally on merge or via existing CI triggers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a058f3ce2fc832db5ee13d3e1e32a38)