### PR TITLE
[codex] Structure webhook nudges

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Tutor MCP is **chat-only**. The LLM drives the learning loop in conversation: it
 | Tool | Description |
 |------|-------------|
 | `record_session_close` | Closes session: persists optional implementation intention (Gollwitzer if-then) and returns a recap brief (concepts practiced, wins, struggles, next review, intent prompt) |
-| `queue_webhook_message` | Queues an LLM-authored Discord message (daily_motivation, daily_recap, reactivation, reminder) for the scheduler to dispatch in a future window |
+| `queue_webhook_message` | Queues a Discord nudge. Prefer the structured `brief` payload (`why_now`, `learning_gain`, `open_loop`, `next_action`) so the scheduler can render a concise learner-facing embed and track the push. |
 
 All tools accept an optional `domain_id` for multi-domain support. Without it, the most recently active (non-archived) domain is used.
 
@@ -235,7 +235,7 @@ The scheduler runs background jobs that detect nine alert types:
 - **AFFECT_NEGATIVE** — Low satisfaction or excessive difficulty on 2 consecutive sessions.
 - **TRANSFER_BLOCKED** — BKT shows mastery but transfer scores remain low across contexts.
 
-Critical alerts are delivered via Discord webhook; dedup prevents the same alert firing twice in one day. Alert computation, the dashboard, and `priority_concept` filter out concept history that no longer belongs to an active (non-archived) domain, so `delete_domain` keeps progression on disk (re-`init_domain` brings it back) without leaking into reads or webhooks.
+Discord nudges are selected for learning value, not volume. Metacognitive signals are ranked into a single structured nudge per learner/tick, and daily dedup prevents the same kind of alert from firing twice in one day. Alert computation, the dashboard, and `priority_concept` filter out concept history that no longer belongs to an active (non-archived) domain, so `delete_domain` keeps progression on disk (re-`init_domain` brings it back) without leaking into reads or webhooks.
 
 ## Motivation Engine
 
@@ -254,7 +254,7 @@ Each brief also carries a Hidi-Renninger **interest phase** (triggered → emerg
 
 ## Webhook Queue (LLM-Authored Nudges)
 
-Daily motivation (8h UTC) and daily recap (21h UTC) are **no longer composed by Go templates**. During sessions, the LLM calls `queue_webhook_message` to schedule a warm, personal message tied to the learner's goal; the scheduler dispatches from the queue within a ±30-minute window. A sober Go fallback fires only when the queue is empty. Failed sends are marked for retry; past-due messages are expired hourly.
+Daily motivation (8h UTC), OLM focus (13h UTC), and daily recap (21h UTC) are **no longer limited to plain text**. During sessions, the LLM calls `queue_webhook_message` with a structured `brief` whenever possible. The scheduler renders it as a Discord embed with a short open loop, "why now", expected learning gain, useful evidence, and the next action. Sent structured pushes are recorded in `webhook_push_log`; `get_next_activity` surfaces unresolved pushes so the next tutor session can reconnect to the Discord nudge. Failed sends are marked for retry; past-due messages are expired hourly.
 
 ## Autonomy Score
 

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -204,6 +204,25 @@ var idempotentMigrations = []string{
 )`,
 	`CREATE INDEX IF NOT EXISTS idx_pedagogical_snapshots_learner_created ON pedagogical_snapshots(learner_id, created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_pedagogical_snapshots_domain_concept ON pedagogical_snapshots(learner_id, domain_id, concept, created_at)`,
+	`CREATE TABLE IF NOT EXISTS webhook_push_log (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    learner_id           TEXT    NOT NULL REFERENCES learners(id),
+    queue_id             INTEGER DEFAULT 0,
+    kind                 TEXT    NOT NULL,
+    domain_id            TEXT    DEFAULT '',
+    domain_name          TEXT    DEFAULT '',
+    concept              TEXT    DEFAULT '',
+    trigger_text         TEXT    DEFAULT '',
+    pedagogical_intent   TEXT    DEFAULT '',
+    learning_gain        TEXT    DEFAULT '',
+    open_loop            TEXT    DEFAULT '',
+    next_action          TEXT    DEFAULT '',
+    pushed_at            DATETIME NOT NULL,
+    opened_session_at    DATETIME,
+    concept_addressed    INTEGER DEFAULT 0,
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+	`CREATE INDEX IF NOT EXISTS idx_webhook_push_log_open ON webhook_push_log(learner_id, domain_id, concept_addressed, pushed_at)`,
 }
 
 // Migrate brings the database schema up to the version expected by this build.

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -44,6 +44,7 @@ func TestMigrate_Idempotent(t *testing.T) {
 		"transfer_records",
 		"implementation_intentions",
 		"webhook_message_queue",
+		"webhook_push_log",
 		"pedagogical_snapshots",
 	}
 	for _, table := range expectedTables {
@@ -70,6 +71,7 @@ func TestMigrate_Idempotent(t *testing.T) {
 		"idx_interactions_misconception",
 		"idx_impl_intent_learner",
 		"idx_wmq_dispatch",
+		"idx_webhook_push_log_open",
 		"idx_pedagogical_snapshots_learner_created",
 		"idx_pedagogical_snapshots_domain_concept",
 	}

--- a/db/store_extra_test.go
+++ b/db/store_extra_test.go
@@ -142,6 +142,49 @@ func TestGetActiveLearners(t *testing.T) {
 	}
 }
 
+func TestWebhookPushLogLifecycle(t *testing.T) {
+	store := setupTestDB(t)
+	now := time.Now().UTC()
+	brief := &models.WebhookBrief{
+		Kind:              "olm:d1",
+		DomainID:          "d1",
+		DomainName:        "Python",
+		Concept:           "boucles",
+		Trigger:           "Focus utile",
+		PedagogicalIntent: "reprendre le bon concept",
+		LearningGain:      "Stabiliser une connaissance fragile.",
+		OpenLoop:          "J'ai garde un mini-bug de boucle.",
+		NextAction:        "Ouvre Claude et reprends les boucles.",
+	}
+	if _, err := store.CreateWebhookPushLog("L1", 42, brief, now); err != nil {
+		t.Fatalf("CreateWebhookPushLog: %v", err)
+	}
+	push, err := store.GetLatestOpenWebhookPush("L1", "d1", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLatestOpenWebhookPush: %v", err)
+	}
+	if push == nil || push.Concept != "boucles" || push.QueueID != 42 {
+		t.Fatalf("unexpected push: %+v", push)
+	}
+	if err := store.MarkWebhookPushSessionOpened("L1", now.Add(time.Minute), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("MarkWebhookPushSessionOpened: %v", err)
+	}
+	push, _ = store.GetLatestOpenWebhookPush("L1", "d1", now.Add(-time.Hour))
+	if push == nil || push.OpenedSessionAt == nil {
+		t.Fatalf("expected opened session marker, got %+v", push)
+	}
+	if err := store.MarkWebhookPushConceptAddressed("L1", "d1", "boucles", now.Add(2*time.Minute), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("MarkWebhookPushConceptAddressed: %v", err)
+	}
+	push, err = store.GetLatestOpenWebhookPush("L1", "d1", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLatestOpenWebhookPush after address: %v", err)
+	}
+	if push != nil {
+		t.Fatalf("addressed push should no longer be open: %+v", push)
+	}
+}
+
 // ─── Refresh tokens ─────────────────────────────────────────────────────────
 
 func TestRefreshTokenLifecycle(t *testing.T) {

--- a/db/webhook_queue.go
+++ b/db/webhook_queue.go
@@ -43,6 +43,119 @@ func (s *Store) EnqueueWebhookMessage(learnerID, kind, content string, scheduled
 	return id, nil
 }
 
+// CreateWebhookPushLog records a learner-facing push after the webhook send
+// succeeds. queueID can be zero for Go fallback messages that did not originate
+// from webhook_message_queue.
+func (s *Store) CreateWebhookPushLog(learnerID string, queueID int64, brief *models.WebhookBrief, pushedAt time.Time) (int64, error) {
+	if learnerID == "" {
+		return 0, fmt.Errorf("learner_id is required")
+	}
+	if brief == nil {
+		return 0, fmt.Errorf("webhook brief is required")
+	}
+	brief.Normalize(brief.Kind)
+	if brief.Kind == "" {
+		return 0, fmt.Errorf("kind is required")
+	}
+	if pushedAt.IsZero() {
+		pushedAt = time.Now().UTC()
+	}
+	result, err := s.db.Exec(
+		`INSERT INTO webhook_push_log
+		 (learner_id, queue_id, kind, domain_id, domain_name, concept, trigger_text,
+		  pedagogical_intent, learning_gain, open_loop, next_action, pushed_at, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		learnerID, queueID, brief.Kind, brief.DomainID, brief.DomainName, brief.Concept,
+		brief.Trigger, brief.PedagogicalIntent, brief.LearningGain, brief.OpenLoop,
+		brief.NextAction, pushedAt.UTC(), time.Now().UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("create webhook push log: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("get webhook push log id: %w", err)
+	}
+	return id, nil
+}
+
+// GetLatestOpenWebhookPush returns the newest unresolved pedagogical push for
+// a learner. If domainID is provided, global pushes with an empty domain_id
+// and matching domain pushes are both eligible.
+func (s *Store) GetLatestOpenWebhookPush(learnerID, domainID string, since time.Time) (*models.WebhookPushLog, error) {
+	query := `SELECT id, learner_id, queue_id, kind, domain_id, domain_name, concept,
+		         trigger_text, pedagogical_intent, learning_gain, open_loop, next_action,
+		         pushed_at, opened_session_at, concept_addressed, created_at
+		  FROM webhook_push_log
+		  WHERE learner_id = ?
+		    AND concept_addressed = 0
+		    AND pushed_at >= ?`
+	args := []any{learnerID, since.UTC()}
+	if domainID != "" {
+		query += ` AND (domain_id = '' OR domain_id = ?)`
+		args = append(args, domainID)
+	}
+	query += ` ORDER BY pushed_at DESC LIMIT 1`
+	row := s.db.QueryRow(query, args...)
+	push, err := scanWebhookPushLog(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get latest webhook push: %w", err)
+	}
+	return push, nil
+}
+
+// MarkWebhookPushSessionOpened notes that a learner returned after a push.
+// It intentionally does not mark concept_addressed; that happens only when an
+// interaction touches the pushed concept.
+func (s *Store) MarkWebhookPushSessionOpened(learnerID string, openedAt, since time.Time) error {
+	if openedAt.IsZero() {
+		openedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(
+		`UPDATE webhook_push_log
+		    SET opened_session_at = COALESCE(opened_session_at, ?),
+		        concept_addressed = CASE WHEN concept = '' THEN 1 ELSE concept_addressed END
+		  WHERE learner_id = ?
+		    AND opened_session_at IS NULL
+		    AND pushed_at >= ?`,
+		openedAt.UTC(), learnerID, since.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("mark webhook push session opened: %w", err)
+	}
+	return nil
+}
+
+// MarkWebhookPushConceptAddressed closes open-loop pushes whose concept was
+// actually worked on in a later session.
+func (s *Store) MarkWebhookPushConceptAddressed(learnerID, domainID, concept string, addressedAt, since time.Time) error {
+	if concept == "" {
+		return nil
+	}
+	if addressedAt.IsZero() {
+		addressedAt = time.Now().UTC()
+	}
+	query := `UPDATE webhook_push_log
+		     SET opened_session_at = COALESCE(opened_session_at, ?),
+		         concept_addressed = 1
+		   WHERE learner_id = ?
+		     AND concept = ?
+		     AND concept_addressed = 0
+		     AND pushed_at >= ?`
+	args := []any{addressedAt.UTC(), learnerID, concept, since.UTC()}
+	if domainID != "" {
+		query += ` AND (domain_id = '' OR domain_id = ?)`
+		args = append(args, domainID)
+	}
+	if _, err := s.db.Exec(query, args...); err != nil {
+		return fmt.Errorf("mark webhook push concept addressed: %w", err)
+	}
+	return nil
+}
+
 // DequeueNextPending returns the highest-priority pending message for a learner/kind
 // whose scheduled_for is within [now-window, now+window] and not expired.
 // Returns (nil, nil) if nothing is pending.
@@ -177,4 +290,25 @@ func scanWebhookQueueItemRows(rows *sql.Rows) (*models.WebhookQueueItem, error) 
 		item.SentAt = &t
 	}
 	return item, nil
+}
+
+func scanWebhookPushLog(row *sql.Row) (*models.WebhookPushLog, error) {
+	push := &models.WebhookPushLog{}
+	var openedAt sql.NullTime
+	var conceptAddressed int
+	err := row.Scan(
+		&push.ID, &push.LearnerID, &push.QueueID, &push.Kind, &push.DomainID,
+		&push.DomainName, &push.Concept, &push.Trigger, &push.PedagogicalIntent,
+		&push.LearningGain, &push.OpenLoop, &push.NextAction, &push.PushedAt,
+		&openedAt, &conceptAddressed, &push.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if openedAt.Valid {
+		t := openedAt.Time
+		push.OpenedSessionAt = &t
+	}
+	push.ConceptAddressed = conceptAddressed != 0
+	return push, nil
 }

--- a/engine/nudge_planner.go
+++ b/engine/nudge_planner.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"tutor-mcp/models"
+)
+
+// NudgeCandidate is the scheduler-facing decision made by the nudge planner.
+// It separates pedagogical priority from transport details so the scheduler
+// can enforce dedup and delivery windows without knowing why a nudge matters.
+type NudgeCandidate struct {
+	Kind     string
+	AlertTag string
+	Priority int
+	Urgency  models.AlertUrgency
+	Brief    models.WebhookBrief
+}
+
+// BuildOLMNudgeBrief turns an OLM snapshot into an open-loop Discord brief.
+// The message is intentionally incomplete: it tells the learner what is worth
+// reopening, but keeps the actual challenge for the tutor session.
+func BuildOLMNudgeBrief(snap *OLMSnapshot) models.WebhookBrief {
+	if snap == nil {
+		return models.WebhookBrief{}
+	}
+	concept := snap.FocusConcept
+	trigger := "Etat d'apprentissage"
+	whyNow := "Un point de ton modele d'apprentissage merite une reprise courte aujourd'hui."
+	if concept != "" {
+		switch snap.FocusUrgency {
+		case models.UrgencyCritical:
+			trigger = "Rappel prioritaire"
+			whyNow = fmt.Sprintf("%s est en zone fragile (%s). Le reprendre maintenant evite une revision plus lourde plus tard.", concept, snap.FocusReason)
+		case models.UrgencyWarning:
+			trigger = "Focus du moment"
+			whyNow = fmt.Sprintf("%s ressort comme le meilleur levier actuel (%s).", concept, snap.FocusReason)
+		default:
+			trigger = "Prochain palier"
+			whyNow = fmt.Sprintf("%s est le prochain petit palier utile.", concept)
+		}
+	}
+
+	evidence := []string{}
+	if buckets := compactBuckets(snap); buckets != "" {
+		evidence = append(evidence, "Repartition: "+buckets)
+	}
+	if snap.FocusReason != "" {
+		evidence = append(evidence, "Signal: "+snap.FocusReason)
+	}
+	if line := MetacogLine(snap); line != "" {
+		evidence = append(evidence, "Meta: "+line)
+	}
+
+	openLoop := "J'ai garde un micro-defi pour verifier ce point sans te donner la solution ici."
+	nextAction := "Ouvre Claude et commence par le focus du jour."
+	if concept != "" {
+		openLoop = fmt.Sprintf("J'ai garde un micro-defi sur %s: assez court pour le tenter, pas assez trivial pour le faire dans Discord.", concept)
+		nextAction = fmt.Sprintf("Ouvre Claude et demande le defi sur %s.", concept)
+	}
+
+	return models.WebhookBrief{
+		Version:           models.WebhookBriefVersion,
+		Kind:              "olm",
+		DomainID:          snap.DomainID,
+		DomainName:        snap.DomainName,
+		Concept:           concept,
+		Trigger:           trigger,
+		PedagogicalIntent: "orienter la prochaine session vers le meilleur gain d'apprentissage",
+		LearningGain:      "Eviter une revision vague: tu sais quoi reprendre, pourquoi, et par quelle action commencer.",
+		WhyNow:            whyNow,
+		Evidence:          evidence,
+		GoalLink:          goalLinkSentence(snap.PersonalGoal, snap.KSTProgress),
+		OpenLoop:          openLoop,
+		NextAction:        nextAction,
+		EstimatedMinutes:  8,
+		Language:          "fr",
+		Tone:              "clair, concret, encourageant",
+	}
+}
+
+// BuildMetacognitiveNudgeCandidates converts raw metacognitive alerts into
+// learner-facing candidates, sorted by expected learning value. The scheduler
+// will enqueue at most one candidate per learner per tick to avoid noisy
+// parallel nudges.
+func BuildMetacognitiveNudgeCandidates(learner *models.Learner, domains []*models.Domain, alerts []models.Alert) []NudgeCandidate {
+	var out []NudgeCandidate
+	for _, alert := range alerts {
+		kind := metacogKindToWebhookKind(alert.Type)
+		if kind == "" {
+			continue
+		}
+		domain := domainForAlert(domains, alert)
+		brief := metacognitiveBrief(learner, domain, alert, kind)
+		out = append(out, NudgeCandidate{
+			Kind:     kind,
+			AlertTag: kind,
+			Priority: metacognitiveNudgePriority(alert.Type),
+			Urgency:  alert.Urgency,
+			Brief:    brief,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Priority > out[j].Priority
+	})
+	return out
+}
+
+func metacognitiveNudgePriority(t models.AlertType) int {
+	switch t {
+	case models.AlertTransferBlocked:
+		return 95
+	case models.AlertCalibrationDiverging:
+		return 90
+	case models.AlertDependencyIncreasing:
+		return 80
+	case models.AlertAffectNegative:
+		return 70
+	default:
+		return 0
+	}
+}
+
+func metacognitiveBrief(_ *models.Learner, domain *models.Domain, alert models.Alert, kind string) models.WebhookBrief {
+	brief := models.WebhookBrief{
+		Version:           models.WebhookBriefVersion,
+		Kind:              kind,
+		DomainID:          domainID(domain),
+		DomainName:        domainName(domain),
+		Concept:           alert.Concept,
+		EstimatedMinutes:  8,
+		Language:          "fr",
+		Tone:              "simple, concret, non culpabilisant",
+		PedagogicalIntent: "transformer un signal metacognitif en action d'apprentissage courte",
+	}
+
+	switch alert.Type {
+	case models.AlertTransferBlocked:
+		concept := alert.Concept
+		if concept == "" {
+			concept = "un concept deja travaille"
+		}
+		brief.Trigger = "Transfert bloque"
+		brief.LearningGain = "Transformer une connaissance reconnue en competence reutilisable dans un nouveau contexte."
+		brief.WhyNow = fmt.Sprintf("%s semble connu, mais le transfert reste fragile: c'est le bon moment pour changer de contexte.", concept)
+		brief.Evidence = []string{"Maitrise elevee detectee", "Au moins deux contextes de transfert faibles"}
+		brief.OpenLoop = fmt.Sprintf("J'ai garde une question Feynman sur %s: elle force a expliquer, pas seulement reconnaitre.", concept)
+		brief.NextAction = fmt.Sprintf("Ouvre Claude et commence par expliquer %s avec tes mots.", concept)
+	case models.AlertCalibrationDiverging:
+		brief.Trigger = "Calibration a reprendre"
+		brief.LearningGain = "Mieux estimer ton niveau pour choisir des exercices ni trop simples ni trop durs."
+		brief.WhyNow = "Ton auto-evaluation s'ecarte de tes resultats recents: une verification a froid donnera une meilleure boussole."
+		brief.Evidence = []string{alert.RecommendedAction}
+		brief.OpenLoop = "J'ai garde un mini-test sans indice: il dira vite si ton impression colle a ce que tu sais faire."
+		brief.NextAction = "Ouvre Claude et commence par une verification courte avant tout nouvel exercice."
+	case models.AlertDependencyIncreasing:
+		brief.Trigger = "Autonomie en baisse"
+		brief.LearningGain = "Reprendre la main progressivement, sans retirer l'aide quand elle est utile."
+		brief.WhyNow = "Les derniers signaux montrent plus d'appui sur le tutorat. Le gain vient d'un essai court avec moins d'aide."
+		brief.Evidence = []string{"Tendance sur plusieurs sessions", alert.RecommendedAction}
+		brief.OpenLoop = "J'ai garde un exercice ou le premier pas est a toi; l'aide revient seulement apres ton essai."
+		brief.NextAction = "Ouvre Claude et demande un premier essai sans hint, puis compare avec le feedback."
+	case models.AlertAffectNegative:
+		brief.Trigger = "Charge a ajuster"
+		brief.LearningGain = "Garder la progression sans transformer la difficulte en fatigue inutile."
+		brief.WhyNow = "Les dernieres sessions ont ete couteuses. Une reprise plus courte et mieux calibree produira plus d'apprentissage."
+		brief.Evidence = []string{"Satisfaction ou difficulte basse sur deux sessions recentes"}
+		brief.OpenLoop = "J'ai garde une version allegee du prochain exercice: meme concept, moins de charge parasite."
+		brief.NextAction = "Ouvre Claude et commence par une activite courte, puis decide si on augmente."
+	default:
+		brief.Trigger = "Signal d'apprentissage"
+		brief.LearningGain = "Transformer le signal en prochaine action claire."
+		brief.WhyNow = alert.RecommendedAction
+		brief.OpenLoop = "J'ai garde une question courte pour verifier le point utile."
+		brief.NextAction = "Ouvre Claude et commence par ce point."
+	}
+	brief.GoalLink = goalLinkFromDomain(domain)
+	return brief
+}
+
+func domainForAlert(domains []*models.Domain, alert models.Alert) *models.Domain {
+	if alert.Concept == "" {
+		if len(domains) > 0 {
+			return domains[0]
+		}
+		return nil
+	}
+	for _, d := range domains {
+		if d == nil {
+			continue
+		}
+		for _, c := range d.Graph.Concepts {
+			if c == alert.Concept {
+				return d
+			}
+		}
+	}
+	if len(domains) > 0 {
+		return domains[0]
+	}
+	return nil
+}
+
+func goalLinkSentence(goal string, progress float64) string {
+	goal = strings.TrimSpace(goal)
+	if goal == "" {
+		return ""
+	}
+	return fmt.Sprintf("Objectif: %s. Etat actuel: %s.", goal, progressPhrase(progress))
+}
+
+func goalLinkFromDomain(domain *models.Domain) string {
+	if domain == nil || strings.TrimSpace(domain.PersonalGoal) == "" {
+		return ""
+	}
+	return "Lien avec ton objectif: " + strings.TrimSpace(domain.PersonalGoal) + "."
+}
+
+func domainID(domain *models.Domain) string {
+	if domain == nil {
+		return ""
+	}
+	return domain.ID
+}
+
+func domainName(domain *models.Domain) string {
+	if domain == nil {
+		return ""
+	}
+	return domain.Name
+}

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"tutor-mcp/db"
@@ -191,12 +192,11 @@ func (s *Scheduler) dispatchQueued(kind, alertTag string, fallback func(*models.
 
 		var payload discordPayload
 		var source string
+		var briefForLog *models.WebhookBrief
 		if item != nil && item.Content != "" {
-			payload = discordPayload{Embeds: []discordEmbed{{
-				Title:       queueKindTitle(kind),
-				Description: item.Content,
-				Color:       queueKindColor(kind),
-			}}}
+			embed, brief := embedFromWebhookContent(kind, item.Content, models.UrgencyInfo)
+			payload = discordPayload{Embeds: []discordEmbed{embed}}
+			briefForLog = brief
 			source = "queue"
 		} else if fallback != nil {
 			payload = fallback(learner)
@@ -214,6 +214,15 @@ func (s *Scheduler) dispatchQueued(kind, alertTag string, fallback func(*models.
 		}
 		if item != nil {
 			_ = s.store.MarkWebhookSent(item.ID, learner.ID, now)
+		}
+		if briefForLog != nil {
+			queueID := int64(0)
+			if item != nil {
+				queueID = item.ID
+			}
+			if _, err := s.store.CreateWebhookPushLog(learner.ID, queueID, briefForLog, now); err != nil {
+				s.logger.Warn("scheduler: push log", "err", err, "learner", learner.ID, "kind", kind)
+			}
 		}
 		s.store.CreateScheduledAlert(learner.ID, alertTag, "", time.Now())
 		s.logger.Info("scheduler: dispatched", "learner", learner.ID, "kind", kind, "source", source)
@@ -245,6 +254,166 @@ func queueKindColor(kind string) int {
 		return 0xFEE75C
 	}
 	return 0x99AAB5
+}
+
+func embedFromWebhookContent(kind, content string, urgency models.AlertUrgency) (discordEmbed, *models.WebhookBrief) {
+	if brief, ok := models.DecodeWebhookBrief(content, kind); ok {
+		return discordEmbedFromBrief(*brief, urgency), brief
+	}
+	return discordEmbed{
+		Title:       queueKindTitle(kind),
+		Description: trimDiscord(content, 1400),
+		Color:       queueKindColor(kind),
+	}, nil
+}
+
+func discordEmbedFromBrief(brief models.WebhookBrief, urgency models.AlertUrgency) discordEmbed {
+	brief.Normalize(brief.Kind)
+	title := briefTitle(brief, urgency)
+	labels := briefLabels(brief.Language)
+	description := brief.OpenLoop
+	if description == "" {
+		description = brief.WhyNow
+	}
+	if description == "" {
+		description = brief.LearningGain
+	}
+	if description == "" {
+		description = "Un signal utile est pret pour ta prochaine session."
+	}
+
+	fields := []discordField{}
+	addField := func(name, value string, inline bool) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		fields = append(fields, discordField{
+			Name:   name,
+			Value:  trimDiscord(value, 900),
+			Inline: inline,
+		})
+	}
+	addField(labels.WhyNow, brief.WhyNow, false)
+	addField(labels.LearningGain, brief.LearningGain, false)
+	addField(labels.Evidence, formatEvidence(brief.Evidence), false)
+	addField(labels.GoalLink, brief.GoalLink, false)
+	addField(labels.NextAction, actionWithMinutes(brief.NextAction, brief.EstimatedMinutes), false)
+
+	footer := &discordFooter{Text: labels.Footer}
+	return discordEmbed{
+		Title:       title,
+		Description: trimDiscord(description, 900),
+		Color:       colorForUrgencyOrKind(urgency, brief.Kind),
+		Fields:      fields,
+		Footer:      footer,
+	}
+}
+
+type webhookBriefLabels struct {
+	WhyNow       string
+	LearningGain string
+	Evidence     string
+	GoalLink     string
+	NextAction   string
+	Footer       string
+}
+
+func briefLabels(language string) webhookBriefLabels {
+	if strings.HasPrefix(strings.ToLower(language), "fr") || language == "" {
+		return webhookBriefLabels{
+			WhyNow:       "Pourquoi maintenant",
+			LearningGain: "Gain d'apprentissage",
+			Evidence:     "Indices utiles",
+			GoalLink:     "Lien avec ton objectif",
+			NextAction:   "Prochaine action",
+			Footer:       "Message concis: le defi se resout dans la session, pas dans Discord.",
+		}
+	}
+	return webhookBriefLabels{
+		WhyNow:       "Why now",
+		LearningGain: "Learning gain",
+		Evidence:     "Useful signals",
+		GoalLink:     "Goal link",
+		NextAction:   "Next action",
+		Footer:       "Short nudge: solve the challenge in the tutor session, not in Discord.",
+	}
+}
+
+func briefTitle(brief models.WebhookBrief, urgency models.AlertUrgency) string {
+	subject := brief.Concept
+	if subject == "" {
+		subject = brief.DomainName
+	}
+	if subject == "" {
+		subject = brief.Trigger
+	}
+	if subject == "" {
+		subject = "prochaine session"
+	}
+	switch urgency {
+	case models.UrgencyCritical:
+		return "A reprendre vite - " + subject
+	case models.UrgencyWarning:
+		return "Focus utile - " + subject
+	default:
+		if brief.Trigger != "" {
+			return brief.Trigger + " - " + subject
+		}
+		return "Nudge d'apprentissage - " + subject
+	}
+}
+
+func colorForUrgencyOrKind(urgency models.AlertUrgency, kind string) int {
+	switch urgency {
+	case models.UrgencyCritical:
+		return colorCritical
+	case models.UrgencyWarning:
+		return colorWarning
+	}
+	if strings.HasPrefix(kind, "olm") {
+		return colorInfo
+	}
+	return queueKindColor(kind)
+}
+
+func formatEvidence(evidence []string) string {
+	if len(evidence) == 0 {
+		return ""
+	}
+	if len(evidence) > 3 {
+		evidence = evidence[:3]
+	}
+	lines := make([]string, 0, len(evidence))
+	for _, e := range evidence {
+		e = strings.TrimSpace(e)
+		if e != "" {
+			lines = append(lines, "- "+e)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func actionWithMinutes(action string, minutes int) string {
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return ""
+	}
+	if minutes <= 0 {
+		return action
+	}
+	return fmt.Sprintf("%s (~%d min)", action, minutes)
+}
+
+func trimDiscord(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return strings.TrimSpace(s[:max-1]) + "…"
 }
 
 // ─── Sober fallback templates (no KPI, no analytics) ─────────────────────────
@@ -293,9 +462,21 @@ func (s *Scheduler) cleanupExpiredData() {
 // ─── Message Formatting ─────────────────────────────────────────────────────
 
 type discordEmbed struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Color       int    `json:"color"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	Color       int            `json:"color"`
+	Fields      []discordField `json:"fields,omitempty"`
+	Footer      *discordFooter `json:"footer,omitempty"`
+}
+
+type discordField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline,omitempty"`
+}
+
+type discordFooter struct {
+	Text string `json:"text"`
 }
 
 type discordPayload struct {
@@ -406,9 +587,9 @@ func (s *Scheduler) sendOLM() {
 			continue
 		}
 
-		var embeds []discordEmbed
+		var prepared []preparedWebhookEmbed
 		for _, d := range domains {
-			if len(embeds) >= 3 {
+			if len(prepared) >= 3 {
 				break
 			}
 			snap, err := BuildOLMSnapshot(s.store, learner.ID, d.ID)
@@ -423,44 +604,58 @@ func (s *Scheduler) sendOLM() {
 			kind := "olm:" + d.ID
 			item, _ := s.store.DequeueNextPending(learner.ID, kind, now, 30*time.Minute)
 			if item != nil && item.Content != "" {
-				embeds = append(embeds, embedFromQueueItem(item, snap.FocusUrgency))
-				_ = s.store.MarkWebhookSent(item.ID, learner.ID, now)
+				embed, brief := embedFromWebhookContent(kind, item.Content, snap.FocusUrgency)
+				prepared = append(prepared, preparedWebhookEmbed{Embed: embed, Item: item, Brief: brief})
 			} else {
-				embeds = append(embeds, fromExportedEmbed(FormatOLMEmbed(snap)))
+				brief := BuildOLMNudgeBrief(snap)
+				prepared = append(prepared, preparedWebhookEmbed{Embed: discordEmbedFromBrief(brief, snap.FocusUrgency), Brief: &brief})
 			}
 		}
 
-		if len(embeds) == 0 {
+		if len(prepared) == 0 {
 			continue
+		}
+		embeds := make([]discordEmbed, 0, len(prepared))
+		for _, p := range prepared {
+			embeds = append(embeds, p.Embed)
 		}
 
 		if err := s.sendDiscordEmbed(learner.WebhookURL, discordPayload{Embeds: embeds}); err != nil {
 			s.logger.Error("scheduler: olm webhook", "err", err, "learner", learner.ID)
 			continue
 		}
+		for _, p := range prepared {
+			queueID := int64(0)
+			if p.Item != nil {
+				queueID = p.Item.ID
+				_ = s.store.MarkWebhookSent(p.Item.ID, learner.ID, now)
+			}
+			if p.Brief != nil {
+				if _, err := s.store.CreateWebhookPushLog(learner.ID, queueID, p.Brief, now); err != nil {
+					s.logger.Warn("scheduler: olm push log", "err", err, "learner", learner.ID)
+				}
+			}
+		}
 		_ = s.store.CreateScheduledAlert(learner.ID, alertKindOLM, "", now)
 		s.logger.Info("scheduler: olm dispatched", "learner", learner.ID, "embeds", len(embeds))
 	}
 }
 
-// embedFromQueueItem renders a queued LLM-authored OLM message. The content
-// is used as-is for Description; the title/color come from FocusUrgency for
-// visual consistency with the Go fallback.
+type preparedWebhookEmbed struct {
+	Embed discordEmbed
+	Item  *models.WebhookQueueItem
+	Brief *models.WebhookBrief
+}
+
+// embedFromQueueItem renders a queued LLM-authored OLM message. Structured
+// WebhookBrief content gets a pedagogical Discord layout; legacy text is used
+// as-is for backwards compatibility.
 func embedFromQueueItem(item *models.WebhookQueueItem, urgency models.AlertUrgency) discordEmbed {
-	title := "🧭 Current state"
-	color := colorInfo
-	switch urgency {
-	case models.UrgencyCritical:
-		title = "🚨 State — one concept needs attention now"
-		color = colorCritical
-	case models.UrgencyWarning:
-		color = colorWarning
+	if item == nil {
+		return discordEmbed{}
 	}
-	return discordEmbed{
-		Title:       title,
-		Description: item.Content,
-		Color:       color,
-	}
+	embed, _ := embedFromWebhookContent(item.Kind, item.Content, urgency)
+	return embed
 }
 
 // alertKindOLM is the alert tag used by sendOLM for daily-dedup checks

--- a/engine/scheduler_metacog.go
+++ b/engine/scheduler_metacog.go
@@ -11,10 +11,9 @@ import (
 )
 
 // metacogKindToWebhookKind maps an AlertType to the webhook_message_queue
-// `kind` slot under which the dispatch enqueues a nudge. Each kind is
-// dispatched independently — a learner with both AFFECT_NEGATIVE and
-// CALIBRATION_DIVERGING firing on the same tick will get two webhook
-// rows, deduped per-day via scheduled_alerts (WasAlertSentToday).
+// `kind` slot under which the dispatch enqueues a nudge. The planner now
+// chooses the highest-value candidate per learner/tick; the kind remains the
+// daily dedup tag for the selected signal.
 func metacogKindToWebhookKind(t models.AlertType) string {
 	switch t {
 	case models.AlertDependencyIncreasing:
@@ -29,47 +28,19 @@ func metacogKindToWebhookKind(t models.AlertType) string {
 	return ""
 }
 
-// metacogFallbackContent returns the sober Go-side fallback nudge body for
-// each metacognitive alert kind. The content is intentionally short and
-// non-prescriptive — it tells the learner *what surfaced* and points to
-// the corresponding tool, leaving the conversational handling to Claude
-// when the learner returns.
-func metacogFallbackContent(a models.Alert) string {
-	switch a.Type {
-	case models.AlertDependencyIncreasing:
-		return "Your autonomy score has dropped over the last 3 sessions. " +
-			"When you come back, we can talk about it - call get_metacognitive_mirror."
-	case models.AlertCalibrationDiverging:
-		return "Your calibration has drifted from reality (" + a.RecommendedAction + "). " +
-			"A short calibration session can help - calibration_check."
-	case models.AlertAffectNegative:
-		return "The last two sessions have been hard. " +
-			"We can adjust tutor_mode when you return."
-	case models.AlertTransferBlocked:
-		concept := a.Concept
-		if concept == "" {
-			concept = "a mastered concept"
-		}
-		return "Transfer on \"" + concept + "\" remains weak despite mastery. " +
-			"A Feynman challenge would likely unblock the situation."
-	}
-	return "A new metacognitive observation is available."
-}
-
 // dispatchMetacognitiveAlerts iterates over every active learner, computes
 // metacognitive alerts (DEPENDENCY / CALIBRATION / AFFECT / TRANSFER) from
-// their current state, and pushes a webhook for each newly-firing alert
-// kind. Per-learner per-day dedup is enforced by dispatchQueued via
-// scheduled_alerts (WasAlertSentToday + CreateScheduledAlert) — the cron
-// cadence only affects detection latency, not delivery frequency.
+// their current state, turns them into structured learner-facing candidates,
+// and pushes at most the best candidate for the learner on this tick.
+// Per-kind daily dedup is enforced by dispatchQueued via scheduled_alerts
+// (WasAlertSentToday + CreateScheduledAlert) — the cron cadence only affects
+// detection latency, not delivery frequency.
 //
 // Two-stage flow on each tick:
 //
-//  1. Compute alerts → enqueue one webhook_message_queue row per *kind*
-//     that just went hot (kind = metacog_dependency / metacog_calibration
-//     / metacog_affect / metacog_transfer). Skip kinds already fired today
-//     (WasAlertSentToday) so we don't enqueue stale duplicates.
-//  2. Drain each enqueued kind via dispatchQueued, which posts the embed
+//  1. Compute alerts → build ranked structured candidates.
+//  2. Enqueue the first candidate whose kind has not fired today.
+//  3. Drain each enqueued kind via dispatchQueued, which posts the embed
 //     and stamps scheduled_alerts so the next tick deduplicates.
 //
 // TRANSFER_BLOCKED is per-concept in the alert payload but is collapsed to
@@ -120,36 +91,33 @@ func (s *Scheduler) dispatchMetacognitiveAlerts() {
 			WithTransferData(states, transfers),
 		)
 
-		// Collapse per-concept alerts down to one row per kind. Keep the
-		// first alert seen for each kind (deterministic enough — alerts
-		// from ComputeMetacognitiveAlerts are produced in a fixed order).
-		seenKind := make(map[string]bool)
-		for _, a := range alerts {
-			kind := metacogKindToWebhookKind(a.Type)
-			if kind == "" || seenKind[kind] {
-				continue
-			}
-			seenKind[kind] = true
-
-			// kind is the dedup tag too — dispatchQueued stamps
-			// scheduled_alerts(alert_type=kind) on success, so a re-tick
-			// today will WasAlertSentToday-skip before re-enqueueing.
-			alreadySent, _ := s.store.WasAlertSentToday(learner.ID, kind)
+		domains, _ := s.store.GetDomainsByLearner(learner.ID, false)
+		candidates := BuildMetacognitiveNudgeCandidates(learner, domains, alerts)
+		for _, candidate := range candidates {
+			// One metacognitive push per tick is intentional: Discord should
+			// surface the highest-learning-value next action, not a bundle of
+			// weak observations.
+			alreadySent, _ := s.store.WasAlertSentToday(learner.ID, candidate.AlertTag)
 			if alreadySent {
 				continue
 			}
-
-			content := metacogFallbackContent(a)
-			if _, err := s.store.EnqueueWebhookMessage(
-				learner.ID, kind, content, now, now.Add(2*time.Hour), 5,
-			); err != nil {
-				s.logger.Error("scheduler: metacog enqueue",
-					"err", err, "learner", learner.ID, "kind", kind)
+			content, err := models.EncodeWebhookBrief(candidate.Brief)
+			if err != nil {
+				s.logger.Error("scheduler: metacog brief encode",
+					"err", err, "learner", learner.ID, "kind", candidate.Kind)
 				continue
 			}
-			enqueuedKinds[kind] = true
+			if _, err := s.store.EnqueueWebhookMessage(
+				learner.ID, candidate.Kind, content, now, now.Add(2*time.Hour), candidate.Priority,
+			); err != nil {
+				s.logger.Error("scheduler: metacog enqueue",
+					"err", err, "learner", learner.ID, "kind", candidate.Kind)
+				continue
+			}
+			enqueuedKinds[candidate.Kind] = true
 			s.logger.Info("scheduler: metacog enqueued",
-				"learner", learner.ID, "kind", kind, "type", a.Type)
+				"learner", learner.ID, "kind", candidate.Kind, "priority", candidate.Priority)
+			break
 		}
 	}
 
@@ -160,4 +128,3 @@ func (s *Scheduler) dispatchMetacognitiveAlerts() {
 		s.dispatchQueued(kind, kind, nil)
 	}
 }
-

--- a/engine/scheduler_metacog_test.go
+++ b/engine/scheduler_metacog_test.go
@@ -114,12 +114,10 @@ func TestDispatchMetacognitiveAlerts_NoOpWithoutTriggerState(t *testing.T) {
 	s.dispatchMetacognitiveAlerts()
 }
 
-// TestDispatchMetacognitiveAlerts_HandlesMultipleKinds ensures that when
-// several kinds fire on the same tick we enqueue + drain each
-// independently. AFFECT_NEGATIVE (from satisfaction) plus
-// CALIBRATION_DIVERGING (from a high-bias calibration record) is the
-// minimal non-trivial multi-kind setup.
-func TestDispatchMetacognitiveAlerts_HandlesMultipleKinds(t *testing.T) {
+// TestDispatchMetacognitiveAlerts_SelectsHighestValueKind ensures that when
+// several metacognitive signals fire on the same tick, the planner emits one
+// strong learner-facing nudge instead of a bundle of weak Discord messages.
+func TestDispatchMetacognitiveAlerts_SelectsHighestValueKind(t *testing.T) {
 	allowAnyURL(t)
 	withoutBackoff(t)
 
@@ -166,21 +164,24 @@ func TestDispatchMetacognitiveAlerts_HandlesMultipleKinds(t *testing.T) {
 	s := schedulerForTest(store)
 	s.dispatchMetacognitiveAlerts()
 
-	// Both kinds should have queue rows (independent per kind).
-	for _, kind := range []string{"metacog_affect", "metacog_calibration"} {
-		var c int
-		if err := rawDB.QueryRow(
-			`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
-			learnerID, kind,
-		).Scan(&c); err != nil {
-			t.Fatalf("count %s: %v", kind, err)
-		}
-		if c != 1 {
-			t.Errorf("queue rows for %s = %d, want 1", kind, c)
-		}
+	var calibrationRows, affectRows int
+	if err := rawDB.QueryRow(
+		`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+		learnerID, "metacog_calibration",
+	).Scan(&calibrationRows); err != nil {
+		t.Fatalf("count calibration: %v", err)
 	}
-	if got := atomic.LoadInt32(&hits); got != 2 {
-		t.Errorf("webhook hits = %d, want 2 (one per kind)", got)
+	if err := rawDB.QueryRow(
+		`SELECT COUNT(*) FROM webhook_message_queue WHERE learner_id = ? AND kind = ?`,
+		learnerID, "metacog_affect",
+	).Scan(&affectRows); err != nil {
+		t.Fatalf("count affect: %v", err)
+	}
+	if calibrationRows != 1 || affectRows != 0 {
+		t.Errorf("queue rows calibration=%d affect=%d, want calibration=1 affect=0", calibrationRows, affectRows)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("webhook hits = %d, want 1", got)
 	}
 }
 

--- a/engine/scheduler_test.go
+++ b/engine/scheduler_test.go
@@ -40,9 +40,9 @@ func TestSendOLM_DispatchesFallbackWhenQueueEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		got := string(body)
-		if !strings.Contains(got, "Current focus") &&
-			!strings.Contains(got, "Next milestone") &&
-			!strings.Contains(got, "needs attention now") {
+		if !strings.Contains(got, "Pourquoi maintenant") &&
+			!strings.Contains(got, "Prochaine action") &&
+			!strings.Contains(got, "Focus utile") {
 			t.Errorf("expected an OLM body, got: %s", got)
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -73,6 +73,13 @@ func TestSendOLM_DispatchesFallbackWhenQueueEmpty(t *testing.T) {
 	sent, _ := store.WasAlertSentToday("L1", alertKindOLM)
 	if !sent {
 		t.Errorf("OLM dispatch should mark sent today")
+	}
+	push, err := store.GetLatestOpenWebhookPush("L1", "", time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLatestOpenWebhookPush: %v", err)
+	}
+	if push == nil {
+		t.Fatalf("OLM dispatch should record a push log")
 	}
 }
 

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Arnaud Guiovanna <https://www.aguiovanna.fr>
+// SPDX-License-Identifier: MIT
+
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+const WebhookBriefVersion = 1
+
+// WebhookBrief is the structured content contract for learner-facing pushes.
+// It keeps Discord copy short while preserving the pedagogical reason behind
+// the nudge: why this matters now, what learning gain is expected, and what
+// should happen when the learner opens the tutor again.
+type WebhookBrief struct {
+	Version           int      `json:"version,omitempty"`
+	Kind              string   `json:"kind,omitempty"`
+	DomainID          string   `json:"domain_id,omitempty"`
+	DomainName        string   `json:"domain_name,omitempty"`
+	Concept           string   `json:"concept,omitempty"`
+	Trigger           string   `json:"trigger,omitempty"`
+	PedagogicalIntent string   `json:"pedagogical_intent,omitempty"`
+	LearningGain      string   `json:"learning_gain,omitempty"`
+	WhyNow            string   `json:"why_now,omitempty"`
+	Evidence          []string `json:"evidence,omitempty"`
+	GoalLink          string   `json:"goal_link,omitempty"`
+	OpenLoop          string   `json:"open_loop,omitempty"`
+	NextAction        string   `json:"next_action,omitempty"`
+	EstimatedMinutes  int      `json:"estimated_minutes,omitempty"`
+	Language          string   `json:"language,omitempty"`
+	Tone              string   `json:"tone,omitempty"`
+}
+
+func (b *WebhookBrief) Normalize(defaultKind string) {
+	if b == nil {
+		return
+	}
+	if b.Version == 0 {
+		b.Version = WebhookBriefVersion
+	}
+	if b.Kind == "" {
+		b.Kind = defaultKind
+	}
+	b.Kind = strings.TrimSpace(b.Kind)
+	b.DomainID = strings.TrimSpace(b.DomainID)
+	b.DomainName = strings.TrimSpace(b.DomainName)
+	b.Concept = strings.TrimSpace(b.Concept)
+	b.Trigger = strings.TrimSpace(b.Trigger)
+	b.PedagogicalIntent = strings.TrimSpace(b.PedagogicalIntent)
+	b.LearningGain = strings.TrimSpace(b.LearningGain)
+	b.WhyNow = strings.TrimSpace(b.WhyNow)
+	b.GoalLink = strings.TrimSpace(b.GoalLink)
+	b.OpenLoop = strings.TrimSpace(b.OpenLoop)
+	b.NextAction = strings.TrimSpace(b.NextAction)
+	b.Language = strings.TrimSpace(b.Language)
+	b.Tone = strings.TrimSpace(b.Tone)
+	if b.EstimatedMinutes < 0 {
+		b.EstimatedMinutes = 0
+	}
+	filtered := b.Evidence[:0]
+	for _, e := range b.Evidence {
+		if trimmed := strings.TrimSpace(e); trimmed != "" {
+			filtered = append(filtered, trimmed)
+		}
+	}
+	b.Evidence = filtered
+}
+
+func (b WebhookBrief) IsStructured() bool {
+	return b.WhyNow != "" || b.LearningGain != "" || b.OpenLoop != "" || b.NextAction != ""
+}
+
+func EncodeWebhookBrief(b WebhookBrief) (string, error) {
+	b.Normalize(b.Kind)
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func DecodeWebhookBrief(raw, defaultKind string) (*WebhookBrief, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "{") {
+		return nil, false
+	}
+	var b WebhookBrief
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		return nil, false
+	}
+	b.Normalize(defaultKind)
+	if !b.IsStructured() {
+		return nil, false
+	}
+	return &b, true
+}
+
+// WebhookPushLog records learner-facing pushes after Discord accepts them.
+// It is intentionally about learning value, not transport: queue_id is zero
+// for Go fallback pushes that were not authored through webhook_message_queue.
+type WebhookPushLog struct {
+	ID                int64      `json:"id"`
+	LearnerID         string     `json:"learner_id"`
+	QueueID           int64      `json:"queue_id,omitempty"`
+	Kind              string     `json:"kind"`
+	DomainID          string     `json:"domain_id,omitempty"`
+	DomainName        string     `json:"domain_name,omitempty"`
+	Concept           string     `json:"concept,omitempty"`
+	Trigger           string     `json:"trigger,omitempty"`
+	PedagogicalIntent string     `json:"pedagogical_intent,omitempty"`
+	LearningGain      string     `json:"learning_gain,omitempty"`
+	OpenLoop          string     `json:"open_loop,omitempty"`
+	NextAction        string     `json:"next_action,omitempty"`
+	PushedAt          time.Time  `json:"pushed_at"`
+	OpenedSessionAt   *time.Time `json:"opened_session_at,omitempty"`
+	ConceptAddressed  bool       `json:"concept_addressed"`
+	CreatedAt         time.Time  `json:"created_at"`
+}

--- a/tools/activity.go
+++ b/tools/activity.go
@@ -123,6 +123,7 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			}
 		}
 		prefetchMs := time.Since(prefetchStart).Milliseconds()
+		extra := map[string]any{}
 
 		// Route to next activity through the regulation pipeline, or through
 		// the explicit review override when the learner asks to revise.
@@ -157,6 +158,19 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 			deps.Logger.Error("orchestrator failed", "err", orchErr, "learner", learnerID, "domain", domain.ID)
 			r, _ := errorResult("could not compute next activity")
 			return r, nil, nil
+		}
+		pushSince := now.Add(-7 * 24 * time.Hour)
+		activeWebhookNudge, _ := deps.Store.GetLatestOpenWebhookPush(learnerID, domain.ID, pushSince)
+		_ = deps.Store.MarkWebhookPushSessionOpened(learnerID, now, pushSince)
+		if activeWebhookNudge != nil {
+			extra["active_webhook_nudge"] = activeWebhookNudge
+			if activeWebhookNudge.OpenLoop != "" || activeWebhookNudge.NextAction != "" {
+				activity.PromptForLLM += fmt.Sprintf(
+					"\nThe learner may be returning from a Discord nudge. Start by reconnecting to this learner-facing open loop without naming internal tools: %s %s",
+					activeWebhookNudge.OpenLoop,
+					activeWebhookNudge.NextAction,
+				)
+			}
 		}
 		overrideResult := LearningNegotiationOverrideConsumeResult{Status: LearningNegotiationOverrideConsumeNone}
 		if overrideActivity, consumed, err := ConsumeLearningNegotiationOverride(deps.Store, learnerID, domain, activity, alerts, now); err != nil {
@@ -322,7 +336,6 @@ func registerGetNextActivity(server *mcp.Server, deps *Deps) {
 		// the pre-fade behaviour: no fade_params key, no mutation
 		// of motivation_brief. See
 		// docs/regulation-design/06-fade-controller.md.
-		extra := map[string]any{}
 		if regulationFadeEnabled() {
 			autonomyMetrics := engine.ComputeAutonomyMetrics(engine.AutonomyInput{
 				Interactions:    allInteractions,

--- a/tools/interaction.go
+++ b/tools/interaction.go
@@ -185,6 +185,8 @@ func registerRecordInteraction(server *mcp.Server, deps *Deps) {
 
 		// Update last active
 		_ = deps.Store.UpdateLastActive(learnerID)
+		pushNow := time.Now().UTC()
+		_ = deps.Store.MarkWebhookPushConceptAddressed(learnerID, domain.ID, params.Concept, pushNow, pushNow.Add(-7*24*time.Hour))
 
 		deps.Logger.Info("interaction recorded",
 			"learner", learnerID,

--- a/tools/prompt.go
+++ b/tools/prompt.go
@@ -127,7 +127,11 @@ C. SESSION END
    - React to the calibration_bias_delta returned.
    - Call record_session_close(domain_id) - read the signals for the closing message.
    - If recap_brief.prompt_for_implementation_intent: ask ONE concrete question ("When and where will you practice next?") and call record_session_close again with implementation_intention.
-   - Then call queue_webhook_message twice: (a) daily_motivation for tomorrow 08:00 UTC, (b) daily_recap for tomorrow 21:00 UTC. Warm tone tied to personal_goal, max ~300 characters each. NEVER raw success rates or dry KPIs - mentor tone, not analytics.
+   - Then call get_olm_snapshot(domain_id) and queue_webhook_message 3 times:
+     (a) daily_motivation for tomorrow 08:00 UTC,
+     (b) olm:<domain_id> for tomorrow 13:00 UTC,
+     (c) daily_recap for tomorrow 21:00 UTC.
+     Prefer the structured brief field over legacy content: why_now, learning_gain, open_loop, next_action. Keep it user-friendly, concise, tied to the learner's goal, and solvable only by reopening the tutor session. NEVER mention internal tool names, raw success rates, or dry KPIs.
 
 D. DOMAIN MAINTENANCE
    - If the learner discovers a concept not in the graph, call add_concepts().

--- a/tools/queue_webhook.go
+++ b/tools/queue_webhook.go
@@ -16,11 +16,12 @@ import (
 )
 
 type QueueWebhookMessageParams struct {
-	Kind         string `json:"kind" jsonschema:"nudge type: daily_motivation | daily_recap | reactivation | reminder | mirror_message | olm:<domain_id> (per-domain OLM snapshot)"`
-	ScheduledFor string `json:"scheduled_for" jsonschema:"ISO 8601 UTC timestamp for the delivery window (e.g. 2026-04-13T08:00:00Z)"`
-	ExpiresAt    string `json:"expires_at,omitempty" jsonschema:"ISO 8601 UTC timestamp after which the message must not be sent"`
-	Content      string `json:"content" jsonschema:"markdown content ready to post to the Discord webhook (max ~300 characters recommended)"`
-	Priority     int    `json:"priority,omitempty" jsonschema:"priority (higher = more important, default 0)"`
+	Kind         string               `json:"kind" jsonschema:"nudge type: daily_motivation | daily_recap | reactivation | reminder | mirror_message | olm:<domain_id> (per-domain OLM snapshot)"`
+	ScheduledFor string               `json:"scheduled_for" jsonschema:"ISO 8601 UTC timestamp for the delivery window (e.g. 2026-04-13T08:00:00Z)"`
+	ExpiresAt    string               `json:"expires_at,omitempty" jsonschema:"ISO 8601 UTC timestamp after which the message must not be sent"`
+	Content      string               `json:"content,omitempty" jsonschema:"legacy markdown content ready to post to the Discord webhook; prefer brief for pedagogical nudges"`
+	Brief        *models.WebhookBrief `json:"brief,omitempty" jsonschema:"structured learner-facing nudge: why_now, learning_gain, open_loop, next_action; concise, user-friendly, no internal tool names"`
+	Priority     int                  `json:"priority,omitempty" jsonschema:"priority (higher = more important, default 0)"`
 }
 
 const maxWebhookContentLen = 1500
@@ -45,12 +46,27 @@ func registerQueueWebhookMessage(server *mcp.Server, deps *Deps) {
 			r, _ := errorResult("scheduled_for is required")
 			return r, nil, nil
 		}
-		if params.Content == "" {
-			r, _ := errorResult("content is required")
+		content := strings.TrimSpace(params.Content)
+		if params.Brief != nil {
+			brief := *params.Brief
+			brief.Normalize(params.Kind)
+			if err := validateWebhookBrief(brief); err != nil {
+				r, _ := errorResult(err.Error())
+				return r, nil, nil
+			}
+			encoded, err := models.EncodeWebhookBrief(brief)
+			if err != nil {
+				r, _ := errorResult(fmt.Sprintf("invalid brief: %v", err))
+				return r, nil, nil
+			}
+			content = encoded
+		}
+		if content == "" {
+			r, _ := errorResult("content or brief is required")
 			return r, nil, nil
 		}
-		if len(params.Content) > maxWebhookContentLen {
-			r, _ := errorResult(fmt.Sprintf("content too long (%d chars, max %d)", len(params.Content), maxWebhookContentLen))
+		if len(content) > maxWebhookContentLen {
+			r, _ := errorResult(fmt.Sprintf("content too long (%d chars, max %d)", len(content), maxWebhookContentLen))
 			return r, nil, nil
 		}
 
@@ -70,7 +86,7 @@ func registerQueueWebhookMessage(server *mcp.Server, deps *Deps) {
 			expiresAt = parsed
 		}
 
-		id, err := deps.Store.EnqueueWebhookMessage(learnerID, params.Kind, params.Content, scheduledFor, expiresAt, params.Priority)
+		id, err := deps.Store.EnqueueWebhookMessage(learnerID, params.Kind, content, scheduledFor, expiresAt, params.Priority)
 		if err != nil {
 			deps.Logger.Error("queue_webhook_message: enqueue failed", "err", err, "learner", learnerID)
 			r, _ := errorResult(fmt.Sprintf("failed to enqueue: %v", err))
@@ -100,6 +116,85 @@ func validWebhookKind(k string) bool {
 	// each with its own state snapshot.
 	if strings.HasPrefix(k, "olm:") && len(k) > len("olm:") {
 		return true
+	}
+	return false
+}
+
+func validateWebhookBrief(brief models.WebhookBrief) error {
+	required := []struct {
+		name  string
+		value string
+		max   int
+	}{
+		{"brief.why_now", brief.WhyNow, 320},
+		{"brief.learning_gain", brief.LearningGain, 260},
+		{"brief.open_loop", brief.OpenLoop, 260},
+		{"brief.next_action", brief.NextAction, 220},
+	}
+	for _, f := range required {
+		if strings.TrimSpace(f.value) == "" {
+			return fmt.Errorf("%s is required", f.name)
+		}
+		if err := validateString(f.name, f.value, f.max); err != nil {
+			return err
+		}
+		if containsInternalToolName(f.value) {
+			return fmt.Errorf("%s must be learner-facing and must not mention internal tool names", f.name)
+		}
+	}
+	optional := []struct {
+		name  string
+		value string
+		max   int
+	}{
+		{"brief.domain_id", brief.DomainID, maxShortLabelLen},
+		{"brief.domain_name", brief.DomainName, maxShortLabelLen},
+		{"brief.concept", brief.Concept, maxShortLabelLen},
+		{"brief.trigger", brief.Trigger, 120},
+		{"brief.pedagogical_intent", brief.PedagogicalIntent, 240},
+		{"brief.goal_link", brief.GoalLink, 280},
+		{"brief.language", brief.Language, maxShortLabelLen},
+		{"brief.tone", brief.Tone, 120},
+	}
+	for _, f := range optional {
+		if err := validateString(f.name, f.value, f.max); err != nil {
+			return err
+		}
+		if containsInternalToolName(f.value) {
+			return fmt.Errorf("%s must be learner-facing and must not mention internal tool names", f.name)
+		}
+	}
+	if len(brief.Evidence) > 3 {
+		return fmt.Errorf("brief.evidence must contain at most 3 concise items")
+	}
+	for i, e := range brief.Evidence {
+		name := fmt.Sprintf("brief.evidence[%d]", i)
+		if err := validateString(name, e, 180); err != nil {
+			return err
+		}
+		if containsInternalToolName(e) {
+			return fmt.Errorf("%s must be learner-facing and must not mention internal tool names", name)
+		}
+	}
+	if brief.EstimatedMinutes < 0 || brief.EstimatedMinutes > 90 {
+		return fmt.Errorf("brief.estimated_minutes must be between 0 and 90")
+	}
+	return nil
+}
+
+func containsInternalToolName(s string) bool {
+	s = strings.ToLower(s)
+	for _, marker := range []string{
+		"get_",
+		"record_",
+		"queue_webhook_message",
+		"calibration_check",
+		"feynman_challenge",
+		"transfer_challenge",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
 	}
 	return false
 }

--- a/tools/queue_webhook_test.go
+++ b/tools/queue_webhook_test.go
@@ -51,7 +51,7 @@ func TestQueueWebhookMessage_MissingContent(t *testing.T) {
 		"scheduled_for": "2026-05-02T08:00:00Z",
 		"content":       "",
 	})
-	if !res.IsError || !strings.Contains(resultText(res), "content is required") {
+	if !res.IsError || !strings.Contains(resultText(res), "content or brief is required") {
 		t.Fatalf("got %q", resultText(res))
 	}
 }
@@ -130,6 +130,55 @@ func TestQueueWebhookMessage_HappyPath(t *testing.T) {
 	}
 }
 
+func TestQueueWebhookMessage_StructuredBrief(t *testing.T) {
+	store, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerQueueWebhookMessage, "L_owner", "queue_webhook_message", map[string]any{
+		"kind":          "olm:d1",
+		"scheduled_for": "2026-05-03T13:00:00Z",
+		"brief": map[string]any{
+			"domain_id":         "d1",
+			"domain_name":       "Python",
+			"concept":           "boucles",
+			"why_now":           "La retention baisse sur les boucles, donc une reprise courte est plus rentable maintenant.",
+			"learning_gain":     "Stabiliser le concept avant de passer a des exercices plus longs.",
+			"open_loop":         "J'ai garde un mini-bug de boucle pour la prochaine session.",
+			"next_action":       "Ouvre Claude et commence par le mini-bug sur les boucles.",
+			"estimated_minutes": 8,
+			"language":          "fr",
+		},
+	})
+	if res.IsError {
+		t.Fatalf("got %q", resultText(res))
+	}
+	pending, err := store.GetPendingWebhookMessages("L_owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending message, got %d", len(pending))
+	}
+	if !strings.Contains(pending[0].Content, `"why_now"`) || !strings.Contains(pending[0].Content, "boucles") {
+		t.Fatalf("structured brief was not persisted as JSON: %q", pending[0].Content)
+	}
+}
+
+func TestQueueWebhookMessage_StructuredBriefRejectsInternalToolNames(t *testing.T) {
+	_, deps := setupToolsTest(t)
+	res := callTool(t, deps, registerQueueWebhookMessage, "L_owner", "queue_webhook_message", map[string]any{
+		"kind":          "daily_motivation",
+		"scheduled_for": "2026-05-03T08:00:00Z",
+		"brief": map[string]any{
+			"why_now":       "On va appeler calibration_check demain.",
+			"learning_gain": "Mieux calibrer ton niveau.",
+			"open_loop":     "J'ai garde un mini-test.",
+			"next_action":   "Ouvre Claude.",
+		},
+	})
+	if !res.IsError || !strings.Contains(resultText(res), "internal tool names") {
+		t.Fatalf("got %q", resultText(res))
+	}
+}
+
 func TestValidWebhookKind(t *testing.T) {
 	cases := map[string]bool{
 		"daily_motivation": true,
@@ -137,6 +186,7 @@ func TestValidWebhookKind(t *testing.T) {
 		"reactivation":     true,
 		"reminder":         true,
 		"mirror_message":   true,
+		"olm:d1":           true,
 		"":                 false,
 		"spam":             false,
 	}

--- a/tools/session_close.go
+++ b/tools/session_close.go
@@ -153,9 +153,9 @@ func buildRecapBrief(deps *Deps, learnerID string, domain *models.Domain) *model
 		"and wait for the answer to call record_session_close again with implementation_intention. " +
 		"Then call get_olm_snapshot to retrieve the learner's structured cognitive state, " +
 		"and call queue_webhook_message 3 times: daily_motivation for tomorrow at 8h UTC (warm, tied to personal_goal) ; " +
-		"olm:<domain_id> for tomorrow at 13h UTC (factual - distribution + focus + ONE metacog line if active + progress toward goal - no pep talk, content must MATCH the get_olm_snapshot snapshot) ; " +
+		"olm:<domain_id> for tomorrow at 13h UTC using the structured brief field (why_now + learning_gain + open_loop + next_action, content must MATCH get_olm_snapshot, no pep talk) ; " +
 		"daily_recap for tomorrow at 21h UTC (gentle recap). " +
-		"No raw KPIs."
+		"Messages must be user-friendly, concrete, learner-facing, and oriented toward learning gain. No raw KPIs, no internal tool names."
 
 	return &models.RecapBrief{
 		ConceptsPracticed:             practiced,


### PR DESCRIPTION
## Contexte
Les webhooks Discord actuels transportaient surtout du texte libre, avec peu de contexte pédagogique et aucune boucle de suivi. Cette PR transforme le nudge en objet structuré orienté gain d'apprentissage.

## Changements
- Ajoute `models.WebhookBrief` avec `why_now`, `learning_gain`, `open_loop`, `next_action`, evidence, concept/domaine, ton et langue.
- Étend `queue_webhook_message` pour accepter `brief` en plus du `content` legacy, avec validation learner-facing et rejet des noms d'outils internes.
- Rend les briefs en embeds Discord structurés : pourquoi maintenant, gain d'apprentissage, indices utiles, lien objectif, prochaine action.
- Ajoute `webhook_push_log` en migration append-only, sans modifier `schema.sql`, pour tracer les pushes envoyés, l'ouverture de session et le concept réellement travaillé.
- Ajoute un `NudgePlanner` pour convertir les alertes métacognitives en nudges contextualisés et ne pousser que le meilleur signal par learner/tick.
- Connecte `get_next_activity` aux pushes non résolus afin que la session puisse reprendre l'open loop Discord.
- Marque le push comme adressé quand `record_interaction` travaille le concept ciblé.
- Aligne les instructions LLM : 3 webhooks de fin de session, avec OLM structuré à 13h.

## Impact
Les messages Discord deviennent plus courts, plus contextualisés, et orientés action pédagogique. Les anciens `content` texte restent compatibles.

## Validation
- `GOCACHE=/tmp/go-build-cache go test ./...`
- `git diff --check`